### PR TITLE
Detect double-hyphen (--) as em dash substitute

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -18,7 +18,7 @@ The user will provide a piece of writing. Your job is to:
 ## What to remove or fix
 
 ### Formatting
-- **Em dashes (—)**: Replace with commas, periods, parentheses, or rewrite as two sentences. Target: zero. Hard max: one per 1,000 words. This applies to headings and section titles too, not just body prose.
+- **Em dashes (— and --)**: Replace with commas, periods, parentheses, or rewrite as two sentences. Target: zero. Hard max: one per 1,000 words. This applies to headings and section titles too, not just body prose. Catch both the Unicode em dash (—) and the double-hyphen substitute (--).
 - **Bold overuse**: Strip bold from most phrases. One bolded phrase per major section at most, or none. If something's important enough to bold, restructure the sentence to lead with it instead.
 - **Emoji in headers**: Remove entirely. No `## 🚀 What This Means`. Exception: social posts may use one or two emoji sparingly — at the end of a line, never mid-sentence.
 - **Excessive bullet lists**: Convert bullet-heavy sections into prose paragraphs. Bullets only for genuinely list-like content (feature comparisons, step-by-step instructions, API parameters).


### PR DESCRIPTION
## Summary
- The em dash formatting rule only flagged the Unicode em dash (`—`) but missed `--`, which AI text frequently uses as a stand-in
- Updated the rule to explicitly call out both forms so neither slips through audits

## Test plan
- [ ] Run the skill against text containing `--` used as em dashes and verify they get flagged
- [ ] Confirm Unicode `—` detection still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)