### PR TITLE
Add worth-verbing and reader-steering frame patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project are documented here.
 
 ---
 
+## [3.3.0] — 2026-04-01
+
+### Added
+- **"Worth [verb]ing" vague endorsement pattern**: `worth reading`, `worth paying attention to`, `worth a look`, `worth exploring`, `worth checking out`, `worth your time` — broadens existing "it's worth noting that" to the full family
+- **Reader-steering frames**: `Here's what's interesting`, `Here's what caught my eye`, `Here's what stood out` — added to both transition phrases and confidence calibration sections with context on when the pattern is a genuine problem vs. when data-backed usage is acceptable
+
+### Changed
+- Version bump to 3.3.0
+
+---
+
 ## [3.2.0] — 2026-03-31
 
 ### Added

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: avoid-ai-writing
 description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Use this skill when asked to "remove AI-isms," "clean up AI writing," "edit writing for AI patterns," "audit writing for AI tells," or "make this sound less like AI." Supports a detection-only mode that flags patterns without rewriting.
-version: 3.2.0
+version: 3.3.0
 license: MIT
 compatibility: Any AI coding assistant that supports agentskills.io SKILL.md format (Claude Code, Cursor, VS Code Copilot, Hermes Agent, OpenHands, etc.) or OpenClaw. No external tools or APIs required.
 metadata:
@@ -56,6 +56,7 @@ In **detect** mode, your job is to:
 ### Sentence structure
 - **"It's not X — it's Y" / "This isn't about X, it's about Y"**: Rewrite as a direct positive statement. Max one per piece, and only if it serves the argument.
 - **Hollow intensifiers**: Cut `genuine`, `real` (as in "a real improvement"), `truly`, `quite frankly`, `to be honest`, `let's be clear`, `it's worth noting that`. Just state the fact.
+- **Vague endorsement ("worth [verb]ing")**: Cut or replace `worth reading`, `worth paying attention to`, `worth a look`, `worth exploring`, `worth checking out`, `worth your time`. These substitute a generic thumbs-up for a specific reason. Say *why* something matters instead.
 - **Hedging**: Cut `perhaps`, `could potentially`, `it's important to note that`, `to be clear`. Make the point directly.
 - **Missing bridge sentences**: Each paragraph should connect to the last. If paragraphs could be rearranged without the reader noticing, add connective tissue.
 - **Compulsive rule of three**: Vary groupings. Use two items, four items, or a full sentence instead of triads. Max one "adjective, adjective, and adjective" pattern per piece.
@@ -206,6 +207,7 @@ These slot-fill constructions signal that a sentence was generated, not written.
 - "Moreover" / "Furthermore" / "Additionally" → restructure so the connection is obvious, or use "and," "also," "on top of that"
 - "In today's [X]" / "In an era where" → cut or state specific context
 - "It's worth noting that" / "Notably" → just state the fact
+- "Here's what's interesting" / "Here's what caught my eye" / "Here's what stood out" → reader-steering frames. Let the content signal its own importance. If you need a lead-in, make it specific: "The revenue number matters because..." not "Here's the interesting part."
 - "In conclusion" / "In summary" / "To summarize" → your conclusion should be obvious
 - "When it comes to" → just talk about the thing directly
 - "At the end of the day" → cut
@@ -310,6 +312,7 @@ These slot-fill constructions signal that a sentence was generated, not written.
 
 ### Confidence calibration phrases
 - "It's worth noting that," "Interestingly," "Surprisingly," "Importantly," "Significantly," "Notably," "Certainly," "Undoubtedly," "Without a doubt" — AI uses these to signal how the reader should feel about a fact instead of letting the fact speak for itself.
+- "Here's what's interesting," "Here's the interesting part," "Here are the parts I found interesting" — reader-steering cue that pre-interprets importance. Works when followed by genuinely surprising data; fails when it introduces a restatement of something obvious (which is the AI default).
 - One "notably" in a 2,000-word piece is fine. Three in 500 words is AI-style emphasis stacking. Flag by density.
 
 ### Excessive structure


### PR DESCRIPTION
## Summary
- Adds **"worth [verb]ing" vague endorsement** pattern (worth reading, worth paying attention to, worth a look, etc.) — broadens existing "it's worth noting that" to the full family
- Adds **reader-steering frames** (here's what's interesting, here's what caught my eye, here's what stood out) to transition phrases and confidence calibration sections
- Includes nuance: data-backed usage (e.g. introducing specific numbers) is acceptable; the AI default of introducing a restatement of the obvious is the problem

## Test plan
- [ ] Verify SKILL.md renders correctly
- [ ] Run skill against sample text containing "worth checking out" and "here's what's interesting" — confirm both are flagged
- [ ] Confirm no false positives on "worth" in non-endorsement contexts (e.g. "net worth", "$5 worth")

🤖 Generated with [Claude Code](https://claude.com/claude-code)