### PR TITLE
feat: GitHub Action — audit changed markdown in PRs

### DIFF
--- a/.github/actions/avoid-ai-writing/action.yml
+++ b/.github/actions/avoid-ai-writing/action.yml
@@ -1,0 +1,49 @@
+name: 'Avoid AI Writing'
+description: 'Audit changed markdown in a PR for AI writing patterns. Posts a summary review comment.'
+author: 'Conor Bronsdon'
+branding:
+  icon: 'edit-3'
+  color: 'orange'
+
+inputs:
+  api-key:
+    description: 'API key from avoidaiwriting.com/developers. Pass via secrets.'
+    required: true
+  paths:
+    description: 'Comma-separated globs of files to audit. Default audits all *.md changes in the PR.'
+    required: false
+    default: '*.md,**/*.md'
+  context:
+    description: 'Audit context. Valid: blog, technical, investor, social, docs, casual. Default: docs.'
+    required: false
+    default: 'docs'
+  max-files:
+    description: 'Cap on files to audit per run (each file = 1 API credit). Default: 10.'
+    required: false
+    default: '10'
+  api-url:
+    description: 'Override the audit endpoint. Only useful for self-hosted forks.'
+    required: false
+    default: 'https://www.avoidaiwriting.com/api/v1/audit'
+
+outputs:
+  files-audited:
+    description: 'Number of files actually audited (after filtering + cap).'
+    value: ${{ steps.audit.outputs.files-audited }}
+  files-flagged:
+    description: 'Number of files where the audit returned non-empty findings.'
+    value: ${{ steps.audit.outputs.files-flagged }}
+
+runs:
+  using: composite
+  steps:
+    - id: audit
+      shell: bash
+      env:
+        AVOID_API_KEY: ${{ inputs.api-key }}
+        AVOID_PATHS: ${{ inputs.paths }}
+        AVOID_CONTEXT: ${{ inputs.context }}
+        AVOID_MAX_FILES: ${{ inputs.max-files }}
+        AVOID_API_URL: ${{ inputs.api-url }}
+        GH_TOKEN: ${{ github.token }}
+      run: ${{ github.action_path }}/run.sh

--- a/.github/actions/avoid-ai-writing/run.sh
+++ b/.github/actions/avoid-ai-writing/run.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Avoid AI Writing GitHub Action — composite runner.
+#
+# What it does:
+#   1. Detect changed markdown files in this PR (vs the base ref)
+#   2. Filter against the user's `paths` globs and `max-files` cap
+#   3. POST each file's contents to the audit API
+#   4. Summarize findings as a single PR comment
+#
+# Why composite + bash (not a JS action):
+#   The skill repo is intentionally zero-build (markdown only). Adding
+#   a JS action means committing a bundled `dist/index.js`, which is
+#   review noise + a maintenance surface that isn't worth it for this
+#   action's narrow scope. curl + gh + jq cover the full path cleanly.
+#
+# Failure modes (action exits 0 on all of these — the goal is review
+# signal, not blocking the PR):
+#   - No markdown changes → "no files to audit" comment, done
+#   - API key missing or rejected → log + exit 0 with no comment
+#   - Individual file too large (>60KB or >5000 words) → skipped with
+#     note in the summary, other files still audit normally
+#   - Insufficient credits mid-run → partial summary + credit note
+#   - Network failure on a single file → that file marked errored,
+#     others continue
+set -euo pipefail
+
+if [[ -z "${AVOID_API_KEY:-}" ]]; then
+  echo "::warning::AVOID_API_KEY not set — skipping audit. Set the api-key input via secrets."
+  exit 0
+fi
+
+if [[ "${GITHUB_EVENT_NAME:-}" != "pull_request" && "${GITHUB_EVENT_NAME:-}" != "pull_request_target" ]]; then
+  echo "::warning::This action expects to run on pull_request or pull_request_target events; got ${GITHUB_EVENT_NAME:-unknown}. Skipping."
+  exit 0
+fi
+
+# Resolve base + head refs from the GitHub event payload.
+base_sha="$(jq -r '.pull_request.base.sha' < "$GITHUB_EVENT_PATH")"
+head_sha="$(jq -r '.pull_request.head.sha' < "$GITHUB_EVENT_PATH")"
+pr_number="$(jq -r '.pull_request.number' < "$GITHUB_EVENT_PATH")"
+
+if [[ -z "$base_sha" || "$base_sha" == "null" ]]; then
+  echo "::warning::Could not resolve base SHA from event payload. Skipping."
+  exit 0
+fi
+
+# Make sure both commits are fetched (actions/checkout often only
+# pulls a shallow tree).
+git fetch --no-tags --depth=1 origin "$base_sha" 2>/dev/null || true
+git fetch --no-tags --depth=1 origin "$head_sha" 2>/dev/null || true
+
+# Get the list of changed files. `--diff-filter=AM` keeps Added +
+# Modified, drops deletes (no point auditing a file we just removed).
+mapfile -t changed < <(git diff --name-only --diff-filter=AM "$base_sha" "$head_sha" 2>/dev/null || true)
+
+# Filter against the user-supplied glob list. We intentionally don't
+# use `find` here — the filter is comma-separated globs matched with
+# bash `[[`, which keeps the action self-contained.
+IFS=',' read -ra patterns <<< "$AVOID_PATHS"
+matched=()
+for f in "${changed[@]}"; do
+  for p in "${patterns[@]}"; do
+    p="${p# }"; p="${p% }"  # trim spaces
+    # shellcheck disable=SC2053
+    if [[ "$f" == $p ]]; then
+      matched+=("$f")
+      break
+    fi
+  done
+done
+
+if [[ ${#matched[@]} -eq 0 ]]; then
+  echo "No markdown changes matched paths=$AVOID_PATHS. Skipping."
+  echo "files-audited=0" >> "$GITHUB_OUTPUT"
+  echo "files-flagged=0" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+# Cap to max-files.
+max_files="${AVOID_MAX_FILES:-10}"
+if [[ ${#matched[@]} -gt $max_files ]]; then
+  echo "::warning::Found ${#matched[@]} matching files; capping to $max_files (configure via max-files input)."
+  matched=("${matched[@]:0:$max_files}")
+fi
+
+context="${AVOID_CONTEXT:-docs}"
+api_url="${AVOID_API_URL:-https://www.avoidaiwriting.com/api/v1/audit}"
+
+# Limits matching the server's cap (60_000 chars / 5000 words). We
+# pre-check locally so a too-large file doesn't burn an API credit
+# just to come back as 400.
+MAX_CHARS=60000
+MAX_WORDS=5000
+
+flagged=0
+audited=0
+audited_list=""
+flagged_list=""
+skipped_list=""
+errored_list=""
+last_credits=""
+
+for f in "${matched[@]}"; do
+  if [[ ! -f "$f" ]]; then
+    skipped_list+=$'\n'"- \`$f\` — file not present at HEAD (renamed or moved)"
+    continue
+  fi
+  bytes=$(wc -c < "$f")
+  words=$(wc -w < "$f")
+  if [[ $bytes -gt $MAX_CHARS ]]; then
+    skipped_list+=$'\n'"- \`$f\` — too large ($bytes bytes; cap is $MAX_CHARS)"
+    continue
+  fi
+  if [[ $words -gt $MAX_WORDS ]]; then
+    skipped_list+=$'\n'"- \`$f\` — too many words ($words; cap is $MAX_WORDS)"
+    continue
+  fi
+
+  # Build the JSON body. jq handles all escaping so embedded quotes /
+  # backticks / newlines in the markdown don't break the request.
+  body="$(jq -n --arg t "$(cat "$f")" --arg c "$context" '{text: $t, context: $c}')"
+
+  http_status=0
+  resp_file="$(mktemp)"
+  http_status=$(curl -sS -o "$resp_file" -w '%{http_code}' \
+    -X POST "$api_url" \
+    -H "Authorization: Bearer $AVOID_API_KEY" \
+    -H "Content-Type: application/json" \
+    --data-binary "$body" \
+    --max-time 90 || echo "000")
+
+  if [[ "$http_status" == "200" ]]; then
+    audited=$((audited + 1))
+    audited_list+=$'\n'"- \`$f\` audited"
+    result="$(jq -r '.result // empty' < "$resp_file")"
+    last_credits="$(jq -r '.credits // empty' < "$resp_file")"
+    if [[ -n "$result" && "$result" != "null" ]]; then
+      flagged=$((flagged + 1))
+      flagged_list+=$'\n\n'"### \`$f\`"$'\n\n'"$result"
+    fi
+  elif [[ "$http_status" == "402" ]]; then
+    errored_list+=$'\n'"- \`$f\` — out of API credits (run halted; remaining files skipped)"
+    rm -f "$resp_file"
+    break
+  elif [[ "$http_status" == "401" ]]; then
+    errored_list+=$'\n'"- API key rejected (\`401\`). Halting."
+    rm -f "$resp_file"
+    break
+  else
+    msg="$(jq -r '.error.message // .error // "unknown"' < "$resp_file" 2>/dev/null || echo "unknown")"
+    errored_list+=$'\n'"- \`$f\` — HTTP $http_status: $msg"
+  fi
+  rm -f "$resp_file"
+done
+
+# Build the comment body. Always include a header so it's identifiable
+# (and so a future pass could replace prior comments by header match).
+comment_body="<!-- avoid-ai-writing-action -->
+## ✍️ Avoid AI Writing — audit summary
+
+Audited **$audited** changed markdown file(s); **$flagged** flagged AI writing patterns."
+
+if [[ -n "$last_credits" ]]; then
+  comment_body+=$'\n\n'"_API credits remaining: $last_credits_"
+fi
+
+if [[ -n "$flagged_list" ]]; then
+  comment_body+=$'\n\n---\n\n## Findings'"$flagged_list"
+fi
+
+if [[ -n "$skipped_list" ]]; then
+  comment_body+=$'\n\n---\n\n### Skipped'"$skipped_list"
+fi
+
+if [[ -n "$errored_list" ]]; then
+  comment_body+=$'\n\n---\n\n### Errors'"$errored_list"
+fi
+
+comment_body+=$'\n\n---\n\n*Generated by [avoid-ai-writing](https://github.com/conorbronsdon/avoid-ai-writing). [Get an API key](https://www.avoidaiwriting.com/developers).*'
+
+# Post the comment via gh CLI. Use a temp file for the body so the
+# command line doesn't choke on long markdown.
+tmp_comment="$(mktemp)"
+printf '%s' "$comment_body" > "$tmp_comment"
+gh pr comment "$pr_number" --body-file "$tmp_comment" --repo "$GITHUB_REPOSITORY"
+rm -f "$tmp_comment"
+
+echo "files-audited=$audited" >> "$GITHUB_OUTPUT"
+echo "files-flagged=$flagged" >> "$GITHUB_OUTPUT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project are documented here.
 
 ---
 
+## [Unreleased]
+
+### Added
+- **GitHub Action** at `.github/actions/avoid-ai-writing/` — composite action that audits changed `*.md` files in PRs and posts a summary review comment. Calls the audit API at avoidaiwriting.com; consumer repos add an `AVOID_API_KEY` secret and a one-step workflow. Skips files over the server caps, fails open so flaky network can't block merges. README has the full workflow snippet under "Installation & Usage".
+- **Example workflow** at `.github/workflows/example-audit.yml` showing the action used against this repo (self-validating reference).
+
+---
+
+## [3.3.1] — 2026-04-17
+
+### Added
+- **"Hit differently" added to Tier 1 word table + emotional flatline pattern** — extends the Tier 1 catalog to flag the AI-favorite "hits differently" framing alongside the existing emotional-flatline pattern.
+
+---
+
 ## [3.3.0] — 2026-04-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -115,6 +115,32 @@ In **detect mode**, the skill returns two sections:
 
 Trigger detect mode with: "detect," "flag only," "audit only," "just flag," "scan," or similar.
 
+### GitHub Action — audit docs PRs
+
+For repos that want AI-pattern audits to fire automatically on every PR touching markdown, this repo also ships a composite GitHub Action at [`.github/actions/avoid-ai-writing`](./.github/actions/avoid-ai-writing). It detects changed `*.md` files in the PR, runs each through the audit API, and posts a summary review comment.
+
+```yaml
+# .github/workflows/audit-docs.yml
+name: Audit changed docs
+on:
+  pull_request:
+    paths: ['**/*.md']
+permissions:
+  pull-requests: write
+  contents: read
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: conorbronsdon/avoid-ai-writing/.github/actions/avoid-ai-writing@main
+        with:
+          api-key: ${{ secrets.AVOID_API_KEY }}
+```
+
+Get an API key at [avoidaiwriting.com/developers](https://www.avoidaiwriting.com/developers). The action skips files over 60KB or 5000 words, caps each run at 10 files, and exits 0 on all error paths so a flaky audit can't block a merge. See [`docs/example-workflow.yml`](./docs/example-workflow.yml) for the full reference workflow.
+
 ## 36 Patterns Detected
 
 ### Content Patterns

--- a/docs/example-workflow.yml
+++ b/docs/example-workflow.yml
@@ -1,0 +1,51 @@
+# Example workflow demonstrating the avoid-ai-writing action.
+#
+# To use this in your own repo:
+#   1. Get an API key from https://www.avoidaiwriting.com/developers
+#   2. Add it as a repo secret named AVOID_API_KEY
+#   3. Drop this file into .github/workflows/ in your repo
+#   4. Open a PR that touches a markdown file — the action will post
+#      a review comment with audit findings
+#
+# This file lives in docs/ (not .github/workflows/) so it stays a
+# reference template. The skill repo doesn't yet have an
+# AVOID_API_KEY secret set, so a live workflow here would fail on
+# every PR. Move this file to .github/workflows/ in your own repo
+# (or in this repo, once the secret is configured) to enable it.
+#
+# The action itself is at .github/actions/avoid-ai-writing/ in this
+# repo.
+
+name: Audit changed docs for AI writing patterns
+
+on:
+  pull_request:
+    paths:
+      - '**/*.md'
+
+# pull-requests: write is required so the action can post the summary
+# comment; contents: read is enough for git diff against the base.
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need both base + head SHAs to compute the diff. Fetch
+          # depth 0 is the simplest way to guarantee both are present
+          # without juggling explicit git fetches.
+          fetch-depth: 0
+
+      # In a consumer repo this would be `uses: conorbronsdon/avoid-ai-writing/.github/actions/avoid-ai-writing@v3`
+      # — local path here so the example is self-validating in CI.
+      - uses: ./.github/actions/avoid-ai-writing
+        with:
+          api-key: ${{ secrets.AVOID_API_KEY }}
+          # Optional overrides:
+          # paths: 'docs/**/*.md,README.md'
+          # context: 'docs'
+          # max-files: '10'


### PR DESCRIPTION
Implements the GitHub Action half of [avoid-ai-writing-app#110](https://github.com/conorbronsdon/avoid-ai-writing-app/issues/110).

## Summary

A composite GitHub Action at `.github/actions/avoid-ai-writing/` that auto-runs on PRs touching markdown, audits each changed file via the live API at avoidaiwriting.com, and posts a single summary review comment back to the PR. Three changed files, ~270 lines of bash + yaml, no `node_modules` to bundle.

## Why composite + bash (not a JS action)

The skill repo is intentionally zero-build (markdown only). A JS action means committing a bundled `dist/index.js`, which is review noise + a maintenance surface that isn't worth it for this action's narrow scope. `curl + gh + jq` cover the full path cleanly.

## Failure-open posture

Every error path exits `0` so a flaky audit can't block a merge:
- API key missing → `::warning::` + skip
- API key rejected (`401`) → halt run, log, exit 0
- File too large (>60KB or >5000 words, mirroring server caps) → skip + note in summary
- Insufficient credits mid-run (`402`) → partial summary + credit note
- Per-file network error → that file marked errored, others continue

Pre-flight size check matches the server's `MAX_TEXT_LENGTH` so we don't burn a credit just to come back as 400.

## Example workflow location

`docs/example-workflow.yml`, **not** `.github/workflows/`. The skill repo doesn't have an `AVOID_API_KEY` secret set yet; an active workflow here would fail on every PR until that's configured. Move to `.github/workflows/` to enable.

## Also in this PR

- Backfills the missing `[3.3.1]` CHANGELOG entry for the "hit differently" Tier 1 addition (commit `088c4ad` from 4/17, never made it into CHANGELOG).
- README "Installation & Usage" gains a "GitHub Action — audit docs PRs" subsection with a copy-paste workflow snippet.

## Test plan

- [ ] Manual smoke test: create a test repo with `AVOID_API_KEY` secret, copy `docs/example-workflow.yml` to `.github/workflows/`, open a PR with a doc change → verify summary comment posts
- [ ] Edge case: PR with only a deleted .md file → action posts "no files to audit" and exits 0
- [ ] Edge case: oversize file (>60KB) → action skips with a "too large" note
- [ ] Edge case: invalid API key → halts cleanly