### PR TITLE
feat: position-pivot preface + Cursor rule port

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,18 @@ clawhub install avoid-ai-writing
 git clone https://github.com/conorbronsdon/avoid-ai-writing ~/.openclaw/skills/avoid-ai-writing
 ```
 
+### Cursor
+
+Drop the ported rule into your project's `.cursor/rules/`:
+
+```bash
+mkdir -p .cursor/rules
+curl -o .cursor/rules/avoid-ai-writing.mdc \
+  https://raw.githubusercontent.com/conorbronsdon/avoid-ai-writing/main/cursor-rules/avoid-ai-writing.mdc
+```
+
+See [`cursor-rules/README.md`](./cursor-rules/README.md) for activation globs and trigger phrases. Functionally identical to the Claude Code skill — same tier vocabulary, same context profiles, same modes.
+
 ### Triggering the skill
 
 Once installed, ask your assistant to clean up AI writing:

--- a/SKILL.md
+++ b/SKILL.md
@@ -18,9 +18,11 @@ You are editing content to remove AI writing patterns ("AI-isms") that make text
 
 ## What this skill is and isn't
 
-This is a **writing-quality nudge**, not a forensic AI detector. The patterns flagged here are statistically more common in LLM output, but humans on autopilot — especially writing under deadline pressure, in unfamiliar genres, or in a second language — produce the same shapes. Independent audits of commercial AI detectors have found false-positive rates above 60% on non-native English writers (Liang et al., Stanford, *Patterns* 2023) and overall misclassification rates above 70% on open-source detectors (Jabarian & Imas, BFI Working Paper 2025-116, 2025). Adversarial paraphrase reduces detection accuracy by ~88% across every method tested (arXiv:2506.07001, 2025).
+This is a **writing-quality tool**, not a verdict. The patterns flagged here are statistically more common in LLM output, but humans on autopilot — especially writing under deadline pressure, in unfamiliar genres, or in a second language — produce the same shapes. Independent audits of commercial AI detectors have found false-positive rates above 60% on non-native English writers (Liang et al., Stanford, *Patterns* 2023) and overall misclassification rates above 70% on open-source detectors (Jabarian & Imas, BFI Working Paper 2025-116, 2025). Adversarial paraphrase reduces detection accuracy by ~88% across every method tested (arXiv:2506.07001, 2025).
 
-The point of running this skill on text is to make it more direct, specific, and human-sounding — not to accuse a writer of using AI. Do not use it to make decisions about academic integrity, hiring, or any context where misclassification would cause harm. The patterns are real and worth fixing in your own writing; they are not evidence about anyone else's.
+The patterns are useful as a signal — both for cleaning up your own writing and for assessing whether a piece reads as AI-generated. Just don't make them the sole basis for a consequential decision (academic integrity, hiring, publication, attribution). Several rules here also fire on second-language writing, deadline-pressed humans, and technical genres that compress vocabulary by design. Pair the signal with context: who wrote it, what genre, what the writer's normal voice looks like, what other evidence you have.
+
+In short: signals, not proof. Worth acting on; not worth ruining someone's day over.
 
 ## Modes
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -384,6 +384,14 @@ These aren't individual word or phrase problems — they're patterns in how the 
 - **Missing first-person perspective**: Where appropriate, the writer should have opinions, preferences, and reactions. AI is relentlessly neutral. If the piece is supposed to have a voice, the absence of "I think," "in my experience," or a stated preference is itself an AI tell.
 - **Over-polishing**: Aggressively editing out every irregularity can push human writing *toward* AI statistical profiles. Natural disfluency, idiosyncratic word choices, and uneven pacing are what keep text out of the "AI-generated" classification. Don't sand away all personality in pursuit of clean prose. This skill should make writing sound more human, not less — if you apply every rule at maximum strictness, you risk creating the very uniformity you're trying to avoid.
 
+### Vocabulary diversity (stylometric)
+
+In longer pieces (200+ words), look at how much vocabulary the text actually uses. The type-token ratio (TTR) — distinct word types divided by total tokens — is a classical stylometric signal that's easy to read by eye. Human prose at this length usually lands somewhere around 0.50–0.65 in English. AI text trends flatter, sometimes drifting under 0.40 when the model gets locked on a small vocabulary loop.
+
+A very low TTR is not by itself proof of AI authorship — narrow topics, technical reference material, and second-language writing all legitimately compress vocabulary. But on general prose where you'd expect range (essays, articles, social content over ~200 words), a TTR below 0.40 is worth a second look. The fix is rarely to thesaurus the text; it's to broaden the *what* — name specific things, cite specific cases, replace a re-used abstract noun with the concrete instance behind it.
+
+This is the first of four stylometric signals on the roadmap. The others (sentence-length burstiness as a continuous measure, function-word z-scores against a human-prose reference, POS-bigram log-odds) require either a POS tagger or a reference distribution and aren't implemented as detector categories yet.
+
 ### When to rewrite from scratch vs. patch
 
 If the text has 5+ flagged vocabulary hits across multiple categories, 3+ distinct pattern categories triggered, and uniform sentence/paragraph length, patching individual phrases won't fix it — the structure itself is AI-generated. Advise a full rewrite: state the core point in one sentence, then rebuild from there.

--- a/cursor-rules/README.md
+++ b/cursor-rules/README.md
@@ -1,0 +1,31 @@
+# Cursor Rule — avoid-ai-writing
+
+Drop-in [Cursor](https://cursor.sh) rule that ports the [`avoid-ai-writing`](../SKILL.md) skill to Cursor's `.mdc` rule format. Functionally identical to the upstream skill — same tier vocabulary, same context profiles, same detect / rewrite modes.
+
+## Install
+
+Copy `avoid-ai-writing.mdc` into your project's `.cursor/rules/` directory:
+
+```sh
+mkdir -p .cursor/rules
+curl -o .cursor/rules/avoid-ai-writing.mdc \
+  https://raw.githubusercontent.com/conorbronsdon/avoid-ai-writing/main/cursor-rules/avoid-ai-writing.mdc
+```
+
+By default the rule activates on `.md`, `.mdx`, `.txt`, `.rst`, and `.adoc` files (via the `globs` field in the frontmatter). Edit the globs in the rule file if you want it on other file types — or set `alwaysApply: true` if you want it on every Cursor session.
+
+## Trigger phrases
+
+Once installed, ask Cursor:
+- *"Remove AI-isms from this section."*
+- *"Audit this draft for AI writing patterns."*
+- *"Make this sound less like AI."*
+- *"Run avoid-ai-writing in detect mode."* (flag without rewriting)
+
+## Old Cursor projects
+
+If you're on a Cursor version that still uses `.cursorrules` (single file at repo root), you can append `avoid-ai-writing.mdc`'s body (the part below the `---` frontmatter) directly to your existing `.cursorrules` file. Modern Cursor projects should prefer the `.cursor/rules/*.mdc` layout.
+
+## Updating
+
+This file is a copy of [`SKILL.md`](../SKILL.md) with Cursor-specific frontmatter. When the upstream skill updates, this file should be re-synced. There's no automated sync between them today — open an issue if drift becomes a problem.

--- a/cursor-rules/avoid-ai-writing.mdc
+++ b/cursor-rules/avoid-ai-writing.mdc
@@ -1,15 +1,7 @@
 ---
-name: avoid-ai-writing
-description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Use this skill when asked to "remove AI-isms," "clean up AI writing," "edit writing for AI patterns," "audit writing for AI tells," or "make this sound less like AI." Supports a detection-only mode that flags patterns without rewriting.
-version: 3.4.0
-license: MIT
-compatibility: Any AI coding assistant that supports agentskills.io SKILL.md format (Claude Code, Cursor, VS Code Copilot, Hermes Agent, OpenHands, etc.) or OpenClaw. No external tools or APIs required.
-metadata:
-  author: Conor Bronsdon
-  tags: writing editing voice quality
-  agentskills_spec: "1.0"
-  openclaw:
-    emoji: "\u270D\uFE0F"
+description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Activate whenever editing prose-heavy files (Markdown, documentation, blog posts, READMEs, release notes, emails). Cursor port of the avoid-ai-writing skill v3.4.0. See https://github.com/conorbronsdon/avoid-ai-writing.
+globs: ["**/*.md", "**/*.mdx", "**/*.txt", "**/*.rst", "**/*.adoc"]
+alwaysApply: false
 ---
 
 # Avoid AI Writing — Audit & Rewrite

--- a/cursor-rules/avoid-ai-writing.mdc
+++ b/cursor-rules/avoid-ai-writing.mdc
@@ -10,9 +10,11 @@ You are editing content to remove AI writing patterns ("AI-isms") that make text
 
 ## What this skill is and isn't
 
-This is a **writing-quality nudge**, not a forensic AI detector. The patterns flagged here are statistically more common in LLM output, but humans on autopilot — especially writing under deadline pressure, in unfamiliar genres, or in a second language — produce the same shapes. Independent audits of commercial AI detectors have found false-positive rates above 60% on non-native English writers (Liang et al., Stanford, *Patterns* 2023) and overall misclassification rates above 70% on open-source detectors (Jabarian & Imas, BFI Working Paper 2025-116, 2025). Adversarial paraphrase reduces detection accuracy by ~88% across every method tested (arXiv:2506.07001, 2025).
+This is a **writing-quality tool**, not a verdict. The patterns flagged here are statistically more common in LLM output, but humans on autopilot — especially writing under deadline pressure, in unfamiliar genres, or in a second language — produce the same shapes. Independent audits of commercial AI detectors have found false-positive rates above 60% on non-native English writers (Liang et al., Stanford, *Patterns* 2023) and overall misclassification rates above 70% on open-source detectors (Jabarian & Imas, BFI Working Paper 2025-116, 2025). Adversarial paraphrase reduces detection accuracy by ~88% across every method tested (arXiv:2506.07001, 2025).
 
-The point of running this skill on text is to make it more direct, specific, and human-sounding — not to accuse a writer of using AI. Do not use it to make decisions about academic integrity, hiring, or any context where misclassification would cause harm. The patterns are real and worth fixing in your own writing; they are not evidence about anyone else's.
+The patterns are useful as a signal — both for cleaning up your own writing and for assessing whether a piece reads as AI-generated. Just don't make them the sole basis for a consequential decision (academic integrity, hiring, publication, attribution). Several rules here also fire on second-language writing, deadline-pressed humans, and technical genres that compress vocabulary by design. Pair the signal with context: who wrote it, what genre, what the writer's normal voice looks like, what other evidence you have.
+
+In short: signals, not proof. Worth acting on; not worth ruining someone's day over.
 
 ## Modes
 
@@ -375,6 +377,14 @@ These aren't individual word or phrase problems — they're patterns in how the 
 - **Read-aloud test**: If the text sounds like it could be read by a text-to-speech engine without sounding weird, it's probably too uniform. Human writing has rhythm that resists robotic delivery.
 - **Missing first-person perspective**: Where appropriate, the writer should have opinions, preferences, and reactions. AI is relentlessly neutral. If the piece is supposed to have a voice, the absence of "I think," "in my experience," or a stated preference is itself an AI tell.
 - **Over-polishing**: Aggressively editing out every irregularity can push human writing *toward* AI statistical profiles. Natural disfluency, idiosyncratic word choices, and uneven pacing are what keep text out of the "AI-generated" classification. Don't sand away all personality in pursuit of clean prose. This skill should make writing sound more human, not less — if you apply every rule at maximum strictness, you risk creating the very uniformity you're trying to avoid.
+
+### Vocabulary diversity (stylometric)
+
+In longer pieces (200+ words), look at how much vocabulary the text actually uses. The type-token ratio (TTR) — distinct word types divided by total tokens — is a classical stylometric signal that's easy to read by eye. Human prose at this length usually lands somewhere around 0.50–0.65 in English. AI text trends flatter, sometimes drifting under 0.40 when the model gets locked on a small vocabulary loop.
+
+A very low TTR is not by itself proof of AI authorship — narrow topics, technical reference material, and second-language writing all legitimately compress vocabulary. But on general prose where you'd expect range (essays, articles, social content over ~200 words), a TTR below 0.40 is worth a second look. The fix is rarely to thesaurus the text; it's to broaden the *what* — name specific things, cite specific cases, replace a re-used abstract noun with the concrete instance behind it.
+
+This is the first of four stylometric signals on the roadmap. The others (sentence-length burstiness as a continuous measure, function-word z-scores against a human-prose reference, POS-bigram log-odds) require either a POS tagger or a reference distribution and aren't implemented as detector categories yet.
 
 ### When to rewrite from scratch vs. patch
 


### PR DESCRIPTION
Two low-hanging-fruit items from the May 2026 competitive landscape research.

## 1. SKILL.md preface — "What this skill is and isn't"

Frames the skill explicitly as a writing-quality nudge, not a forensic detector. Independent-audit evidence against detection-as-forensics is now overwhelming:

- Liang et al. (Stanford, *Patterns* 2023): 61.3% TOEFL false-positive across 7 detectors
- Jabarian & Imas (BFI 2025): OSS detectors misclassify up to 78% of human text
- Adversarial paraphrase (arXiv:2506.07001, June 2025): ~88% T@1%F reduction across all methods
- Turnitin lost its first lawsuit Feb 2026 (Newby v. Adelphi)

The new preface explicitly disavows the forensic use case. Inoculates the project against the reputational + liability risk hitting Turnitin et al.

## 2. Cursor rule — `cursor-rules/avoid-ai-writing.mdc`

Modern `.cursor/rules/*.mdc` format port of SKILL.md. Activates on prose globs (.md, .mdx, .txt, .rst, .adoc). Body is verbatim SKILL.md; only frontmatter differs.

Opens a new distribution channel — `PatrickJS/awesome-cursorrules` (39.5K stars) has zero prose-humanizer entries. Awesome-cursorrules submission is the natural follow-up.

## Test plan
- [ ] Preface reads cleanly and doesn't contradict any existing rule
- [ ] `.mdc` file parses correctly when dropped into a Cursor project's `.cursor/rules/` dir
- [ ] README install snippet works as a one-liner curl