### PR TITLE
Make repo SSOT for the detection engine

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+## Summary
+
+<!-- What does this change and why? -->
+
+## Checklist
+
+- [ ] `npm test` passes (engine fixtures + `CATEGORIES.md` contract check)
+- [ ] If I added a detector `type`: it's documented in `detector/CATEGORIES.md` and has a fixture in `detector/patterns.test.js` (a true positive **and** a must-not-fire case)
+- [ ] If I added a judgment-only rule: it's listed under "Skill-only" in `detector/CATEGORIES.md`
+- [ ] I considered false positives and added carve-outs for legitimate human writing
+- [ ] The prose I added passes the skill's own audit (no AI-writing tells, terse bullets, no hollow intensifiers)
+- [ ] `CHANGELOG.md` entry added under a dated `## [X.Y.Z]` heading, and `SKILL.md` `version:` bumped if a rule changed

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,5 +8,6 @@
 - [ ] If I added a detector `type`: it's documented in `detector/CATEGORIES.md` and has a fixture in `detector/patterns.test.js` (a true positive **and** a must-not-fire case)
 - [ ] If I added a judgment-only rule: it's listed under "Skill-only" in `detector/CATEGORIES.md`
 - [ ] I considered false positives and added carve-outs for legitimate human writing
+- [ ] Any factual claim about how AI or humans write (e.g. "ChatGPT emits X", "humans rarely do Y") cites a source
 - [ ] The prose I added passes the skill's own audit (no AI-writing tells, terse bullets, no hollow intensifiers)
 - [ ] `CHANGELOG.md` entry added under a dated `## [X.Y.Z]` heading, and `SKILL.md` `version:` bumped if a rule changed

--- a/.github/workflows/detector-test.yml
+++ b/.github/workflows/detector-test.yml
@@ -1,0 +1,23 @@
+name: detector
+
+on:
+  push:
+    paths:
+      - "detector/**"
+      - "package.json"
+      - ".github/workflows/detector-test.yml"
+  pull_request:
+    paths:
+      - "detector/**"
+      - "package.json"
+      - ".github/workflows/detector-test.yml"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: npm test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,15 @@ positives erode trust in every other rule. Before proposing a rule, ask who woul
 get flagged by mistake, and add carve-outs for the legitimate cases. A signal
 that fires on most normal prose is not worth adding.
 
+## Cite your sources
+
+If your rule rests on a factual claim about how AI or humans write — "ChatGPT
+emits curly quotes by default," "most writers rarely do X" — link a source for
+it. These claims get checked, and some turn out wrong or more nuanced than they
+first seem (smart quotes, for instance, are a typing-time default on macOS and in
+Word, not a publication-step artifact). A claim with a citation can be verified;
+an asserted one can't. Put the links in the PR description or inline in the rule.
+
 ## Run the tests
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# Contributing
+
+Thanks for helping improve this skill. It teaches an LLM (and now a deterministic
+engine) to spot and fix AI-writing tells. Contributions are welcome — a few things
+keep the project coherent.
+
+## How the repo fits together
+
+| Path | What it holds |
+|------|---------------|
+| `SKILL.md` | The human-readable catalog of rules. The source of truth for what counts as an AI tell. |
+| `detector/patterns.js` | The deterministic engine — the executable subset of the rules. |
+| `detector/CATEGORIES.md` | The map between SKILL.md rules and detector `type`s. Keep it current. |
+| `README.md` | The pitch and the numbered prose-pattern list. |
+| `cursor-rules/`, `plugins/` | Editor and tool integrations. |
+
+## Adding or changing a rule
+
+First decide which kind of rule it is:
+
+- **Regex-detectable** (a phrase, a character, a structural shape) → add it to
+  `SKILL.md`, add the detection to `detector/patterns.js` with a new `type`, and
+  add a row to `detector/CATEGORIES.md`. Cover it with a fixture in
+  `detector/patterns.test.js` (both a true positive and a case that must *not*
+  fire).
+- **Judgment-only** (needs reading for meaning — tone, structure, name-dropping)
+  → add it to `SKILL.md` prose and list it under "Skill-only" in
+  `detector/CATEGORIES.md`. There is no detector type for these.
+
+If you are unsure which it is, open an issue first and we will sort it out.
+
+## Precision over recall
+
+This skill is deliberately biased toward false negatives: a rule that wrongly
+flags ordinary human writing is worse than one that misses a tell, because false
+positives erode trust in every other rule. Before proposing a rule, ask who would
+get flagged by mistake, and add carve-outs for the legitimate cases. A signal
+that fires on most normal prose is not worth adding.
+
+## Run the tests
+
+```bash
+npm test
+```
+
+This runs the engine fixtures and the `CATEGORIES.md` contract check (every
+detector `type` must be documented, and every documented type must be real). Both
+must pass. No dependencies to install; Node 18+ only.
+
+## Write clean prose
+
+This repo polices writing quality, so the prose you add has to clear the same
+bar. Run your additions through the skill itself. Keep rule bullets terse and
+lead with the directive — match the length and tone of the bullets already in
+`SKILL.md`. Drop intensifiers like "strong" or "powerful"; let the rule stand on
+its own.
+
+## Changelog and versioning
+
+Add an entry to `CHANGELOG.md` under a dated, versioned heading
+(`## [X.Y.Z] — YYYY-MM-DD`), matching the existing entries. A new rule is a minor
+version bump; update the `version:` field in the `SKILL.md` frontmatter to match.

--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ Trigger detect mode with: "detect," "flag only," "audit only," "just flag," "sca
 
 ## 42 Patterns Detected
 
+> These 42 are the human-facing prose rules. The [detector engine](./detector/) implements **43 `type` categories** — a different count, because it splits the vocabulary tiers and adds stylometric/fingerprint signals (punctuation distribution, function-word entropy, bypass-trick detection) that work as math over a document rather than as a rule you'd look up. The two are mapped in [`detector/CATEGORIES.md`](./detector/CATEGORIES.md); don't "fix" one count to match the other.
+
 ### Content Patterns
 
 | # | Pattern | Before | After |

--- a/README.md
+++ b/README.md
@@ -235,6 +235,26 @@ Added in v3.4 to catch LLM output that sidesteps the vocabulary tables by substi
 
 That's 35+ AI tells.
 
+## Run the detector
+
+The skill ships a deterministic, zero-dependency detection engine in
+[`detector/`](./detector/) — the same 43-category engine the rules above
+describe, as runnable code. It works in Node (`>=18`) and the browser with no
+build step.
+
+```bash
+npm test          # run the detector's fixtures (no deps to install)
+```
+
+```js
+const AIDetector = require("./detector/patterns.js");
+const { score, label, issues } = AIDetector.analyzeText("Your text here…");
+```
+
+See [`detector/README.md`](./detector/README.md) for the full `analyzeText` API
+and [`detector/CATEGORIES.md`](./detector/CATEGORIES.md) for the rule ↔ category
+map that keeps `SKILL.md` and the engine in sync.
+
 ## $avoid token + web app
 
 The community created a Solana token around this project. You can burn $avoid tokens to run the audit skill through a web app:

--- a/detector/CATEGORIES.md
+++ b/detector/CATEGORIES.md
@@ -1,0 +1,86 @@
+# Category map: SKILL.md ↔ detector
+
+This table is the anti-drift contract between the human-readable rules in
+`../SKILL.md` and the executable engine in `patterns.js`. When you add a rule to
+the skill, decide here whether it's regex-detectable (give it a detector `type`)
+or LLM-only judgment (mark it so). When you add a detector `type`, point it back
+at the skill section it enforces.
+
+The engine exposes 43 issue `type`s (see `TYPE_LABELS` in `patterns.js`). The
+skill has more `###` sections than that — the gap is **not** missing coverage,
+it's rules that are judgment calls a regex can't make. The three groups below
+account for every entry on both sides.
+
+## A. Direct mapping (skill rule → detector `type`)
+
+| Detector `type` | Label | SKILL.md section |
+|---|---|---|
+| `tier1` / `tier2` / `tier3` | AI vocabulary / Word cluster / Overused word | Words and phrases to replace |
+| `transition` | AI transition | Transition phrases to remove or rewrite |
+| `template-phrase` | Template phrase | Template phrases (avoid) |
+| `tier3-phrase` / `tier3-phrase-cluster` | Boilerplate phrase / cluster | Template phrases (avoid) |
+| `chatbot` | Chatbot artifact | Chatbot artifacts |
+| `sycophantic` | Sycophantic tone | Sycophantic tone |
+| `acknowledgment-loop` | Acknowledgment loop | Acknowledgment loops |
+| `filler` | Filler phrase | Filler phrases |
+| `hollow-intensifier` | Hollow intensifier | Filler phrases (intensifiers) |
+| `generic-conclusion` | Generic conclusion | Generic conclusions |
+| `future-narrative` | Generic future narrative | Generic future-narrative closers |
+| `lets-construction` | "Let's" opener | "Let's" constructions |
+| `reasoning-artifact` | Reasoning artifact | Reasoning chain artifacts |
+| `significance-inflation` | Significance inflation | Significance inflation |
+| `novelty-inflation` | Novelty inflation | Novelty inflation |
+| `real-actual-inflation` | "Real/actual" inflation | "Real/actual" adjective inflation |
+| `vague-attribution` | Vague attribution | Vague attributions |
+| `emotional-flatline` | Emotional flatline | Emotional flatline / Superficial -ing analyses |
+| `cutoff-disclaimer` | Cutoff disclaimer | Cutoff disclaimers |
+| `false-concession` | False concession | False concession structure |
+| `rhetorical-question` | Rhetorical question | Rhetorical question openers |
+| `formulaic-opener` | Formulaic opener | Formulaic challenges |
+| `confidence-calibration` | Confidence stacking | Confidence calibration phrases |
+| `hedge-stack` | Hedge-stacked prediction | Hedge-stacked predictions |
+| `parenthetical-hedge` | Parenthetical hedge | Parenthetical hedging |
+| `hashtag-stuff` | Hashtag stuffing | Hashtag stuffing |
+| `bullet-np-list` | Bullet-NP list | Bullet lists of bare noun phrases |
+| `title-case-header` | Title Case header | Title case headings |
+| `em-dash` / `formatting` | Em dash overuse / Formatting | Formatting |
+| `uniformity` | Rhythm uniformity | Rhythm and uniformity |
+| `low-ttr` | Low vocabulary diversity | Vocabulary diversity (stylometric) |
+| `ai-placeholder` | Unfilled placeholder | Unfilled placeholders |
+| `ai-citation-markup` | Chatbot citation markup leak | Chatbot citation markup leaks |
+| `ai-utm-source` | AI-tool URL parameter | AI-tool URL parameters |
+
+## B. Detector-only (stylometric / fingerprint — no skill prose)
+
+These extend the skill with signals that work as math over the whole document,
+not as a phrase a human editor would look up:
+
+| Detector `type` | Label | Why it's engine-only |
+|---|---|---|
+| `smart-punct-signature` | Smart-punct signature | Distribution of curly quotes / ellipsis chars |
+| `punct-distribution` | Punctuation distribution | Per-paragraph punctuation uniformity |
+| `fnword-trigram-entropy` | Grammar repetition | Function-word trigram entropy |
+| `cross-para-burstiness` | Cross-paragraph rhythm | Sentence-length variance across paragraphs |
+| `normalization-flag` | Bypass-trick chars | Zero-width / homoglyph humanizer-bypass detection |
+
+## C. Skill-only (LLM judgment — no detector `type`)
+
+Rules that require reading for meaning, so they live in the skill prose and are
+applied by the model, not the regex engine. Listed so future contributors don't
+mistake their absence for a coverage gap:
+
+- Synonym cycling
+- Copula avoidance
+- Promotional language
+- Structural issues / Excessive structure / Inline-header lists / Numbered list inflation
+- False ranges
+- Notability name-dropping
+- When to rewrite from scratch vs. patch
+- Severity tiers (P0 / P1 / P2)
+- Self-reference escape hatch
+- Output format
+
+> **Partial:** the skill's **Context profiles / Tolerance matrix / Auto-detection
+> cues** are partly realized by the engine's `options.contextMode`
+> (`general` / `technical`), which suppresses context-inappropriate flags. Full
+> profile-based tolerance remains an LLM-side judgment.

--- a/detector/CATEGORIES.md
+++ b/detector/CATEGORIES.md
@@ -49,6 +49,14 @@ account for every entry on both sides.
 | `ai-placeholder` | Unfilled placeholder | Unfilled placeholders |
 | `ai-citation-markup` | Chatbot citation markup leak | Chatbot citation markup leaks |
 | `ai-utm-source` | AI-tool URL parameter | AI-tool URL parameters |
+| `smart-punct-signature` | Smart-punct signature | Formatting (curly quotation marks) — *partial* |
+
+> **Partial map:** `smart-punct-signature` fires only when curly quotes co-occur
+> with an em-dash, an Oxford comma, and clean typing (≥80 words) — never on curly
+> punctuation alone. The SKILL.md Formatting rule treats curly quotes as a weak,
+> corroborating signal in plain-text contexts and excludes apostrophes. The two
+> agree in spirit (curly punctuation is never conclusive on its own) but differ in
+> mechanism — so this is a partial map, not 1:1.
 
 ## B. Detector-only (stylometric / fingerprint — no skill prose)
 
@@ -57,7 +65,6 @@ not as a phrase a human editor would look up:
 
 | Detector `type` | Label | Why it's engine-only |
 |---|---|---|
-| `smart-punct-signature` | Smart-punct signature | Distribution of curly quotes / ellipsis chars |
 | `punct-distribution` | Punctuation distribution | Per-paragraph punctuation uniformity |
 | `fnword-trigram-entropy` | Grammar repetition | Function-word trigram entropy |
 | `cross-para-burstiness` | Cross-paragraph rhythm | Sentence-length variance across paragraphs |

--- a/detector/CATEGORIES.md
+++ b/detector/CATEGORIES.md
@@ -11,6 +11,12 @@ skill has more `###` sections than that — the gap is **not** missing coverage,
 it's rules that are judgment calls a regex can't make. The three groups below
 account for every entry on both sides.
 
+Three counts coexist on purpose and should not be forced to match: the README's
+**42 patterns** are the human-facing prose catalog, the engine's **43 `type`s**
+split the vocabulary tiers and add stylometric signals, and SKILL.md's ~50
+`###` sections include meta-rules with no detectable form. The
+`categories.test.js` check enforces only the engine ↔ this-file mapping.
+
 ## A. Direct mapping (skill rule → detector `type`)
 
 | Detector `type` | Label | SKILL.md section |

--- a/detector/README.md
+++ b/detector/README.md
@@ -1,0 +1,55 @@
+# Detector engine
+
+`patterns.js` is the executable expression of this skill's pattern rules — a
+zero-dependency, build-step-free detection engine that scores text for
+AI-writing tells. It runs identically in Node (`>=18`) and in the browser.
+
+The skill's `SKILL.md` is the human-readable catalog of rules; this engine is
+the deterministic, testable implementation of the regex-detectable subset, plus
+stylometric and AI-tool-fingerprint detectors that don't make sense as prose.
+See [`CATEGORIES.md`](./CATEGORIES.md) for the rule ↔ category mapping that keeps
+the two in sync.
+
+## Run it
+
+```bash
+npm test          # runs detector/patterns.test.js (no deps to install)
+# or directly:
+node detector/patterns.test.js
+```
+
+```js
+const AIDetector = require("./detector/patterns.js");
+const result = AIDetector.analyzeText("Your text here…");
+console.log(result.score, result.label, result.issues.length);
+```
+
+In the browser, load `patterns.js` as a plain script — it self-registers as a
+global `AIDetector` (the `module.exports` block is guarded and only runs under
+CommonJS).
+
+## `analyzeText(text, options?)` → result
+
+| Field | Type | Meaning |
+|---|---|---|
+| `score` | `0–100` | 0 = clean, 100 = heavy AI |
+| `label` | string | `Minimal` / `Some` / `Strong` / `Heavy` (or `Empty` / `Too short` / `Text too long`) |
+| `issues[]` | `{type, text, severity, …}` | one entry per detected pattern; `type` keys map to [`CATEGORIES.md`](./CATEGORIES.md) |
+| `stats` | object | `wordCount`, per-tier counts, `contextMode`, `denseAIVocab`, normalization flags, etc. |
+| `document_classification` | string | trinary `HUMAN_ONLY` / `MIXED` / `AI_ONLY` (shape mirrors GPTZero for swap-in) |
+| `class_probabilities` | `{human, mixed, ai}` | sums to exactly 1.0 |
+| `confidence_category` | `low` / `medium` / `high` | |
+| `highlight_sentence_for_ai` | region[] | sentence spans with byte offsets + per-region score, for UI highlighting |
+
+`options.contextMode` accepts `general` (default) or `technical`; technical mode
+suppresses flags that are legitimate in code-adjacent prose (e.g. Title Case
+headers). Invalid modes fall back to `general` and set `stats.contextModeFallback`.
+
+## Design notes
+
+- **FN-biased.** False positives damage trust more than false negatives, so
+  `MIXED` is wide and `AI_ONLY` requires multiple corroborating signals.
+- **Scoring is non-linear.** Repeated hits of the same phrase are deduplicated;
+  category weights live in the `ISSUE_WEIGHTS` table.
+- **Length gates.** Under ~10 words → `Too short` (unscorable); over 10k words →
+  `Text too long`.

--- a/detector/categories.test.js
+++ b/detector/categories.test.js
@@ -31,12 +31,9 @@ function test(name, fn) {
 const typeKeys = Object.keys(AIDetector.TYPE_LABELS);
 const md = fs.readFileSync(path.join(__dirname, 'CATEGORIES.md'), 'utf8');
 
-// All backtick tokens anywhere in the doc, e.g. `tier1`.
-const mentioned = new Set();
-for (const m of md.matchAll(/`([a-z0-9][a-z0-9-]*)`/g)) mentioned.add(m[1]);
-
 // Type tokens claimed in the first column of any table row, excluding the
-// literal header token `type` and markdown separators.
+// literal header token `type` and markdown separators. A stray mention in
+// prose doesn't count — a type has to land in an actual mapping-table row.
 const tableTypes = new Set();
 for (const line of md.split('\n')) {
   if (!line.startsWith('|')) continue;
@@ -50,12 +47,12 @@ for (const line of md.split('\n')) {
 console.log('CATEGORIES.md anti-drift contract');
 console.log(`  (${typeKeys.length} detector types, ${tableTypes.size} documented in tables)`);
 
-test('every detector type is documented in CATEGORIES.md', () => {
-  const missing = typeKeys.filter((k) => !mentioned.has(k));
+test('every detector type is documented in a CATEGORIES.md table', () => {
+  const missing = typeKeys.filter((k) => !tableTypes.has(k));
   assert.deepEqual(
     missing,
     [],
-    `detector types missing from CATEGORIES.md: ${missing.join(', ')}`
+    `detector types missing from CATEGORIES.md tables: ${missing.join(', ')}`
   );
 });
 

--- a/detector/categories.test.js
+++ b/detector/categories.test.js
@@ -1,0 +1,76 @@
+/**
+ * Avoid AI Writing — CATEGORIES.md anti-drift contract test
+ *
+ * CATEGORIES.md is the map between SKILL.md rules and detector `type`s. A map
+ * that nothing checks rots — so this test makes the contract executable:
+ *
+ *   - every detector `type` (TYPE_LABELS key) must be documented in CATEGORIES.md
+ *   - every detector `type` referenced in the CATEGORIES.md tables must be real
+ *
+ * Add a detector type without documenting it → this fails. Rename/remove a type
+ * and leave a stale row → this fails. Dependency-free; runs on node >= 18.
+ */
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const AIDetector = require('./patterns.js');
+
+let failed = 0;
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+  } catch (err) {
+    failed++;
+    console.error(`  ✗ ${name}`);
+    console.error(`    ${err.message}`);
+  }
+}
+
+const typeKeys = Object.keys(AIDetector.TYPE_LABELS);
+const md = fs.readFileSync(path.join(__dirname, 'CATEGORIES.md'), 'utf8');
+
+// All backtick tokens anywhere in the doc, e.g. `tier1`.
+const mentioned = new Set();
+for (const m of md.matchAll(/`([a-z0-9][a-z0-9-]*)`/g)) mentioned.add(m[1]);
+
+// Type tokens claimed in the first column of any table row, excluding the
+// literal header token `type` and markdown separators.
+const tableTypes = new Set();
+for (const line of md.split('\n')) {
+  if (!line.startsWith('|')) continue;
+  const firstCell = line.split('|')[1] || '';
+  if (/^[\s:-]+$/.test(firstCell)) continue; // separator row
+  for (const m of firstCell.matchAll(/`([a-z0-9][a-z0-9-]*)`/g)) {
+    if (m[1] !== 'type') tableTypes.add(m[1]);
+  }
+}
+
+console.log('CATEGORIES.md anti-drift contract');
+console.log(`  (${typeKeys.length} detector types, ${tableTypes.size} documented in tables)`);
+
+test('every detector type is documented in CATEGORIES.md', () => {
+  const missing = typeKeys.filter((k) => !mentioned.has(k));
+  assert.deepEqual(
+    missing,
+    [],
+    `detector types missing from CATEGORIES.md: ${missing.join(', ')}`
+  );
+});
+
+test('every type referenced in the tables is a real detector type', () => {
+  const keySet = new Set(typeKeys);
+  const stale = [...tableTypes].filter((t) => !keySet.has(t));
+  assert.deepEqual(
+    stale,
+    [],
+    `CATEGORIES.md references types that no longer exist: ${stale.join(', ')}`
+  );
+});
+
+if (failed > 0) {
+  console.error(`\n${failed} contract check(s) failed.`);
+  process.exit(1);
+}
+console.log('\nCATEGORIES.md contract holds.');

--- a/detector/patterns.js
+++ b/detector/patterns.js
@@ -1,0 +1,1623 @@
+/**
+ * Avoid AI Writing — detection engine (canonical source of truth)
+ * Implements 43-category pattern detection. This repo's SKILL.md (v3.4.0)
+ * catalogs the human-editable pattern rules; this engine is the executable
+ * expression of the regex-detectable subset and extends it with stylometric and
+ * AI-tool-fingerprint detectors that don't make sense as skill prose
+ * (cross-paragraph burstiness, smart-punct signatures, function-word
+ * trigram entropy, low type-token ratio, AI-tool URL parameters,
+ * chatbot citation markup leaks, unfilled placeholders).
+ *
+ * Scoring model:
+ *   Each category has a weight in the ISSUE_WEIGHTS table. Detection runs
+ *   produce raw (possibly duplicate) issues which are then deduplicated by
+ *   (type, text) pair. rawScore is the sum of category weights across the
+ *   deduped list — so the number reflects the same distinct signals the
+ *   user sees in the issue list.
+ *
+ *   Weights are deliberately non-flat across severity tags. Cutoff
+ *   disclaimers (10) and chatbot artifacts (8) weigh more than vague
+ *   attributions (5), even though all three are tagged `critical`, because
+ *   the skill treats them as stronger or weaker AI-origin signals.
+ *
+ *   rawScore is then normalized to 0-100 via `log2(wordCount/50)` so longer
+ *   texts don't accumulate unboundedly on the same density of patterns.
+ */
+
+const AIDetector = (() => {
+  // ═══ Tier 1 pre-pass: normalize bypass tricks ══════════════════════
+  //
+  // Humanizer tools and prompt-injection bypass techniques insert
+  // invisible / lookalike chars to defeat exact-string detectors. Strip
+  // them BEFORE pattern matching so "delve" with a Cyrillic 'е' still
+  // hits the Tier 1 list. Unicode ranges sourced from
+  // It-s-AI/llm-detection/detection/attacks/.
+  //
+  // Tracks what was stripped so the trinary classifier can use
+  // "normalization triggered" as a corroborating AI signal — humans don't
+  // paste ZWSPs into their own writing.
+  const CYRILLIC_LOOKALIKES = {
+    'а': 'a', 'е': 'e', 'о': 'o', 'р': 'p', 'с': 'c', 'х': 'x',
+    'у': 'y', 'к': 'k', 'м': 'm', 'н': 'h', 'в': 'b', 'т': 't',
+    'А': 'A', 'Е': 'E', 'О': 'O', 'Р': 'P', 'С': 'C', 'Х': 'X',
+    'У': 'Y', 'К': 'K', 'М': 'M', 'Н': 'H', 'В': 'B', 'Т': 'T',
+  };
+  const GREEK_LOOKALIKES = { 'ο': 'o', 'Ο': 'O', 'α': 'a', 'Α': 'A', 'ρ': 'p', 'Ρ': 'P' };
+
+  function normalizeText(text) {
+    const flags = { zeroWidth: 0, homoglyph: 0, roleplay: 0 };
+    let out = text;
+
+    // 1. Strip zero-width chars (ZWSP U+200B, ZWNJ U+200C, ZWJ U+200D,
+    //    BOM U+FEFF, word joiner U+2060).
+    out = out.replace(/[​-‍﻿⁠]/g, () => { flags.zeroWidth++; return ''; });
+
+    // 2. Swap Cyrillic / Greek Latin-lookalike chars back to Latin so
+    //    pattern matching catches obfuscated tokens.
+    out = out.replace(/[Ѐ-ӿͰ-Ͽ]/g, (m) => {
+      const swap = CYRILLIC_LOOKALIKES[m] ?? GREEK_LOOKALIKES[m];
+      if (swap) { flags.homoglyph++; return swap; }
+      return m;
+    });
+
+    // 3. Strip *roleplay-action* markers — paired *...* containing an
+    //    action verb (nods, sighs, laughs, smiles, etc.) anchored to
+    //    the start of the inner phrase. This is the actual chat-model
+    //    artifact shape. Markdown `**bold**` is rejected by the
+    //    lookbehind/lookahead; legitimate multi-word `*italic*` is
+    //    preserved because the verb whitelist is narrow.
+    const ROLEPLAY_VERBS = /^(?:nods|sighs|laughs|smiles|frowns|shrugs|grins|winks|chuckles|gasps|pauses|thinks|wonders|whispers|shouts|gestures|raises|leans|turns|looks|glances|smirks|blinks|nodding|sighing|laughing|smiling|thinking|gesturing)\b/i;
+    out = out.replace(/(?<!\*)\*([^*\n]{1,80}?)\*(?!\*)/gu, (m, inner) => {
+      if (ROLEPLAY_VERBS.test(inner)) { flags.roleplay++; return ''; }
+      return m;
+    });
+
+    return { text: out, flags };
+  }
+
+  // ─── Tier 1: Always flag ───────────────────────────────────────────
+  const TIER1 = {
+    'delve': 'explore, dig into, look at',
+    'tapestry': 'describe the actual complexity',
+    'paradigm': 'model, approach, framework',
+    'embark': 'start, begin',
+    'beacon': 'rewrite entirely',
+    'robust': 'strong, reliable, solid',
+    'comprehensive': 'thorough, complete, full',
+    'cutting-edge': 'latest, newest, advanced',
+    'pivotal': 'important, key, critical',
+    'underscores': 'highlights, shows',
+    'meticulous': 'careful, detailed, precise',
+    'meticulously': 'carefully, precisely',
+    'seamless': 'smooth, easy, without friction',
+    'seamlessly': 'smoothly, easily',
+    'game-changer': 'describe what changed',
+    'game-changing': 'describe what changed',
+    'utilize': 'use',
+    'nestled': 'is located, sits',
+    'vibrant': 'describe what makes it active',
+    'thriving': 'growing, active',
+    'showcasing': 'showing, demonstrating',
+    'bustling': 'busy, active',
+    'intricate': 'complex, detailed',
+    'intricacies': 'complexities, details',
+    'ever-evolving': 'changing, growing',
+    'enduring': 'lasting, long-running',
+    'daunting': 'hard, difficult',
+    'holistic': 'complete, full, whole',
+    'holistically': 'completely, fully',
+    'actionable': 'practical, useful, concrete',
+    'impactful': 'effective, significant',
+    'learnings': 'lessons, findings, takeaways',
+    'synergy': 'describe the combined effect',
+    'synergies': 'describe the combined effect',
+    'interplay': 'relationship, connection',
+    'commence': 'start, begin',
+    'ascertain': 'find out, determine',
+    'endeavor': 'effort, attempt, try',
+    'symphony': 'describe the coordination',
+    'embrace': 'adopt, accept, use',
+  };
+
+  // Multi-word tier 1 phrases
+  const TIER1_PHRASES = [
+    { pattern: /\bdelve\s+into\b/gi, replace: 'explore, dig into' },
+    { pattern: /\blandscape\b/gi, replace: 'field, space, industry', filter: true },
+    { pattern: /\brealm\b/gi, replace: 'area, field, domain' },
+    { pattern: /\btestament\s+to\b/gi, replace: 'shows, proves' },
+    { pattern: /\bleverage\b/gi, replace: 'use' },
+    { pattern: /\bwatershed\s+moment\b/gi, replace: 'turning point, shift' },
+    { pattern: /\bmarking\s+a\s+pivotal\s+moment\b/gi, replace: 'state what happened' },
+    { pattern: /\bthe\s+future\s+looks\s+bright\b/gi, replace: 'cut or say something specific' },
+    { pattern: /\bonly\s+time\s+will\s+tell\b/gi, replace: 'cut or say something specific' },
+    { pattern: /\bdespite\s+challenges[^.]*continues?\s+to\s+thrive\b/gi, replace: 'name the challenge and response' },
+    { pattern: /\bdeep\s+dive\b/gi, replace: 'look at, examine' },
+    { pattern: /\bdive\s+into\b/gi, replace: 'look at, examine' },
+    { pattern: /\bunpack(?:ing)?\b/gi, replace: 'explain, break down' },
+    { pattern: /\bcomplexities\b/gi, replace: 'name the actual problems' },
+    { pattern: /\bthought\s+leader(?:ship)?\b/gi, replace: 'expert, authority' },
+    { pattern: /\bbest\s+practices\b/gi, replace: 'what works, proven methods' },
+    { pattern: /\bat\s+its\s+core\b/gi, replace: 'cut, just state it' },
+    { pattern: /\bin\s+order\s+to\b/gi, replace: 'to' },
+    { pattern: /\bdue\s+to\s+the\s+fact\s+that\b/gi, replace: 'because' },
+    { pattern: /\bserves\s+as\b/gi, replace: 'is' },
+    { pattern: /\bfeatures\b/gi, replace: 'has, includes', filter: true },
+    { pattern: /\bboasts\b/gi, replace: 'has' },
+  ];
+
+  // ─── Tier 2: Flag in clusters (2+ per paragraph) ──────────────────
+  const TIER2 = {
+    'harness': 'use, take advantage of',
+    'navigate': 'work through, handle',
+    'navigating': 'working through, handling',
+    'foster': 'encourage, support, build',
+    'elevate': 'improve, raise, strengthen',
+    'unleash': 'release, enable, unlock',
+    'streamline': 'simplify, speed up',
+    'empower': 'enable, let, allow',
+    'bolster': 'support, strengthen',
+    'spearhead': 'lead, drive, run',
+    'resonate': 'connect with, appeal to',
+    'resonates': 'connects with, appeals to',
+    'revolutionize': 'change, transform',
+    'facilitate': 'enable, help, allow',
+    'facilitates': 'enables, helps, allows',
+    'underpin': 'support, form the basis of',
+    'nuanced': 'specific, subtle, detailed',
+    'crucial': 'important, key, necessary',
+    'multifaceted': 'describe the actual facets',
+    'ecosystem': 'system, community, network',
+    'myriad': 'many, numerous',
+    'plethora': 'many, a lot of',
+    'encompass': 'include, cover, span',
+    'catalyze': 'start, trigger, accelerate',
+    'reimagine': 'rethink, redesign, rebuild',
+    'galvanize': 'motivate, rally, push',
+    'augment': 'add to, expand, supplement',
+    'cultivate': 'build, develop, grow',
+    'illuminate': 'clarify, explain, show',
+    'elucidate': 'explain, clarify',
+    'juxtapose': 'compare, contrast',
+    'transformative': 'describe what changed',
+    'transformation': 'describe what changed',
+    'cornerstone': 'foundation, basis, key part',
+    'paramount': 'most important, top priority',
+    'poised': 'ready, set, about to',
+    'burgeoning': 'growing, emerging',
+    'nascent': 'new, early-stage',
+    'quintessential': 'typical, classic, defining',
+    'overarching': 'main, central, broad',
+    'underpinning': 'basis, foundation',
+    'underpinnings': 'basis, foundations',
+    'paradigm-shifting': 'describe what shifted',
+  };
+
+  // ─── Tier 3: Flag by density ───────────────────────────────────────
+  const TIER3 = [
+    'significant', 'significantly', 'innovative', 'innovation',
+    'effective', 'effectively', 'dynamic', 'dynamics',
+    'scalable', 'scalability', 'compelling', 'unprecedented',
+    'exceptional', 'exceptionally', 'remarkable', 'remarkably',
+    'sophisticated', 'instrumental',
+    'world-class', 'state-of-the-art', 'best-in-class',
+  ];
+
+  // Multi-word Tier 3 phrases. Density-gated like single Tier 3 words because
+  // these legitimately show up in human crypto/web3/dev writing. Threshold is
+  // intentionally lower than single-word Tier 3 (≥2 occurrences of the same
+  // phrase) — repeating the same multi-word boilerplate is a stronger AI tell
+  // than re-using "significant."
+  const TIER3_PHRASES = [
+    /\bemerging\s+(?:sector|space|category|industry)\b/gi,
+    /\bthe\s+integration\s+of\b/gi,
+    /\bthe\s+intersection\s+of\b/gi,
+    /\bcommunity-?driven\b/gi,
+    /\blong-?term\s+sustainability\b/gi,
+    /\buser\s+engagement\b/gi,
+    /\bdecentralized\s+compute\b/gi,
+    /\b(?:sustainable\s+)?reward\s+emissions?\b/gi,
+    /\btokenized\s+incentive\s+structures?\b/gi,
+    /\bdesigned\s+for\s+long-?term\b/gi,
+  ];
+
+  // O(1) lookup from any token form (hyphenated or dashless) to its canonical
+  // Tier 3 word. Counting originally did nested-loop word matching which was
+  // O(tokens × TIER3) — slow on long pastes.
+  const TIER3_LOOKUP = new Map();
+  for (const word of TIER3) {
+    TIER3_LOOKUP.set(word, word);
+    const dashless = word.replace(/-/g, '');
+    if (dashless !== word) TIER3_LOOKUP.set(dashless, word);
+  }
+
+  // Per-category score weights. Applied to distinct (deduplicated) issues so
+  // the score reflects the same signals the user sees in the issue list.
+  // Non-uniform on purpose: critical rules like cutoff disclaimers (×10) and
+  // chatbot artifacts (×8) weigh more than vague attributions (×5), even
+  // though all three are tagged `critical`.
+  const ISSUE_WEIGHTS = {
+    tier1: 5,
+    tier2: 3,
+    tier3: 2,
+    transition: 2,
+    chatbot: 8,
+    sycophantic: 8,
+    filler: 2,
+    'generic-conclusion': 3,
+    'lets-construction': 2,
+    'reasoning-artifact': 6,
+    'acknowledgment-loop': 3,
+    'significance-inflation': 4,
+    'vague-attribution': 5,
+    'hollow-intensifier': 2,
+    'emotional-flatline': 2,
+    'novelty-inflation': 3,
+    'cutoff-disclaimer': 10,
+    'template-phrase': 3,
+    'false-concession': 2,
+    'rhetorical-question': 2,
+    'confidence-calibration': 2,
+    'em-dash': 4,
+    uniformity: 5,
+    formatting: 3,
+    'tier3-phrase': 3,
+    // Structural / cluster signals are deliberately weighted high. Unlike
+    // single-vocabulary hits they're near-dispositive on social-length
+    // posts (a 15-hashtag block, a 6-item bullet-NP list, three distinct
+    // crypto-shill phrases stacked) and would otherwise be suppressed by
+    // the log2(words/50) length divisor on short pastes.
+    'tier3-phrase-cluster': 12,
+    'hashtag-stuff': 12,
+    'bullet-np-list': 10,
+    'hedge-stack': 6,
+    'future-narrative': 12,
+    'real-actual-inflation': 5,
+    'formulaic-opener': 8,
+    'title-case-header': 4,
+    'parenthetical-hedge': 3,
+    'smart-punct-signature': 6,
+    'punct-distribution': 6,
+    'fnword-trigram-entropy': 5,
+    'cross-para-burstiness': 5,
+    'normalization-flag': 9,
+    // Vocabulary-diversity signal (type-token ratio). Weighted modestly
+    // because the threshold (>=200 tokens AND TTR<0.4) is conservative;
+    // it stacks with structural signals to push borderline scores up.
+    'low-ttr': 3,
+    // AI-tool fingerprints. Weighted higher than statistical patterns
+    // because each is a near-definitive single-hit signal — the AI tool
+    // literally left its mark in the text. citation-markup ranks highest
+    // (smoking gun: the literal internal markup of ChatGPT/Grok/etc.),
+    // UTM tracking second (auto-appended by the tool to URLs it writes),
+    // placeholders third (strong but humans use bracketed slots in
+    // templates legitimately and forget them — still a publishing bug
+    // but slightly less definitive AI evidence).
+    'ai-placeholder': 10,
+    'ai-citation-markup': 15,
+    'ai-utm-source': 12,
+  };
+
+  // ─── Transition phrases ────────────────────────────────────────────
+  const TRANSITIONS = [
+    /\bmoreover\b/gi,
+    /\bfurthermore\b/gi,
+    /\badditionally\b/gi,
+    /\bin\s+today'?s\b/gi,
+    /\bin\s+an\s+era\s+where\b/gi,
+    /\bit'?s\s+worth\s+noting\s+that\b/gi,
+    /\bnotably\b/gi,
+    /\bin\s+conclusion\b/gi,
+    /\bin\s+summary\b/gi,
+    /\bto\s+summarize\b/gi,
+    /\bwhen\s+it\s+comes\s+to\b/gi,
+    /\bat\s+the\s+end\s+of\s+the\s+day\b/gi,
+    /\bthat\s+(?:being\s+)?said\b/gi,
+  ];
+
+  // ─── Chatbot artifacts ─────────────────────────────────────────────
+  const CHATBOT_ARTIFACTS = [
+    /\bi\s+hope\s+this\s+helps\b/gi,
+    /\bcertainly!\b/gi,
+    /\babsolutely!\b/gi,
+    /\bgreat\s+question!\b/gi,
+    /\bexcellent\s+point!\b/gi,
+    /\bfeel\s+free\s+to\s+reach\s+out\b/gi,
+    /\blet\s+me\s+know\s+if\s+you\s+need\s+anything\b/gi,
+    /\bin\s+this\s+article,?\s+we\s+will\s+explore\b/gi,
+    /\blet'?s\s+dive\s+in!?\b/gi,
+  ];
+
+  // ─── Sycophantic tone ──────────────────────────────────────────────
+  const SYCOPHANTIC = [
+    /\byou'?re\s+absolutely\s+right\b/gi,
+    /\bthat'?s\s+a\s+really\s+insightful\b/gi,
+    /\bthat'?s\s+a\s+great\s+question\b/gi,
+    /\bexcellent\s+question\b/gi,
+  ];
+
+  // ─── Filler phrases ────────────────────────────────────────────────
+  const FILLERS = [
+    /\bit\s+is\s+important\s+to\s+note\s+that\b/gi,
+    /\bin\s+terms\s+of\b/gi,
+    /\bthe\s+reality\s+is\s+that\b/gi,
+    /\bit'?s\s+important\s+to\s+note\s+that\b/gi,
+  ];
+
+  // ─── Generic conclusions ───────────────────────────────────────────
+  const GENERIC_CONCLUSIONS = [
+    /\bthe\s+future\s+looks\s+bright\b/gi,
+    /\bonly\s+time\s+will\s+tell\b/gi,
+    /\bone\s+thing\s+is\s+certain\b/gi,
+    /\bas\s+we\s+move\s+forward\b/gi,
+  ];
+
+  // ─── "Let's" constructions ─────────────────────────────────────────
+  const LETS_PATTERNS = [
+    /\blet'?s\s+explore\b/gi,
+    /\blet'?s\s+take\s+a\s+look\b/gi,
+    /\blet'?s\s+break\s+this\s+down\b/gi,
+    /\blet'?s\s+examine\b/gi,
+    /\blet'?s\s+(?:consider|discuss|delve|unpack|walk\s+through)\b/gi,
+  ];
+
+  // ─── Reasoning chain artifacts ─────────────────────────────────────
+  const REASONING_ARTIFACTS = [
+    /\blet\s+me\s+think\s+step\s+by\s+step\b/gi,
+    /\bbreaking\s+this\s+down\b/gi,
+    /\bto\s+approach\s+this\s+systematically\b/gi,
+    /\bhere'?s\s+my\s+thought\s+process\b/gi,
+    /\bfirst,?\s+let'?s\s+consider\b/gi,
+    /\bworking\s+through\s+this\s+logically\b/gi,
+  ];
+
+  // ─── Acknowledgment loops ──────────────────────────────────────────
+  const ACKNOWLEDGMENT_LOOPS = [
+    /\byou'?re\s+asking\s+about\b/gi,
+    /\bthe\s+question\s+of\s+whether\b/gi,
+    /\bto\s+answer\s+your\s+question\b/gi,
+  ];
+
+  // ─── Significance inflation ────────────────────────────────────────
+  const SIGNIFICANCE_INFLATION = [
+    /\bmarking\s+a\s+(?:pivotal|significant|important)\s+moment\b/gi,
+    /\ba\s+watershed\s+moment\s+for\b/gi,
+    /\bin\s+the\s+evolution\s+of\b/gi,
+    /\ba\s+(?:pivotal|defining)\s+moment\s+in\b/gi,
+  ];
+
+  // ─── Vague attributions ────────────────────────────────────────────
+  const VAGUE_ATTRIBUTIONS = [
+    /\bexperts\s+(?:believe|say|suggest|agree)\b/gi,
+    /\bstudies\s+(?:show|suggest|indicate)\b/gi,
+    /\bresearch\s+(?:shows|suggests|indicates)\b/gi,
+    /\bindustry\s+leaders\s+(?:agree|believe|say)\b/gi,
+  ];
+
+  // ─── Hollow intensifiers ──────────────────────────────────────────
+  const HOLLOW_INTENSIFIERS = [
+    /\bgenuine(?:ly)?\b/gi,
+    /\btruly\b/gi,
+    /\bquite\s+frankly\b/gi,
+    /\bto\s+be\s+honest\b/gi,
+    /\blet'?s\s+be\s+clear\b/gi,
+  ];
+
+  // ─── Emotional flatline ────────────────────────────────────────────
+  // The "interesting (part|thing|aspect|piece)" family is matched in two
+  // shapes: (1) "the most interesting X" inline (the canonical AI list
+  // intro), and (2) bare "Interesting X:" used as a section-header opener,
+  // which is the section-break variant that slipped past v3.3.x.
+  const EMOTIONAL_FLATLINE = [
+    /\bwhat\s+surprised\s+me\s+most\b/gi,
+    /\bi\s+was\s+fascinated\s+to\b/gi,
+    /\bwhat\s+struck\s+me\s+was\b/gi,
+    /\bi\s+was\s+excited\s+to\s+learn\b/gi,
+    /\bthe\s+most\s+interesting\s+(?:part|thing|aspect|piece)\b/gi,
+    // Multiline flag (/m) so `^` matches at every line start, including
+    // position 0 of a pasted text that has no leading newline. The earlier
+    // `(?:^|\n)` form silently missed bare openers at the very start of
+    // input — caught by silent-failure audit 2026-05-16.
+    /^\s*interesting\s+(?:part|thing|aspect|piece)(?:\s+of\s+(?:the\s+)?\w+)?\s*:/gim,
+  ];
+
+  // ─── Novelty inflation ─────────────────────────────────────────────
+  const NOVELTY_INFLATION = [
+    /\bthe\s+failure\s+mode\s+nobody'?s?\s+naming\b/gi,
+    /\ba\s+problem\s+nobody\s+talks\s+about\b/gi,
+    /\bthe\s+insight\s+everyone'?s?\s+missing\b/gi,
+    /\bwhat\s+nobody\s+tells\s+you\b/gi,
+  ];
+
+  // ─── Cutoff disclaimers ────────────────────────────────────────────
+  // Includes the canonical LLM self-identification phrases — these are
+  // near-dispositive on their own (real humans don't write "as an AI
+  // language model" in first person). Patterns cover the major model
+  // families' default disclaimer language.
+  const CUTOFF_DISCLAIMERS = [
+    /\bas\s+of\s+my\s+last\s+update\b/gi,
+    /\bas\s+of\s+my\s+(?:knowledge\s+)?(?:cut-?off|last\s+training)\b/gi,
+    /\bi\s+don'?t\s+have\s+access\s+to\s+real-?time\s+(?:data|information)\b/gi,
+    /\bbased\s+on\s+available\s+information\b/gi,
+    /\bas\s+an?\s+(?:ai|artificial\s+intelligence|large\s+language|ai\s+language)\s+(?:language\s+)?model\b/gi,
+    /\bi\s+(?:am|'m)\s+an?\s+(?:ai|artificial\s+intelligence|large\s+language)\s+(?:assistant|model)?\b/gi,
+    /\bi\s+cannot\s+(?:provide|give|offer)\s+(?:legal|medical|financial|professional)\s+advice\b/gi,
+    /\bmy\s+training\s+data\s+(?:only\s+)?(?:goes\s+up\s+to|extends\s+to|ends\s+(?:in|at))\b/gi,
+  ];
+
+  // ─── AI-tool fingerprints ──────────────────────────────────────────
+  // Three near-definitive AI-origin signals adapted from
+  // Aboudjem/humanizer-skill P33-P35 (see docs/competitive/audits/
+  // 2026-05-17-aboudjem-humanizer-skill.md). Unlike the statistical
+  // patterns above, single hit on any of these is strong evidence —
+  // the AI tool literally left its fingerprint in the text.
+
+  // Unfilled slot-fill placeholders. Catches the canonical "[Your Name]"
+  // family plus dated stubs and HTML/MD comments with placeholder verbs.
+  const AI_PLACEHOLDERS = [
+    // Directive stubs ("[Your Name]", "[INSERT SOURCE URL]",
+    // "[Describe the specific section]") — verb-led, the user was
+    // told to fill in.
+    /\[(?:Your|Insert|Add|Enter|Describe|Specify|Choose|Pick)[^\]\n]{1,80}\]/gi,
+    // Noun-only template variables common in AI-generated email or
+    // letter boilerplate. Match the bare noun OR noun + qualifier.
+    // Conservative list: only nouns that almost never appear as
+    // bracketed real content (citation refs, code identifiers, etc.
+    // are excluded because they typically contain dots, slashes,
+    // hyphens, or version numbers).
+    /\[(?:Recipient|Sender|Topic|Subject|Salutation|Closing|Position|Department|Project Name|Company Name|Date)(?:\s+[^\]\n]{0,60})?\]/gi,
+    // All-caps directive forms ("[INSERT X]", "[FILL IN]") — the
+    // uppercase tells you it's a slot, not real content.
+    /\[(?:INSERT|FILL\s+IN|ADD|TODO|TBD|PLACEHOLDER)[^\]\n]{0,80}\]/g,
+    // Date stubs.
+    /\b(?:19|20)\d{2}-XX-XX\b/g,
+    /\bXX\/XX\/(?:19|20)\d{2}\b/g,
+    // HTML/Markdown comment placeholders with placeholder verbs.
+    /<!--\s*(?:add|fill\s+in|insert|todo|placeholder)[^>]{0,120}-->/gi,
+  ];
+
+  // Chatbot citation/markup tokens that leak through copy-paste.
+  // `citeturn0search0` / `citeturn0news5` from ChatGPT, contentReference
+  // tokens, oai_citation, attached_file references, grok_card markers.
+  // Each is a near-definitive signature of a specific tool.
+  const AI_CITATION_MARKUP = [
+    /\bcite(?:turn|news|search|navigation)\d+(?:search|turn|news|navigation)\d+/gi,
+    /contentReference\s*\[oaicite:[^\]]+\]\s*\{[^}]*\}/gi,
+    /\boai_citation\b/gi,
+    /\[attached_file:\d+\]/gi,
+    /\bgrok_card\b/gi,
+  ];
+
+  // UTM/tracking parameters auto-appended by AI tools to URLs they
+  // generate. Survives copy-paste even when nothing else does.
+  const AI_UTM_SOURCE = [
+    /[?&]utm_source=(?:chatgpt|openai|copilot|claude|grok|gemini|perplexity)(?:\.com|\.ai)?\b/gi,
+    /[?&]referrer=(?:chatgpt|copilot|grok|claude|gemini|perplexity)\.(?:com|ai)\b/gi,
+  ];
+
+  // ─── Template phrases ──────────────────────────────────────────────
+  const TEMPLATE_PHRASES = [
+    /\ba\s+\w+\s+step\s+(?:towards?|forward\s+for)\b/gi,
+    /\bwhether\s+you'?re\s+\w+\s+or\s+\w+/gi,
+    /\bi\s+recently\s+had\s+the\s+pleasure\s+of\b/gi,
+  ];
+
+  // ─── False concession ──────────────────────────────────────────────
+  const FALSE_CONCESSION = [
+    /\bwhile\s+\w+\s+is\s+impressive\b/gi,
+    /\balthough\s+\w+\s+has\s+made\s+strides\b/gi,
+    /\bdespite\s+\w+\s+challenges?\b/gi,
+  ];
+
+  // ─── Rhetorical question openers ───────────────────────────────────
+  const RHETORICAL_QUESTIONS = [
+    /\bbut\s+what\s+does\s+this\s+mean\s+for\b/gi,
+    /\bso\s+why\s+should\s+you\s+care\b/gi,
+    /\bwhat'?s\s+next\?\s*/gi,
+  ];
+
+  // ─── Hedge-stacked predictions ─────────────────────────────────────
+  // Stacks a modal with a hedge adverb: "could potentially create new
+  // opportunities", "may eventually unlock value." Either word alone is
+  // fine; the stack is the tell.
+  const HEDGE_STACK = [
+    /\b(?:could|may|might)\s+(?:\w+\s+){0,2}(?:potentially|eventually|ultimately|possibly|conceivably)\b/gi,
+    /\b(?:potentially|eventually|ultimately)\s+(?:could|may|might)\b/gi,
+  ];
+
+  // ─── Generic future-narrative closers ──────────────────────────────
+  // The "may become one of the most important narratives" template — vague
+  // future significance with no falsifiable claim. Covers narratives /
+  // stories / trends / themes / chapters / movements.
+  const FUTURE_NARRATIVE = [
+    /\b(?:may|could|will|is\s+(?:poised|set)\s+to)\s+become\s+(?:one\s+of\s+)?(?:the\s+)?(?:most\s+)?\w+\s+(?:narratives?|stories|developments?|trends?|movements?|chapters?|themes?|forces?)\b/gi,
+    /\bone\s+of\s+the\s+most\s+important\s+(?:narratives?|stories|trends?|themes?)\s+of\s+the\s+(?:next|coming)\s+\w+\b/gi,
+  ];
+
+  // ─── "Real/actual" adjective inflation ─────────────────────────────
+  // "Real on-chain tokenomics", "actual reward sustainability" — using
+  // real/actual/genuine/true as an empty intensifier on an abstract noun
+  // to imply the rest of the field is fake/superficial.
+  const REAL_ACTUAL_INFLATION = [
+    /\b(?:real|actual|genuine|true)\s+(?:on-?chain\s+)?(?:tokenomics|economics|utility|adoption|sustainability|impact|revenue|fundamentals|demand|value|innovation|traction)\b/gi,
+  ];
+
+  // ─── Formulaic openers ─────────────────────────────────────────────
+  // The "In the rapidly evolving world of X, Y has emerged as..." family
+  // — LLM-default essay openers.
+  const FORMULAIC_OPENERS = [
+    /\bin\s+the\s+(?:rapidly\s+|ever-?\s*)?(?:evolving|changing|expanding|growing|shifting)\s+(?:world|landscape|realm|space|field|domain|era)\s+of\b/gi,
+    /\bin\s+(?:an?|the)\s+(?:digital\s+)?age\s+(?:where|of)\b/gi,
+    /\bas\s+(?:we|the\s+world|society|industries?)\s+(?:continue|move|navigate|enter)\s+(?:to\s+)?(?:evolve|forward|into|through)\b/gi,
+    // "has emerged as a leader/force/category" — gated to the inflated
+    // nouns that signal pseudo-significance, since bare "has emerged as
+    // a" matches normal English ("Rust has emerged as a serious systems
+    // language"). Same gating for "has become increasingly".
+    /\bhas\s+emerged\s+as\s+(?:a|the|one\s+of)\s+(?:leading|key|major|critical|essential|fundamental|pivotal|prominent|dominant|important)\s+\w+/gi,
+    /\bhas\s+become\s+increasingly\s+(?:important|critical|popular|relevant|prominent|essential)\b/gi,
+  ];
+
+  // ─── Title Case Section Headers in non-technical prose ─────────────
+  // "Strategic Negotiations And Key Partnerships" — every content word
+  // capitalized. Acceptable in API docs, ML papers, news headlines. Tell
+  // in marketing/personal/blog prose. Gated to "personal" / "marketing"
+  // context modes (technical mode skips this check).
+  const TITLE_CASE_HEADER = /^([A-Z][a-z]+(?:\s+(?:[A-Z][a-z]+|and|or|of|the|in|for|to|a|an))+\s+[A-Z][a-z]+)\s*$/gm;
+
+  // ─── Parenthetical hedging asides ──────────────────────────────────
+  // "(and increasingly, X)", "(or more precisely, Y)", "(though to be
+  // fair, Z)" — pseudo-aside that adds no information but performs
+  // thoughtfulness. Different from genuine human parentheticals which
+  // tend to be tangents or clarifications, not hedges.
+  const PARENTHETICAL_HEDGE = [
+    /\(\s*(?:and\s+)?(?:increasingly|notably|importantly|crucially|interestingly|perhaps)[,]?\s+[^)]{3,60}\)/gi,
+    /\(\s*or\s+more\s+(?:precisely|accurately|specifically)[,]?\s+[^)]{3,60}\)/gi,
+    /\(\s*though\s+to\s+be\s+fair[,]?\s+[^)]{3,60}\)/gi,
+    /\(\s*at\s+least\s+(?:in\s+)?(?:theory|principle|part)[,]?\s+[^)]{0,60}\)/gi,
+  ];
+
+  // ─── Confidence calibration ────────────────────────────────────────
+  const CONFIDENCE_CALIBRATION = [
+    /\binterestingly\b/gi,
+    /\bsurprisingly\b/gi,
+    /\bimportantly\b/gi,
+    /\bsignificantly\b/gi,
+    /\bcertainly\b/gi,
+    /\bundoubtedly\b/gi,
+    /\bwithout\s+a\s+doubt\b/gi,
+  ];
+
+  // ═══ Helpers ═══════════════════════════════════════════════════════
+
+  function tokenize(text) {
+    return text.toLowerCase().match(/[\w'-]+/g) || [];
+  }
+
+  function countWords(text) {
+    return (text.match(/\S+/g) || []).length;
+  }
+
+  function getParagraphs(text) {
+    return text.split(/\n\s*\n/).filter(p => p.trim().length > 0);
+  }
+
+  function getSentences(text) {
+    return text.split(/[.!?]+/).filter(s => s.trim().length > 5);
+  }
+
+  function matchPatterns(text, patterns, category, severity) {
+    const issues = [];
+    for (const pat of patterns) {
+      const regex = new RegExp(pat.source, pat.flags);
+      let match;
+      while ((match = regex.exec(text)) !== null) {
+        issues.push({
+          type: category,
+          text: match[0],
+          index: match.index,
+          severity,
+          suggestion: null,
+        });
+      }
+    }
+    return issues;
+  }
+
+  // ═══ Main analysis ═════════════════════════════════════════════════
+
+  // Upper bound for one scan. Above this we bail rather than running all
+  // regex passes over a huge buffer — protects page perf on pasted novels.
+  const MAX_WORDS = 10000;
+
+  // V2 contract defaults so early-exit paths (Empty/tooShort/tooLong)
+  // still return the same field shape a v2 consumer expects. Without
+  // this, `result.document_classification === 'AI_ONLY'` is `undefined`
+  // on edge inputs and fails open.
+  // UNSCORED is returned on empty / too-short / too-long inputs where
+  // we declined to score. Distinct from HUMAN_ONLY (which is a positive
+  // classification) so a caller can't mistake a refused scan for a
+  // confident human verdict — a 50k-word LLM-generated document is
+  // not "human", it's just outside our scoring window.
+  function buildV2Defaults(classification, confidence) {
+    const probs = classification === 'HUMAN_ONLY'
+      ? { human: 1, mixed: 0, ai: 0 }
+      : classification === 'AI_ONLY'
+        ? { human: 0, mixed: 0, ai: 1 }
+        : { human: 0.333, mixed: 0.334, ai: 0.333 };
+    return {
+      document_classification: classification,
+      class_probabilities: probs,
+      confidence_category: confidence,
+      highlight_sentence_for_ai: [],
+    };
+  }
+
+  function analyzeText(text, options = {}) {
+    if (!text || text.trim().length === 0) {
+      return { ...buildV2Defaults('UNSCORED', 'low'), score: 0, label: 'Empty', issues: [], stats: {}, tooShort: true };
+    }
+
+    // Context mode gates rules that are noisy in technical writing. Modes:
+    //   'general' (default) — full ruleset
+    //   'technical' — skip title-case headers, formulaic openers gated to
+    //                 prose-only structures; lower em-dash + formatting weights
+    //   'marketing' — full ruleset + boost on formulaic-opener / future-narrative
+    //   'personal'  — full ruleset, normal weights
+    // Mode is purely a soft gate; nothing is silently suppressed without
+    // being reflected in stats.contextMode for transparency.
+    // Mode validation: an unknown string (e.g. typo "tecnical") would
+    // otherwise silently downgrade to general-mode behavior. Coerce to
+    // 'general' and surface the original value in stats for traceability.
+    const VALID_CONTEXT_MODES = new Set(['general', 'technical', 'marketing', 'personal']);
+    const requestedMode = options.contextMode || 'general';
+    const contextMode = VALID_CONTEXT_MODES.has(requestedMode) ? requestedMode : 'general';
+    const contextModeFallback = requestedMode !== contextMode ? requestedMode : null;
+
+    // Pre-pass: strip Markdown blockquotes before scoring. A human
+    // reacting to AI text by quoting it shouldn't have the quoted block
+    // counted against their own writing. Requires ≥2 consecutive `> `
+    // lines to count as a blockquote — single-line `> ls -la` shell
+    // prompts in technical docs stay in the text.
+    let quotedLines = 0;
+    const rawLines = text.split(/\r?\n/);
+    const isQuote = rawLines.map((l) => /^\s*>\s/.test(l));
+    const stripIdx = new Set();
+    for (let i = 0; i < rawLines.length; i++) {
+      if (isQuote[i] && ((isQuote[i - 1] && i > 0) || isQuote[i + 1])) {
+        stripIdx.add(i);
+        quotedLines++;
+      }
+    }
+    text = rawLines.filter((_, i) => !stripIdx.has(i)).join('\n');
+
+    // Pre-pass: strip bypass-trick chars before pattern matching so
+    // "delve" with a Cyrillic 'е' still hits Tier 1. Original text is
+    // preserved so reported `match.index` values remain visually accurate.
+    const norm = normalizeText(text);
+    text = norm.text;
+
+    const wordCount = countWords(text);
+    if (wordCount < 10) {
+      return { ...buildV2Defaults('UNSCORED', 'low'), score: 0, label: 'Too short', issues: [], stats: { wordCount, contextMode, contextModeFallback }, tooShort: true };
+    }
+    if (wordCount > MAX_WORDS) {
+      return {
+        ...buildV2Defaults('UNSCORED', 'low'),
+        score: 0,
+        label: 'Text too long',
+        issues: [],
+        stats: { wordCount, contextMode, contextModeFallback },
+        tooLong: true,
+      };
+    }
+
+    const tokens = tokenize(text);
+    const paragraphs = getParagraphs(text);
+    const sentences = getSentences(text);
+    const issues = [];
+    let rawScore = 0;
+
+    // ── 1. Tier 1 words ──────────────────────────────────────────
+    const tier1Found = new Set();
+    for (const token of tokens) {
+      if (TIER1[token] && !tier1Found.has(token)) {
+        tier1Found.add(token);
+        issues.push({
+          type: 'tier1',
+          text: token,
+          severity: 'high',
+          suggestion: TIER1[token],
+        });
+      }
+    }
+
+    // Tier 1 multi-word phrases. Adds each distinct phrase (lowercased) to
+    // `tier1Found` so the same phrase hit multiple times only produces one
+    // issue — matches the downstream dedup behavior.
+    for (const phrase of TIER1_PHRASES) {
+      const regex = new RegExp(phrase.pattern.source, phrase.pattern.flags);
+      let match;
+      while ((match = regex.exec(text)) !== null) {
+        const lower = match[0].toLowerCase();
+        if (tier1Found.has(lower)) continue;
+        tier1Found.add(lower);
+        issues.push({
+          type: 'tier1',
+          text: match[0],
+          severity: 'high',
+          suggestion: phrase.replace,
+        });
+      }
+    }
+
+    // ── 2. Tier 2 clusters ───────────────────────────────────────
+    let tier2Clusters = 0;
+    for (const para of paragraphs) {
+      const paraTokens = tokenize(para);
+      const found = [];
+      for (const token of paraTokens) {
+        if (TIER2[token] && !found.includes(token)) {
+          found.push(token);
+        }
+      }
+      if (found.length >= 2) {
+        tier2Clusters++;
+        for (const word of found) {
+          issues.push({
+            type: 'tier2',
+            text: word,
+            severity: 'medium',
+            suggestion: TIER2[word],
+          });
+        }
+      }
+    }
+
+    // ── 3. Tier 3 density ────────────────────────────────────────
+    const tier3Counts = {};
+    for (const token of tokens) {
+      const canonical = TIER3_LOOKUP.get(token);
+      if (canonical) tier3Counts[canonical] = (tier3Counts[canonical] || 0) + 1;
+    }
+    // Flag at 3% of word count, but never below 3 occurrences. Previous
+    // floor of 1 meant a 50-word text with one "significant" got flagged
+    // as Tier 3 overuse, which was noise.
+    const densityThreshold = Math.max(3, Math.floor(wordCount * 0.03));
+    let tier3Flags = 0;
+    for (const [word, count] of Object.entries(tier3Counts)) {
+      if (count >= densityThreshold) {
+        tier3Flags++;
+        issues.push({
+          type: 'tier3',
+          text: `"${word}" x${count}`,
+          severity: 'low',
+          suggestion: `Overused (${count} times in ${wordCount} words)`,
+        });
+      }
+    }
+
+    // ── 4–21. Pattern categories ─────────────────────────────────
+    issues.push(...matchPatterns(text, TRANSITIONS, 'transition', 'medium'));
+    issues.push(...matchPatterns(text, CHATBOT_ARTIFACTS, 'chatbot', 'critical'));
+    issues.push(...matchPatterns(text, SYCOPHANTIC, 'sycophantic', 'critical'));
+    issues.push(...matchPatterns(text, FILLERS, 'filler', 'medium'));
+    issues.push(...matchPatterns(text, GENERIC_CONCLUSIONS, 'generic-conclusion', 'medium'));
+    issues.push(...matchPatterns(text, LETS_PATTERNS, 'lets-construction', 'medium'));
+    issues.push(...matchPatterns(text, REASONING_ARTIFACTS, 'reasoning-artifact', 'critical'));
+    issues.push(...matchPatterns(text, ACKNOWLEDGMENT_LOOPS, 'acknowledgment-loop', 'medium'));
+    issues.push(...matchPatterns(text, SIGNIFICANCE_INFLATION, 'significance-inflation', 'high'));
+    issues.push(...matchPatterns(text, VAGUE_ATTRIBUTIONS, 'vague-attribution', 'critical'));
+    issues.push(...matchPatterns(text, HOLLOW_INTENSIFIERS, 'hollow-intensifier', 'medium'));
+    issues.push(...matchPatterns(text, EMOTIONAL_FLATLINE, 'emotional-flatline', 'low'));
+    issues.push(...matchPatterns(text, NOVELTY_INFLATION, 'novelty-inflation', 'medium'));
+    issues.push(...matchPatterns(text, CUTOFF_DISCLAIMERS, 'cutoff-disclaimer', 'critical'));
+    issues.push(...matchPatterns(text, AI_PLACEHOLDERS, 'ai-placeholder', 'critical'));
+    issues.push(...matchPatterns(text, AI_CITATION_MARKUP, 'ai-citation-markup', 'critical'));
+    issues.push(...matchPatterns(text, AI_UTM_SOURCE, 'ai-utm-source', 'critical'));
+    issues.push(...matchPatterns(text, TEMPLATE_PHRASES, 'template-phrase', 'high'));
+    issues.push(...matchPatterns(text, FALSE_CONCESSION, 'false-concession', 'medium'));
+    issues.push(...matchPatterns(text, RHETORICAL_QUESTIONS, 'rhetorical-question', 'medium'));
+    issues.push(...matchPatterns(text, HEDGE_STACK, 'hedge-stack', 'high'));
+    issues.push(...matchPatterns(text, FUTURE_NARRATIVE, 'future-narrative', 'high'));
+    issues.push(...matchPatterns(text, REAL_ACTUAL_INFLATION, 'real-actual-inflation', 'medium'));
+
+    // ── Tier 1 v2: formulaic openers + parenthetical hedges ──────────
+    issues.push(...matchPatterns(text, FORMULAIC_OPENERS, 'formulaic-opener', 'high'));
+    issues.push(...matchPatterns(text, PARENTHETICAL_HEDGE, 'parenthetical-hedge', 'medium'));
+
+    // Title-case headers — gated to marketing/personal/general modes
+    // (technical mode legitimately uses Title Case section headers).
+    if (contextMode !== 'technical') {
+      const titleHits = matchPatterns(text, [TITLE_CASE_HEADER], 'title-case-header', 'medium');
+      // Drop matches that look like proper-noun titles (single line, all
+      // tokens capitalized incl. function words) — that's headline style,
+      // not the AI-section-header tell which has mid-sentence "And".
+      const filtered = titleHits.filter((h) => {
+        const tokens = h.text.split(/\s+/);
+        return tokens.length >= 4 && /\b(?:And|Or|Of|The|In|For|To|A|An)\b/.test(h.text);
+      });
+      issues.push(...filtered);
+    }
+
+    // ── Normalization-trigger flag ───────────────────────────────────
+    // ZWSPs or homoglyphs in pasted prose are near-dispositive: humans
+    // don't insert these into their own writing. Single roleplay marker
+    // can be a false positive on Markdown emphasis (filtered to multi-
+    // word inner already), so requires ≥2.
+    if (norm.flags.zeroWidth > 0 || norm.flags.homoglyph >= 2) {
+      issues.push({
+        type: 'normalization-flag',
+        text: `${norm.flags.zeroWidth} zero-width + ${norm.flags.homoglyph} homoglyph swap${norm.flags.homoglyph === 1 ? '' : 's'}`,
+        severity: 'critical',
+        suggestion: 'Text contains invisible/lookalike chars typical of AI-humanizer bypass tools. Re-type from your own keyboard.',
+      });
+    }
+    if (norm.flags.roleplay >= 2) {
+      issues.push({
+        type: 'normalization-flag',
+        text: `${norm.flags.roleplay} *roleplay-action* markers stripped`,
+        severity: 'high',
+        suggestion: 'Paired *action* markers are a chat-model artifact.',
+      });
+    }
+
+    // ── Smart-punctuation co-occurrence signature ────────────────────
+    // Curly quotes + em-dash + Oxford comma all present + zero typos
+    // (no double-spaces, no missing apostrophes in common contractions)
+    // is a near-dispositive paste-from-LLM signature: humans typing
+    // directly into a textarea don't produce all four. Standalone any of
+    // these is meaningless — co-occurrence is the signal.
+    {
+      const hasCurly = /[“”‘’]/.test(text);
+      const hasEmDash = /—/.test(text);
+      const oxfordHit = text.match(/\b\w+,\s+\w+,\s+and\s+\w+/g);
+      const hasOxford = (oxfordHit?.length || 0) >= 1;
+      const doubleSpaces = (text.match(/[^.!?]  +/g) || []).length;
+      const missingApos = /\b(?:dont|wont|cant|isnt|wasnt|shouldnt|wouldnt|couldnt|youre|theyre|its\s+a\s+\w+ing)\b/i.test(text);
+      const clean = doubleSpaces === 0 && !missingApos;
+      const signals = [hasCurly, hasEmDash, hasOxford, clean].filter(Boolean).length;
+      if (signals >= 4 && wordCount >= 80) {
+        issues.push({
+          type: 'smart-punct-signature',
+          text: 'curly-quotes + em-dash + Oxford comma + zero typos',
+          severity: 'high',
+          suggestion: 'Smart-punctuation signature consistent with LLM output. Humans typing into textareas rarely produce all four.',
+        });
+      }
+    }
+
+    // ── Punctuation distribution mode ────────────────────────────────
+    // Humans cluster trimodal across paragraphs (some paras heavy, some
+    // light, some none). AI converges on a normal distribution. We can't
+    // run a real modality test client-side, but we can flag the AI
+    // signature: low variance of per-paragraph punctuation density.
+    // Requires ≥4 paragraphs to be meaningful.
+    if (paragraphs.length >= 4) {
+      const densities = paragraphs.map((p) => {
+        const words = (p.match(/\S+/g) || []).length;
+        if (words < 5) return null;
+        const puncts = (p.match(/[,;:—()]/g) || []).length;
+        return puncts / words;
+      }).filter((d) => d !== null);
+      if (densities.length >= 4) {
+        const mean = densities.reduce((a, b) => a + b, 0) / densities.length;
+        const variance = densities.reduce((s, d) => s + (d - mean) ** 2, 0) / densities.length;
+        const cv = mean > 0 ? Math.sqrt(variance) / mean : 0;
+        // CV < 0.25 across paragraphs means each paragraph has the same
+        // punctuation density — the AI signature. Humans usually swing
+        // wider. Threshold derived from stylometry papers (arxiv 2507.00838).
+        if (cv < 0.25 && mean >= 0.04) {
+          issues.push({
+            type: 'punct-distribution',
+            text: `Punctuation density uniform across paragraphs (CV=${cv.toFixed(2)})`,
+            severity: 'medium',
+            suggestion: 'AI text holds punctuation density steady; human writers swing between dense and sparse paragraphs.',
+          });
+        }
+      }
+    }
+
+    // ── Function-word trigram entropy ────────────────────────────────
+    // POS-trigram entropy is the academic signal; function-word trigram
+    // entropy approximates it without a tagger (function words ARE the
+    // closed-class POS classes). AI text has lower entropy because LLM
+    // sampling collapses onto a narrower set of grammatical templates.
+    //
+    // Method: extract function-word indicators per sentence, build
+    // trigrams over the sequence, compute Shannon entropy. Bins below
+    // threshold flag.
+    if (wordCount >= 150) {
+      const FUNC_WORDS = new Set([
+        'the','a','an','and','or','but','of','to','in','on','at','by','for','with',
+        'from','as','is','was','are','were','be','been','being','have','has','had',
+        'do','does','did','will','would','should','could','may','might','must','can',
+        'this','that','these','those','it','its','they','them','their','there','here',
+        'we','our','us','i','you','your','he','she','his','her','him','not','no','so',
+        'if','then','than','when','where','which','who','what','how','why','because',
+      ]);
+      const seq = tokens.map((t) => FUNC_WORDS.has(t) ? t : '_').filter((_, i, arr) => arr[i] !== '_' || (i > 0 && arr[i - 1] !== '_'));
+      if (seq.length >= 50) {
+        const trigrams = {};
+        for (let i = 0; i < seq.length - 2; i++) {
+          const tg = `${seq[i]}|${seq[i + 1]}|${seq[i + 2]}`;
+          trigrams[tg] = (trigrams[tg] || 0) + 1;
+        }
+        const total = seq.length - 2;
+        let entropy = 0;
+        for (const c of Object.values(trigrams)) {
+          const p = c / total;
+          entropy -= p * Math.log2(p);
+        }
+        // Normalize by log2(distinct trigrams) so entropy ranges roughly
+        // 0..1 and threshold is interpretable. Empirical threshold: human
+        // prose ~0.85-0.95 normalized, AI prose ~0.70-0.82.
+        const distinctCount = Object.keys(trigrams).length;
+        const normalized = distinctCount > 1 ? entropy / Math.log2(distinctCount) : 1;
+        if (normalized < 0.82 && total >= 50) {
+          issues.push({
+            type: 'fnword-trigram-entropy',
+            text: `Function-word trigram entropy ${normalized.toFixed(2)} (low)`,
+            severity: 'medium',
+            suggestion: 'Grammatical structure is unusually repetitive. AI sampling collapses onto narrower templates than human writing.',
+          });
+        }
+        // Degenerate case: single distinct trigram repeated across the
+        // whole document is the strongest possible AI signal but the
+        // normalized fallback returns 1.0 (= "fully human"), inverting
+        // the signal. Catch it explicitly.
+        if (distinctCount === 1 && total >= 50) {
+          issues.push({
+            type: 'fnword-trigram-entropy',
+            text: 'Single function-word trigram repeated across document',
+            severity: 'high',
+            suggestion: 'Grammatical structure is fully degenerate — every clause uses the same function-word skeleton.',
+          });
+        }
+      }
+    }
+
+    // ── Cross-paragraph burstiness ───────────────────────────────────
+    // We already check within-paragraph sentence-length uniformity. AI
+    // is also flat ACROSS paragraphs — every paragraph has roughly the
+    // same sentence-length variance. Humans vary: terse paras next to
+    // discursive paras. Measure variance of CV across paragraphs.
+    if (paragraphs.length >= 4) {
+      const cvs = paragraphs.map((p) => {
+        const sents = getSentences(p);
+        if (sents.length < 3) return null;
+        const lens = sents.map(countWords);
+        const m = lens.reduce((a, b) => a + b, 0) / lens.length;
+        if (m === 0) return null;
+        const v = lens.reduce((s, l) => s + (l - m) ** 2, 0) / lens.length;
+        return Math.sqrt(v) / m;
+      }).filter((c) => c !== null);
+      if (cvs.length >= 4) {
+        const cvMean = cvs.reduce((a, b) => a + b, 0) / cvs.length;
+        const cvVar = cvs.reduce((s, c) => s + (c - cvMean) ** 2, 0) / cvs.length;
+        const cvStd = Math.sqrt(cvVar);
+        // Std-of-CV below 0.08 means every paragraph has roughly the same
+        // internal rhythm — AI signature. Human prose typically swings
+        // 0.15-0.40 across paragraphs of mixed purpose.
+        if (cvStd < 0.08 && cvMean < 0.45) {
+          issues.push({
+            type: 'cross-para-burstiness',
+            text: `Sentence-rhythm uniform across paragraphs (σCV=${cvStd.toFixed(2)})`,
+            severity: 'medium',
+            suggestion: 'Every paragraph has the same internal rhythm. Humans vary cadence between terse and discursive paragraphs.',
+          });
+        }
+      }
+    }
+
+    // ── Tier 3 multi-word phrase density ─────────────────────────
+    // Two complementary rules:
+    //   (a) Per-phrase density — same gating as single-word Tier 3: each
+    //       phrase fine alone, repetition is the tell. Threshold = 2.
+    //   (b) Cross-phrase clustering — ≥3 *distinct* boilerplate phrases
+    //       in one piece. LLMs varying their own boilerplate often use
+    //       each phrase only once but stack 5-10 across the text. The
+    //       per-phrase rule misses this; the cluster rule catches it.
+    // Track non-overlapping match spans so a longer phrase swallowing a
+    // shorter one (e.g., "designed for long-term sustainability" matches
+    // both "designed for long-term" AND "long-term sustainability") only
+    // contributes one distinct hit. Without dedup the cluster threshold
+    // can be reached by a single sentence stacking overlapping regexes.
+    const claimedSpans = [];
+    function spanOverlaps(start, end) {
+      for (const [s, e] of claimedSpans) {
+        if (start < e && end > s) return true;
+      }
+      return false;
+    }
+    let distinctPhrasesHit = 0;
+    for (const phrase of TIER3_PHRASES) {
+      const regex = new RegExp(phrase.source, phrase.flags);
+      const phraseSpans = [];
+      let phraseMatch;
+      while ((phraseMatch = regex.exec(text)) !== null) {
+        const start = phraseMatch.index;
+        const end = start + phraseMatch[0].length;
+        if (!spanOverlaps(start, end)) {
+          phraseSpans.push([start, end, phraseMatch[0]]);
+        }
+      }
+      if (phraseSpans.length === 0) continue;
+      for (const [s, e] of phraseSpans) claimedSpans.push([s, e]);
+      distinctPhrasesHit++;
+      if (phraseSpans.length >= 2) {
+        issues.push({
+          type: 'tier3-phrase',
+          text: `"${phraseSpans[0][2].toLowerCase()}" x${phraseSpans.length}`,
+          severity: 'medium',
+          suggestion: `Boilerplate phrase repeated ${phraseSpans.length}× — replace at least one with specifics`,
+        });
+      }
+    }
+    if (distinctPhrasesHit >= 3) {
+      issues.push({
+        type: 'tier3-phrase-cluster',
+        text: `${distinctPhrasesHit} distinct boilerplate phrases`,
+        severity: 'high',
+        suggestion: 'Several stock crypto/web3 phrases stacked in one piece. Rewrite around one specific claim or observation.',
+      });
+    }
+
+    // ── Hashtag stuffing ─────────────────────────────────────────
+    // 6+ hashtags in a single post is rare for thoughtful humans and
+    // near-universal for LLM-generated social posts. Counted globally,
+    // not per-paragraph, since the trailing hashtag block is the shape
+    // we care about.
+    // Match #tag at start of text or after any non-word char (whitespace,
+    // punctuation, line breaks). URL fragments are already excluded
+    // because the char immediately before `#` in a URL path is always
+    // a word char (e.g. `example.com/page#section` — `e` before `#`).
+    // Earlier char class `[\s\\]` had a literal backslash and silently
+    // missed hashtags after sentence punctuation; an interim `[\s]` fix
+    // on origin only caught whitespace-preceded tags.
+    const hashtagMatches = text.match(/(?:^|\W)#\w[\w-]*/g) || [];
+    if (hashtagMatches.length >= 6) {
+      issues.push({
+        type: 'hashtag-stuff',
+        text: `${hashtagMatches.length} hashtags`,
+        severity: 'medium',
+        suggestion: 'Cut to 2-3 specific tags or none. Long hashtag blocks read as bot output.',
+      });
+    }
+
+    // ── Bullet list of bare noun phrases ─────────────────────────
+    // ≥5 consecutive bullet items that are short (≤6 words) and contain
+    // no finite-verb / modal token. Catches the "Stable mining efficiency
+    // / Reliable pool connectivity / Optimized RandomX performance ..."
+    // shape LLMs default to. Markdown bullets, escaped Markdown bullets,
+    // unicode bullets, and dashes are all matched. Numbered lists are
+    // excluded — those have a separate "numbered list inflation" rule.
+    //
+    // Note: verbRe covers auxiliaries and modals ("was", "will", "can",
+    // etc.). Regular past-tense verbs ("fixed", "removed") are not
+    // matched here; instead, the ≤6-word length gate excludes most
+    // real-world changelog lines, which tend to read "fixed the X that
+    // was doing Y" (>6 words). Short two-word action items ("* fixed
+    // bug") would pass both gates — an acceptable trade-off to avoid
+    // false-negative risk from adjectives ending in -ed ("skilled",
+    // "advanced") that share the same surface form.
+    const lines = text.split(/\r?\n/);
+    const bulletRe = /^\s*(?:\*|-|•|\+)\s+(.+)$/;
+    const verbRe = /\b(?:is|are|was|were|has|have|had|will|would|should|must|do|does|did|can|could|may|might|am|been|being)\b/i;
+    const fenceRe = /^\s*(?:```|~~~)/;
+    let run = [];
+    let blankStreak = 0;
+    let inFence = false;
+    function flushRun() {
+      if (run.length >= 5) {
+        const bareNP = run.filter((it) => {
+          const wc = (it.match(/\S+/g) || []).length;
+          return wc > 0 && wc <= 6 && !verbRe.test(it);
+        });
+        if (bareNP.length >= 5 && bareNP.length / run.length >= 0.75) {
+          issues.push({
+            type: 'bullet-np-list',
+            text: `${run.length}-item bullet list of bare noun phrases`,
+            severity: 'high',
+            suggestion: 'Convert to a prose paragraph or merge items. Long lists of bare adj+noun pairs read as AI scaffolding.',
+          });
+        }
+      }
+      run = [];
+      blankStreak = 0;
+    }
+    for (const line of lines) {
+      if (fenceRe.test(line)) {
+        // Code-fence toggle. Bullets inside fences are CLI flag docs or
+        // option dumps, not prose AI scaffolding — flush any prose run
+        // we were tracking and skip until the fence closes.
+        flushRun();
+        inFence = !inFence;
+        continue;
+      }
+      if (inFence) continue;
+      const m = line.match(bulletRe);
+      if (m) {
+        run.push(m[1].trim());
+        blankStreak = 0;
+      } else if (line.trim() === '') {
+        // A single blank line inside a list is normal Markdown spacing;
+        // two or more blank lines break the run, since visually-disjoint
+        // bullet sections shouldn't merge into one logical list.
+        blankStreak++;
+        if (blankStreak >= 2) flushRun();
+      } else {
+        flushRun();
+      }
+    }
+    flushRun();
+
+    // Confidence calibration is only flagged when it stacks (3+ instances).
+    // Gating happens pre-dedup on raw match count, since that signals actual
+    // stacking, not just vocabulary use.
+    const confIssues = matchPatterns(text, CONFIDENCE_CALIBRATION, 'confidence-calibration', 'low');
+    if (confIssues.length >= 3) issues.push(...confIssues);
+
+    // ── 22. Em dash frequency ────────────────────────────────────
+    // Match real em dashes, plus `--` only when surrounded by whitespace on at
+    // least one side (skips CLI flags like --save-dev and YAML `---` blocks).
+    const emDashCount = (text.match(/—|(?<=\s)--(?=\s|$)|(?<=^|\s)--(?=\s)/gm) || []).length;
+    const emDashRate = emDashCount / (wordCount / 1000);
+    if (emDashRate > 1) {
+      issues.push({
+        type: 'em-dash',
+        text: `${emDashCount} em dashes in ${wordCount} words`,
+        severity: 'medium',
+        suggestion: 'Replace with commas, periods, or rewrite',
+      });
+    }
+
+    // ── 23. Sentence length uniformity ───────────────────────────
+    if (sentences.length >= 5) {
+      const lengths = sentences.map(s => countWords(s));
+      const avg = lengths.reduce((a, b) => a + b, 0) / lengths.length;
+      const variance = lengths.reduce((sum, l) => sum + Math.pow(l - avg, 2), 0) / lengths.length;
+      const stdDev = Math.sqrt(variance);
+      const cv = avg > 0 ? stdDev / avg : 0;
+
+      if (cv < 0.25 && avg > 10) {
+        issues.push({
+          type: 'uniformity',
+          text: `Sentence lengths cluster around ${Math.round(avg)} words (low variation)`,
+          severity: 'medium',
+          suggestion: 'Mix short punchy sentences with longer flowing ones',
+        });
+      }
+    }
+
+    // ── Type-token ratio (stylometric — vocabulary diversity) ────
+    // TTR = distinct word types / total tokens. Human prose at 200+
+    // words typically sits around 0.50–0.65 for English; AI prose
+    // tends flatter (0.55–0.75 looks normal, but the lower end of the
+    // *too-flat* tail at >=200 words is where the signal lives — too
+    // FEW unique words for the length). This is the simplest of the
+    // four stylometric signals identified in the May 2026 detection-
+    // research review (docs/competitive/detection-research.md): no
+    // POS tagger required, no model, pure JS.
+    //
+    // Threshold tuning: flag only when the sample is large enough
+    // that low TTR is meaningfully suspicious (>=200 tokens) AND TTR
+    // is below 0.40 (very vocabulary-poor). Conservative on purpose;
+    // false positives on short or topic-narrow human prose are easy
+    // to trigger and would drown out other signals. The detector-
+    // research lens flagged TTR as one of four stylometric add-ons;
+    // POS-bigram log-odds, function-word z-scores, and sentence-
+    // length burstiness are still TODO.
+    if (tokens.length >= 200) {
+      const unique = new Set(tokens).size;
+      const ttr = unique / tokens.length;
+      if (ttr < 0.4) {
+        issues.push({
+          type: 'low-ttr',
+          text: `Vocabulary diversity ${(ttr * 100).toFixed(1)}% (${unique} unique / ${tokens.length} tokens)`,
+          severity: 'low',
+          suggestion: 'Text reuses a narrow word set. Vary nouns and verbs deliberately, or check if the topic genuinely warrants the repetition.',
+        });
+      }
+    }
+
+    // ── 24. Paragraph length uniformity ──────────────────────────
+    if (paragraphs.length >= 4) {
+      const paraLengths = paragraphs.map(p => getSentences(p).length);
+      const avg = paraLengths.reduce((a, b) => a + b, 0) / paraLengths.length;
+      const allSimilar = paraLengths.every(l => Math.abs(l - avg) <= 1);
+      if (allSimilar && avg >= 3) {
+        issues.push({
+          type: 'uniformity',
+          text: `All paragraphs are ~${Math.round(avg)} sentences`,
+          severity: 'low',
+          suggestion: 'Vary paragraph length deliberately',
+        });
+      }
+    }
+
+    // ── 25. Bold overuse ─────────────────────────────────────────
+    const boldMatches = text.match(/\*\*[^*]+\*\*/g) || [];
+    if (boldMatches.length > 3) {
+      issues.push({
+        type: 'formatting',
+        text: `${boldMatches.length} bold phrases`,
+        severity: 'medium',
+        suggestion: 'Strip bold from most; restructure to lead with key info',
+      });
+    }
+
+    // ── Score from the deduped issue list ───────────────────────
+    // Previously rawScore was accumulated inline per pattern hit, so
+    // repeated hits of the same phrase (or overlapping matches) inflated
+    // the score while the displayed issue list was deduplicated. That
+    // produced the UX regression where a "heavy AI patterns" label sat
+    // above a list of two items. Now the dedup runs first, then each
+    // distinct issue contributes its category weight — so the number
+    // reflects the same signals the user actually sees.
+    const deduped = deduplicateIssues(issues);
+    for (const issue of deduped) {
+      rawScore += ISSUE_WEIGHTS[issue.type] ?? 2;
+    }
+
+    // Scale by text length: longer text gets more chances to trigger.
+    const lengthFactor = Math.max(1, Math.log2(wordCount / 50));
+    const normalizedScore = Math.min(100, Math.round(rawScore / lengthFactor));
+
+    const label = getLabel(normalizedScore);
+
+    // ── Sentence-region smoothing (HMM-style without an HMM) ─────────
+    // Map each text-bearing issue back to its sentence indexes, then
+    // merge adjacent flagged sentences into contiguous regions for UI
+    // highlighting. Borrowed from GPTZero's sentence-highlighting model
+    // — gives users "this paragraph is AI" rather than scattered hits.
+    const regions = buildSentenceRegions(text, deduped);
+
+    // Stats derived from the same deduped list so tier counts + patternCount
+    // sum to `deduped.length`. Previously patternCount subtracted
+    // `tier2Clusters` (a paragraph count) which produced inconsistent totals.
+    const tier1Count = deduped.filter((i) => i.type === 'tier1').length;
+    const tier2Count = deduped.filter((i) => i.type === 'tier2').length;
+    const tier3Count = deduped.filter((i) => i.type === 'tier3').length;
+
+    // ── Trinary classification (GPTZero-shaped) ──────────────────────
+    // Decouples confidence from AI-proportion. Maps the 0-100 score plus
+    // structural signals into HUMAN_ONLY / MIXED / AI_ONLY with a
+    // confidence band. Thresholds are FN-biased: ambiguity routes to
+    // MIXED, never AI_ONLY. Quote from GPTZero's design principle:
+    // "biases the detector to prefer making less-harmful false-negative
+    // errors over false-positive errors."
+    // Dense-AI-vocab trifecta: ≥5 distinct tier1 hits + ≥2 tier2 cluster
+    // paragraphs + ≥1 transition phrase, AND ≥150 words. Catches
+    // saturated ChatGPT prose without firing on dense-jargon human
+    // technical writing where the tier1 vocabulary (robust,
+    // comprehensive, leverage, ecosystem) legitimately overlaps with
+    // systems-programming idiom. Word-count gate prevents short ESL or
+    // contrived adversarial sentences from tripping the corroborator.
+    const tier1Distinct = new Set(deduped.filter((i) => i.type === 'tier1').map((i) => (i.text || '').toLowerCase())).size;
+    const hasTier2Cluster = tier2Clusters >= 2;
+    const hasTransition = deduped.some((i) => i.type === 'transition');
+    const denseAIVocab = wordCount >= 150 && tier1Distinct >= 5 && hasTier2Cluster && hasTransition;
+
+    const trinary = classifyTrinary({
+      score: normalizedScore,
+      issues: deduped,
+      regions,
+      normFlags: norm.flags,
+      wordCount,
+      denseAIVocab,
+    });
+
+    return {
+      // Legacy fields preserved for existing callers.
+      score: normalizedScore,
+      label,
+      issues: deduped,
+      stats: {
+        wordCount,
+        tier1Count,
+        tier2Count,
+        tier2Clusters,
+        tier3Count,
+        tier3Flags,
+        patternCount: deduped.length - tier1Count - tier2Count - tier3Count,
+        contextMode,
+        contextModeFallback,
+        normalization: norm.flags,
+        quotedLines,
+        unmappedHighlights: regions._unmapped ?? 0,
+        denseAIVocab,
+        tier1Distinct,
+      },
+      // Trinary API — shape mirrors GPTZero so integrators can swap.
+      document_classification: trinary.classification,
+      class_probabilities: trinary.probabilities,
+      confidence_category: trinary.confidence,
+      highlight_sentence_for_ai: regions,
+    };
+  }
+
+  // ═══ Sentence regions + trinary classifier ═════════════════════════
+
+  function buildSentenceRegions(text, issues) {
+    // Split text into sentences with byte offsets preserved so the UI
+    // can highlight spans accurately. Sentence boundaries are coarse
+    // (.!?) — fine for highlighting, not for linguistic correctness.
+    const sentences = [];
+    const sentenceRe = /[^.!?]+[.!?]+|\S[^.!?]*$/g;
+    let m;
+    while ((m = sentenceRe.exec(text)) !== null) {
+      const trimmed = m[0].trim();
+      if (trimmed.length < 4) continue;
+      sentences.push({ start: m.index, end: m.index + m[0].length, text: trimmed });
+    }
+    if (sentences.length === 0) return [];
+
+    // Map issue.text back to sentence indexes via substring search. Issues
+    // without a meaningful text (e.g. summary signals like "Punctuation
+    // density uniform across paragraphs") have no sentence anchor — they
+    // contribute to the document-level signal but not to highlights.
+    // Filter by issue TYPE not text-regex: text-based filtering used to
+    // drop legitimate phrase issues containing "across" / "density".
+    const SUMMARY_ONLY_TYPES = new Set([
+      'punct-distribution',
+      'cross-para-burstiness',
+      'fnword-trigram-entropy',
+      'smart-punct-signature',
+      'normalization-flag',
+      'uniformity',
+      'em-dash',
+      'formatting',
+      'tier3',
+      'tier3-phrase',
+      'tier3-phrase-cluster',
+      'hashtag-stuff',
+      'bullet-np-list',
+    ]);
+    const hits = sentences.map(() => ({ count: 0, weight: 0 }));
+    const lowerText = text.toLowerCase();
+    let unmappedHighlights = 0;
+    for (const issue of issues) {
+      if (!issue.text || issue.text.length > 200) continue;
+      if (SUMMARY_ONLY_TYPES.has(issue.type)) continue;
+      const needle = issue.text.toLowerCase();
+      let idx = 0;
+      let matched = false;
+      while ((idx = lowerText.indexOf(needle, idx)) !== -1) {
+        matched = true;
+        for (let i = 0; i < sentences.length; i++) {
+          if (idx >= sentences[i].start && idx < sentences[i].end) {
+            hits[i].count++;
+            hits[i].weight += ISSUE_WEIGHTS[issue.type] ?? 2;
+            break;
+          }
+        }
+        idx += needle.length;
+      }
+      if (!matched) unmappedHighlights++;
+    }
+
+    // Window-merge contiguous flagged sentences. Allow 1 unflagged
+    // sentence gap between two flagged ones (the "smoothing" — keeps
+    // a single boring sentence from breaking what's clearly an AI
+    // passage). A sentence is "flagged" if it has ≥1 hit.
+    const regions = [];
+    let cur = null;
+    for (let i = 0; i < sentences.length; i++) {
+      if (hits[i].count > 0) {
+        if (cur === null) {
+          cur = { startSentence: i, endSentence: i, start: sentences[i].start, end: sentences[i].end, hitCount: hits[i].count, weight: hits[i].weight };
+        } else {
+          cur.endSentence = i;
+          cur.end = sentences[i].end;
+          cur.hitCount += hits[i].count;
+          cur.weight += hits[i].weight;
+        }
+      } else if (cur !== null) {
+        // Allow one-sentence gap.
+        const next = hits[i + 1];
+        if (next && next.count > 0) {
+          cur.endSentence = i;
+          cur.end = sentences[i].end;
+          continue;
+        }
+        regions.push(finalizeRegion(cur));
+        cur = null;
+      }
+    }
+    if (cur !== null) regions.push(finalizeRegion(cur));
+    // Expose the unmapped-highlight count via a non-enumerable property
+    // so the array length still reads naturally for consumers; the
+    // analyzer pulls it into stats.unmappedHighlights for diagnostics.
+    Object.defineProperty(regions, '_unmapped', { value: unmappedHighlights, enumerable: false });
+    return regions;
+  }
+
+  function finalizeRegion(r) {
+    // Map cumulative weight inside the region to a 0-1 score. Cap at 20
+    // weight = 1.0 (matches Heavy threshold density).
+    const score = Math.min(1, r.weight / 20);
+    return {
+      startSentence: r.startSentence,
+      endSentence: r.endSentence,
+      start: r.start,
+      end: r.end,
+      hitCount: r.hitCount,
+      score: Math.round(score * 100) / 100,
+    };
+  }
+
+  // FN-biased: false positives damage trust more than false negatives,
+  // so MIXED is wide and AI_ONLY requires multiple signals. Quote from
+  // GPTZero: "biases the detector to prefer making less-harmful
+  // false-negative errors over false-positive errors."
+  function classifyTrinary({ score, issues, regions, normFlags, wordCount, denseAIVocab }) {
+    // Strong corroborators — each is near-dispositive on its own:
+    //   - cutoff-disclaimer (LLM self-identifies as an AI)
+    //   - reasoning-artifact + chatbot-artifact co-occurrence
+    //   - normalization-flag at threshold (≥2 ZWSP or homoglyphs).
+    //     Threshold parity prevents a single stray ZWSP in copy-paste
+    //     from Word/Notion from flipping to AI_ONLY at score 0.
+    //   - denseAIVocab: ≥4 distinct tier1 hits AND ≥1 tier2 cluster AND
+    //     ≥1 transition phrase — the trifecta that saturated ChatGPT
+    //     prose triggers without needing whitelisted stylometric hits.
+    const hasCutoff = issues.some((i) => i.type === 'cutoff-disclaimer');
+    const hasNormFlag = normFlags.zeroWidth >= 2 || normFlags.homoglyph >= 2;
+    const hasReasoning = issues.some((i) => i.type === 'reasoning-artifact');
+    const hasChatbot = issues.some((i) => i.type === 'chatbot');
+    const strongCorrob =
+      (hasCutoff ? 1 : 0) +
+      (hasNormFlag ? 1 : 0) +
+      (hasReasoning && hasChatbot ? 1 : 0) +
+      (denseAIVocab ? 1 : 0);
+
+    // Weak (stylometric) corroborators — suggestive on their own,
+    // dispositive in combination. Smart-punct-signature matches
+    // Word-edited human prose so doesn't count without other support.
+    const stylometricHits = ['punct-distribution', 'cross-para-burstiness', 'fnword-trigram-entropy']
+      .filter((t) => issues.some((i) => i.type === t)).length;
+    const hasSmartPunct = issues.some((i) => i.type === 'smart-punct-signature');
+    const weakCorrob = (stylometricHits >= 2 ? 1 : 0) + (hasSmartPunct ? 1 : 0);
+
+    // Thresholds:
+    //   score < 15 with no strong → HUMAN_ONLY
+    //   strong ≥ 1 OR score ≥ 70 → AI_ONLY (lowered from 80; high
+    //     density of AI vocab is sufficient evidence)
+    //   score ≥ 40 with any corroborator → AI_ONLY
+    //   everything else with score ≥ 15 → MIXED
+    const totalCorrob = strongCorrob + weakCorrob;
+    let classification;
+    if (score < 15 && strongCorrob === 0) classification = 'HUMAN_ONLY';
+    else if (strongCorrob >= 1 || score >= 70) classification = 'AI_ONLY';
+    else if (score >= 40 && totalCorrob >= 1) classification = 'AI_ONLY';
+    else classification = 'MIXED';
+
+    // Humanizer-flag escalation: presence of bypass-trick chars is
+    // adversarial signal. If a normalization-flag fired we already
+    // counted it in strongCorrob → AI_ONLY. Confidence also gets a
+    // floor of 'medium' in that case (an adversary actively evading
+    // detection should never read as low-confidence noise).
+
+    // Soft probability distribution. Not calibrated against a labeled
+    // corpus yet (TODO when corpus exists — see roadmap.md). Largest
+    // class is computed as `1 - others` after rounding to guarantee
+    // sum=1 exactly. Sub-1% drift would otherwise hide in toFixed.
+    const aiSoft = Math.min(0.97, score / 100 + totalCorrob * 0.06 + strongCorrob * 0.08);
+    let p;
+    if (classification === 'HUMAN_ONLY') p = { human: Math.max(0.6, 1 - aiSoft), mixed: Math.min(0.35, aiSoft * 0.8), ai: Math.min(0.1, aiSoft * 0.3) };
+    else if (classification === 'AI_ONLY') p = { human: Math.max(0.02, 1 - aiSoft - 0.05), mixed: 0.1, ai: aiSoft };
+    else p = { human: Math.max(0.15, 0.6 - aiSoft * 0.5), mixed: 0.5, ai: aiSoft * 0.7 };
+    const rawSum = p.human + p.mixed + p.ai;
+    p.human = +(p.human / rawSum).toFixed(3);
+    p.mixed = +(p.mixed / rawSum).toFixed(3);
+    // Assign ai as the remainder so the three values sum to exactly 1.
+    // Clamp to >= 0 in case rounding pushes human+mixed above 1 (the
+    // remainder would otherwise show as -0 or -0.001 — surfaces as a
+    // negative percentage in any UI doing Math.round(p.ai * 100)).
+    p.ai = Math.max(0, +(1 - p.human - p.mixed).toFixed(3));
+    const probabilities = p;
+
+    // Confidence band:
+    //   high   — strongCorrob ≥ 2, OR cutoff-disclaimer, OR score < 8 (clean long doc)
+    //   medium — strongCorrob ≥ 1, OR score ≥ 45 with weak corroborator, OR score < 20
+    //   low    — everything else
+    let confidence;
+    if (strongCorrob >= 2 || hasCutoff || (score < 8 && wordCount >= 100)) confidence = 'high';
+    else if (strongCorrob >= 1 || (score >= 45 && weakCorrob >= 1) || score < 20) confidence = 'medium';
+    else confidence = 'low';
+
+    return { classification, probabilities, confidence };
+  }
+
+  function getLabel(score) {
+    if (score === 0) return 'Clean';
+    if (score <= 15) return 'Minimal AI signals';
+    if (score <= 35) return 'Some AI patterns';
+    if (score <= 60) return 'Moderate AI signals';
+    if (score <= 80) return 'Strong AI signals';
+    return 'Heavy AI patterns';
+  }
+
+  function getColor(score) {
+    if (score <= 15) return '#44bb66';
+    if (score <= 35) return '#88bb44';
+    if (score <= 60) return '#ddaa00';
+    if (score <= 80) return '#ff8833';
+    return '#ff4444';
+  }
+
+  function deduplicateIssues(issues) {
+    const seen = new Set();
+    return issues.filter(issue => {
+      const key = `${issue.type}:${issue.text.toLowerCase()}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+  }
+
+  // ─── Severity labels ──────────────────────────────────────────
+  const SEVERITY_LABELS = {
+    critical: 'P0',
+    high: 'P1',
+    medium: 'P2',
+    low: 'P3',
+  };
+
+  const TYPE_LABELS = {
+    'tier1': 'AI vocabulary',
+    'tier2': 'Word cluster',
+    'tier3': 'Overused word',
+    'transition': 'AI transition',
+    'chatbot': 'Chatbot artifact',
+    'sycophantic': 'Sycophantic tone',
+    'filler': 'Filler phrase',
+    'generic-conclusion': 'Generic conclusion',
+    'lets-construction': '"Let\'s" opener',
+    'reasoning-artifact': 'Reasoning artifact',
+    'acknowledgment-loop': 'Acknowledgment loop',
+    'significance-inflation': 'Significance inflation',
+    'vague-attribution': 'Vague attribution',
+    'hollow-intensifier': 'Hollow intensifier',
+    'emotional-flatline': 'Emotional flatline',
+    'novelty-inflation': 'Novelty inflation',
+    'cutoff-disclaimer': 'Cutoff disclaimer',
+    'template-phrase': 'Template phrase',
+    'false-concession': 'False concession',
+    'rhetorical-question': 'Rhetorical question',
+    'confidence-calibration': 'Confidence stacking',
+    'em-dash': 'Em dash overuse',
+    'uniformity': 'Rhythm uniformity',
+    'formatting': 'Formatting',
+    'tier3-phrase': 'Boilerplate phrase',
+    'tier3-phrase-cluster': 'Boilerplate cluster',
+    'hashtag-stuff': 'Hashtag stuffing',
+    'bullet-np-list': 'Bullet-NP list',
+    'hedge-stack': 'Hedge-stacked prediction',
+    'future-narrative': 'Generic future narrative',
+    'real-actual-inflation': '"Real/actual" inflation',
+    'formulaic-opener': 'Formulaic opener',
+    'title-case-header': 'Title Case header',
+    'parenthetical-hedge': 'Parenthetical hedge',
+    'smart-punct-signature': 'Smart-punct signature',
+    'punct-distribution': 'Punctuation distribution',
+    'fnword-trigram-entropy': 'Grammar repetition',
+    'cross-para-burstiness': 'Cross-paragraph rhythm',
+    'normalization-flag': 'Bypass-trick chars',
+    'low-ttr': 'Low vocabulary diversity',
+    'ai-placeholder': 'Unfilled placeholder',
+    'ai-citation-markup': 'Chatbot citation markup leak',
+    'ai-utm-source': 'AI-tool URL parameter',
+  };
+
+  return {
+    analyzeText,
+    normalizeText,
+    getLabel,
+    getColor,
+    SEVERITY_LABELS,
+    TYPE_LABELS,
+  };
+})();
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = AIDetector;
+}

--- a/detector/patterns.test.js
+++ b/detector/patterns.test.js
@@ -1,0 +1,714 @@
+/**
+ * Avoid AI Writing — detector fixtures
+ *
+ * Node-runnable smoke tests for the detection engine. Intentionally small and
+ * dependency-free so they run on any `node >= 18` without installing
+ * anything. Invoked via `npm run test:detector` and in CI.
+ *
+ * Failure modes worth catching:
+ *   - AI-heavy text scoring as human (regression in pattern coverage)
+ *   - Plain prose scoring above "minimal" (false-positive drift)
+ *   - Length gates (too-short / too-long) not firing
+ *   - Stats failing to sum to issue count (dedup math drift)
+ */
+
+const assert = require('node:assert/strict');
+const AIDetector = require('./patterns.js');
+
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+  } catch (err) {
+    failed++;
+    console.error(`  ✗ ${name}`);
+    console.error(`    ${err.message}`);
+  }
+}
+
+console.log('Detector fixtures');
+
+test('empty text returns Empty label', () => {
+  const r = AIDetector.analyzeText('');
+  assert.equal(r.label, 'Empty');
+  assert.equal(r.issues.length, 0);
+});
+
+test('text under 10 words returns tooShort flag', () => {
+  const r = AIDetector.analyzeText('Short unscorable text snippet.');
+  assert.equal(r.tooShort, true);
+  assert.equal(r.label, 'Too short');
+});
+
+test('text over 10k words returns tooLong flag', () => {
+  const r = AIDetector.analyzeText('word '.repeat(10001));
+  assert.equal(r.tooLong, true);
+  assert.equal(r.label, 'Text too long');
+});
+
+test('AI-heavy paragraph scores in Strong/Heavy range', () => {
+  const text = [
+    "In today's ever-evolving landscape, we delve into the intricate",
+    'tapestry of innovation. This seamless, robust paradigm showcases a',
+    'comprehensive framework. Moreover, it truly is a game-changer.',
+    'Furthermore, this pivotal moment underscores how we navigate the',
+    'complexities of modern AI.',
+  ].join(' ');
+  const r = AIDetector.analyzeText(text);
+  assert.ok(r.score >= 60, `expected score ≥60, got ${r.score}`);
+  assert.ok(['Strong AI signals', 'Heavy AI patterns'].includes(r.label), `got label: ${r.label}`);
+});
+
+test('plain human bug-report prose stays in Minimal range', () => {
+  const text = [
+    'The build broke again this morning. Rolled back the auth refactor',
+    'and tests pass now. Still need to figure out why the token refresh',
+    'path hits a 401 for users on Safari but not Firefox — probably a',
+    'cookie scope issue but I want to confirm before shipping a fix.',
+  ].join(' ');
+  const r = AIDetector.analyzeText(text);
+  assert.ok(r.score <= 20, `expected score ≤20, got ${r.score}`);
+});
+
+test('stats fields sum to issues length', () => {
+  const text = [
+    "In today's landscape of innovation, we leverage seamless paradigms",
+    'to harness the power of transformation. It is important to note',
+    'that experts believe this is pivotal. Let me think step by step.',
+  ].join(' ');
+  const r = AIDetector.analyzeText(text);
+  const sum = r.stats.tier1Count + r.stats.tier2Count + r.stats.tier3Count + r.stats.patternCount;
+  assert.equal(sum, r.issues.length, `stats sum (${sum}) != issues (${r.issues.length})`);
+});
+
+test('repeated Tier 1 phrase does not inflate score linearly', () => {
+  const single = AIDetector.analyzeText('We delve into the landscape of many things today.');
+  const fivefold = AIDetector.analyzeText(
+    'We delve into the landscape. We delve into the landscape. We delve into the landscape. We delve into the landscape. We delve into the landscape of things.'
+  );
+  assert.ok(
+    fivefold.score <= single.score + 20,
+    `repeated phrase should not 5× the score (single=${single.score}, fivefold=${fivefold.score})`
+  );
+});
+
+test('em-dash detector ignores CLI flags like --save-dev', () => {
+  const text = 'Run npm install --save-dev and then npm run build --no-verify --silent. Takes about ten seconds on this machine. The package is installed into node_modules directly after the install command completes successfully.';
+  const r = AIDetector.analyzeText(text);
+  const emDashIssues = r.issues.filter((i) => i.type === 'em-dash');
+  assert.equal(emDashIssues.length, 0, 'CLI flags should not count as em dashes');
+});
+
+test('chatbot artifacts score as P0 critical', () => {
+  const text = "I hope this helps! Let me know if you need anything else. Great question! Feel free to reach out.";
+  const r = AIDetector.analyzeText(text);
+  const chatbotIssues = r.issues.filter((i) => i.type === 'chatbot');
+  assert.ok(chatbotIssues.length >= 2, `expected chatbot detections, got ${chatbotIssues.length}`);
+  assert.equal(AIDetector.SEVERITY_LABELS[chatbotIssues[0].severity], 'P0');
+});
+
+test('crypto-shill social post with hashtag block + bullet-NP lists flags', () => {
+  // Reported 2026-05-16 as a "skipped" detection. Avoids every Tier 1
+  // word ("delve", "robust", "leverage") and substitutes synonyms the
+  // wordlist misses, but stacks structural signals: 6-item bullet-NP
+  // list, 15-tag hashtag block, "may become one of the most important
+  // narratives" future-narrative template, "could potentially" hedge
+  // stack, and ten distinct crypto-shill boilerplate phrases.
+  const text = `The future of decentralized computational infrastructure is evolving rapidly as blockchain-integrated mining ecosystems continue to merge with artificial intelligence, distributed compute, and tokenized incentive structures.
+
+MineBench represents an interesting example of this emerging sector by combining benchmark-based mining participation, token rewards, and scalable network contribution models into a unified ecosystem designed for long-term sustainability and user engagement.
+
+After several hours of testing, the platform demonstrated:
+
+* Stable mining efficiency
+* Reliable pool connectivity
+* Optimized RandomX computational performance
+* Low failed share rates
+* Effective hardware utilization
+* Consistent thermal stability
+
+The integration of reward-based participation mechanisms alongside decentralized infrastructure concepts could potentially create new opportunities for community-driven computational networks.
+
+The intersection of AI, DePIN, mining infrastructure, and decentralized compute may become one of the most important narratives of the next market cycle.
+
+#AI #Crypto #Blockchain #DePIN #Mining #Web3 #Solana #RandomX #DecentralizedAI #PassiveIncome #Infrastructure #Innovation #Technology #FutureTech #Tokenomics`;
+  const r = AIDetector.analyzeText(text);
+  const types = new Set(r.issues.map((i) => i.type));
+  assert.ok(types.has('bullet-np-list'), 'expected bullet-np-list flag');
+  assert.ok(types.has('hashtag-stuff'), 'expected hashtag-stuff flag');
+  assert.ok(types.has('future-narrative'), 'expected future-narrative flag');
+  assert.ok(types.has('hedge-stack'), 'expected hedge-stack flag');
+  assert.ok(types.has('tier3-phrase-cluster'), 'expected tier3-phrase-cluster flag');
+  assert.ok(r.score >= 25, `expected score ≥25 (Some/Moderate), got ${r.score}`);
+});
+
+test('"Interesting part of the project:" header opener flags emotional-flatline', () => {
+  // The canonical AI list-intro pattern matched "the most interesting
+  // part" but missed the bare "Interesting part of X:" section-header
+  // form. v3.4 covers both shapes.
+  const text = '\nInteresting part of the project:\nSome content follows that talks about the real on-chain tokenomics of the system at length.';
+  const r = AIDetector.analyzeText(text);
+  const types = new Set(r.issues.map((i) => i.type));
+  assert.ok(types.has('emotional-flatline'), 'expected emotional-flatline flag');
+});
+
+test('"real on-chain tokenomics" flags real-actual-inflation', () => {
+  const text = 'The team is researching real on-chain tokenomics and actual reward sustainability versus electricity cost across the network deployment phase.';
+  const r = AIDetector.analyzeText(text);
+  const types = new Set(r.issues.map((i) => i.type));
+  assert.ok(types.has('real-actual-inflation'), 'expected real-actual-inflation flag');
+});
+
+test('hashtag-stuff does not fire on prose with 2-3 hashtags', () => {
+  const text = 'Shipped the new build last night. Catching bugs faster with the new instrumentation. Notes are in the doc, and the next push lands tomorrow. #buildinpublic #devlog';
+  const r = AIDetector.analyzeText(text);
+  const types = new Set(r.issues.map((i) => i.type));
+  assert.ok(!types.has('hashtag-stuff'), 'should not flag 2 hashtags as hashtag-stuff');
+});
+
+test('bullet-np-list does not fire on prose containing short verb-form bullets', () => {
+  // Genuine list items with finite verbs should not trip the bare-NP
+  // detector. The verb-token guard is what keeps todo lists, changelog
+  // entries, and step-by-step instructions out of the false-positive
+  // bucket.
+  const text = `Today's changelog:
+
+* fixed the auth bug that was hitting Safari users
+* removed the legacy webhook handler that nobody calls anymore
+* added a retry on the token refresh path
+* shipped the new build to staging this morning
+* will deploy to prod after the smoke tests pass
+
+That's the full list for this push.`;
+  const r = AIDetector.analyzeText(text);
+  const types = new Set(r.issues.map((i) => i.type));
+  assert.ok(!types.has('bullet-np-list'), 'verb-form bullets should not trip bare-NP detector');
+});
+
+test('tier3-phrase fires on per-phrase repetition (>=2 hits)', () => {
+  // The same boilerplate phrase used twice in one piece. Isolates the
+  // per-phrase density rule from the cluster rule — cluster needs >=3
+  // distinct phrases, this one needs >=2 hits of one phrase.
+  const text = 'The integration of payments matters for adoption. The integration of identity is the next step. Both unlock material flows.';
+  const r = AIDetector.analyzeText(text);
+  const types = new Set(r.issues.map((i) => i.type));
+  assert.ok(types.has('tier3-phrase'), 'expected tier3-phrase flag for 2x repetition');
+});
+
+test('tier3-phrase-cluster fires on 3 distinct phrases at density 1 each', () => {
+  // The cluster-rule boundary: each phrase appears only once, but three
+  // distinct phrases stacked is the LLM-self-varies-boilerplate shape.
+  // Per-phrase rule should NOT fire here; cluster rule should.
+  const text = 'The team works on decentralized compute. Their thesis is community-driven and the long-term sustainability of the network matters most. Adoption is improving.';
+  const r = AIDetector.analyzeText(text);
+  const types = new Set(r.issues.map((i) => i.type));
+  assert.ok(types.has('tier3-phrase-cluster'), 'expected tier3-phrase-cluster flag at 3 distinct phrases');
+  assert.ok(!types.has('tier3-phrase'), 'per-phrase rule should NOT fire when each phrase appears once');
+});
+
+test('tier3-phrase span dedup: overlapping regex matches count as one phrase', () => {
+  // "designed for long-term sustainability" matches both
+  // "designed for long-term" AND "long-term sustainability" — the second
+  // is contained in the first. Span-dedup keeps this as one distinct hit.
+  const text = 'This protocol is designed for long-term sustainability and nothing else.';
+  const r = AIDetector.analyzeText(text);
+  const types = new Set(r.issues.map((i) => i.type));
+  assert.ok(!types.has('tier3-phrase-cluster'), 'overlapping matches should not stack toward cluster threshold');
+});
+
+test('emotional-flatline opener fires at position 0 (no leading newline)', () => {
+  // Earlier (^|\n) form silently missed bare openers at true start of
+  // input. /m flag fixes it.
+  const text = 'Interesting part of the project:\nThey shipped in two weeks.';
+  const r = AIDetector.analyzeText(text);
+  const types = new Set(r.issues.map((i) => i.type));
+  assert.ok(types.has('emotional-flatline'), 'expected emotional-flatline at position 0');
+});
+
+test('bullet-np-list ignores bullets inside fenced code blocks', () => {
+  // CLI flag docs / option dumps inside ``` fences are not prose AI
+  // scaffolding. False-positive that would fire on most READMEs.
+  const text = "Run with one of these modes via `--mode`:\n\n```\n- unit\n- smoke\n- integration\n- e2e\n- perf\n- stress\n```\n\nDefaults to `unit` if omitted.";
+  const r = AIDetector.analyzeText(text);
+  const types = new Set(r.issues.map((i) => i.type));
+  assert.ok(!types.has('bullet-np-list'), 'bullets inside code fences should not flag');
+});
+
+test('bullet-np-list flushes on 2+ blank lines between bullet sections', () => {
+  // A single blank line is normal Markdown spacing inside one list.
+  // Two or more blank lines separate visually-disjoint sections — those
+  // should not merge into one long run.
+  const text = '* alpha\n* beta\n\n\nA paragraph of prose.\n\n\n* gamma\n* delta\n* epsilon';
+  const r = AIDetector.analyzeText(text);
+  const types = new Set(r.issues.map((i) => i.type));
+  assert.ok(!types.has('bullet-np-list'), 'sections separated by 2+ blank lines should not merge');
+});
+
+test('hashtag-stuff matches tags after sentence punctuation', () => {
+  // Hashtags immediately following sentence punctuation — common in
+  // LinkedIn/X trailing blocks. The prior regex char class `[\s\\]`
+  // had a literal backslash and silently missed any tag not preceded
+  // by whitespace.
+  const text = "Built a thing this week.\n#startup #crypto #web3 #ai #devlog #shipping #foundermode";
+  const r = AIDetector.analyzeText(text);
+  const types = new Set(r.issues.map((i) => i.type));
+  assert.ok(types.has('hashtag-stuff'), 'expected hashtag-stuff on 7-tag trailing block');
+});
+
+test('hashtag-stuff excludes URL fragments from the count', () => {
+  // URL anchors like example.com/page#section must not count toward
+  // the hashtag threshold or every doc post with a fragment link
+  // would false-positive.
+  const text = 'See the spec at example.com/api#auth and the deploy guide at example.com/ops#rollback and the troubleshooting notes at example.com/help#errors and the changelog at example.com/log#latest. Also kb.example.com/faq#section1 and forum.example.com/t/123#post-4 round out the references.';
+  const r = AIDetector.analyzeText(text);
+  const types = new Set(r.issues.map((i) => i.type));
+  assert.ok(!types.has('hashtag-stuff'), 'URL fragments should not count as hashtags');
+});
+
+test('low-ttr fires on a 200+ token text with narrow vocabulary', () => {
+  // Vocabulary-poor synthetic sample: same 11-word sentence repeated.
+  // ~200 tokens, ~11 unique = ~5% TTR. Well under the 40% threshold.
+  // Stylometric signal from the May 2026 detection-research review
+  // (docs/competitive/detection-research.md).
+  const sentence = 'The system shows the system improves the system every iteration. ';
+  const text = sentence.repeat(20);
+  const r = AIDetector.analyzeText(text);
+  const types = new Set(r.issues.map((i) => i.type));
+  assert.ok(types.has('low-ttr'), `expected low-ttr flag, got types: ${[...types].join(', ')}`);
+});
+
+test('low-ttr does not fire on natural human prose at 200+ tokens', () => {
+  // 200+ tokens of varied human-style prose. TTR should comfortably
+  // exceed the 0.40 threshold even with some natural repetition.
+  const text = `When the build broke this morning, I rolled back the recent auth refactor and
+ran the integration tests again. Most of them passed cleanly, but a handful
+of edge cases around token refresh still tripped the staging environment.
+Safari users hit a 401 on the second request of any session that crossed
+the hour mark, while Firefox sessions stayed authenticated as expected.
+Digging through the logs, the culprit looked like a cookie scope issue
+introduced during the migration to the new domain. I patched the path
+parameter, redeployed to staging, and watched the metrics dashboard for
+twenty minutes before pushing to production. Memory usage stayed flat,
+latency held steady around forty milliseconds, and the error rate dropped
+back below baseline once the rollout completed. Closing the incident
+ticket now and writing up notes for the team retrospective tomorrow.`;
+  const r = AIDetector.analyzeText(text);
+  const types = new Set(r.issues.map((i) => i.type));
+  assert.ok(!types.has('low-ttr'), `low-ttr should not fire on natural prose, got types: ${[...types].join(', ')}`);
+});
+
+test('low-ttr does not fire on short texts (<200 tokens)', () => {
+  // Same vocab-poor pattern but only ~50 tokens — below the sample-size
+  // threshold. Avoids drowning short social posts in a stylometric flag
+  // that needs more data to be reliable.
+  const text = ('The system shows the system improves the system. '.repeat(5));
+  const r = AIDetector.analyzeText(text);
+  const types = new Set(r.issues.map((i) => i.type));
+  assert.ok(!types.has('low-ttr'), 'low-ttr should not fire below 200 tokens');
+});
+
+test('ai-placeholder fires on common slot-fill bracket patterns', () => {
+  // The canonical AI-generated boilerplate that users paste without
+  // filling in. Each shape is enough on its own. Catches the "[Your
+  // Name]" family, dated stubs, and HTML comment placeholders.
+  for (const text of [
+    'Dear [Recipient], I am writing regarding [Topic of Discussion].',
+    'Last updated 2025-XX-XX. Authors: [INSERT TEAM NAMES HERE].',
+    'See the report from XX/XX/2024 for context.',
+    '<!-- TODO: add citation when paper publishes -->',
+    '<!-- fill in the missing section before shipping -->',
+  ]) {
+    const r = AIDetector.analyzeText(text + ' Additional padding text to clear the word-count gate. '.repeat(2));
+    const types = new Set(r.issues.map((i) => i.type));
+    assert.ok(types.has('ai-placeholder'), `expected ai-placeholder for: ${text}`);
+  }
+});
+
+test('ai-placeholder does not fire on legitimate bracketed content', () => {
+  // Real bracketed content — citations, optional matches, code
+  // references — should NOT trip the placeholder regex. The pattern
+  // is gated on placeholder VERBS (Your/Insert/Add/Describe/etc.).
+  const text = 'The release notes for [v1.2.3] cover the [auth.refresh] path and reference [@example/user]. We saw it on commit [a3f7b21]. Padding text to clear the word-count gate so the analyzer runs the full pass cleanly.';
+  const r = AIDetector.analyzeText(text);
+  const types = new Set(r.issues.map((i) => i.type));
+  assert.ok(!types.has('ai-placeholder'), `expected no ai-placeholder, got: ${[...types].join(', ')}`);
+});
+
+test('ai-citation-markup fires on chatbot-internal tokens', () => {
+  // Each of these is a near-definitive fingerprint of a specific
+  // chat tool. Their presence is proof of copy-paste origin.
+  for (const text of [
+    'The school has been recognized as an international centre. citeturn0search1 More details below.',
+    'See the appendix contentReference[oaicite:3]{index=3} for the data.',
+    'According to the source oai_citation provided by the model, the figure is 12.',
+    'The user uploaded [attached_file:1] for review.',
+    'The grok_card here links to the relevant policy. ' + 'Padding text to clear the gate. '.repeat(3),
+  ]) {
+    const r = AIDetector.analyzeText(text + ' '.repeat(0) + 'Padding text to clear the word-count gate. '.repeat(2));
+    const types = new Set(r.issues.map((i) => i.type));
+    assert.ok(types.has('ai-citation-markup'), `expected ai-citation-markup for: ${text.slice(0, 50)}...`);
+  }
+});
+
+test('ai-utm-source fires on AI-tool tracking parameters', () => {
+  // utm_source values that AI tools auto-append to URLs they generate.
+  // Each one is essentially proof the URL came out of a chatbot.
+  for (const text of [
+    'See https://example.com/article?utm_source=chatgpt.com for the source.',
+    'Link: https://example.com/?utm_source=copilot.com&utm_medium=referral',
+    'https://docs.example.com/page?utm_source=claude.ai is the canonical reference.',
+    'Reference URL: https://example.com/post?utm_source=perplexity.ai found via search.',
+    'Article: https://example.com/blog?referrer=grok.com via the link.',
+  ]) {
+    const r = AIDetector.analyzeText(text + ' Padding text to clear the word-count gate so the analyzer runs cleanly across all categories.');
+    const types = new Set(r.issues.map((i) => i.type));
+    assert.ok(types.has('ai-utm-source'), `expected ai-utm-source for: ${text.slice(0, 60)}...`);
+  }
+});
+
+test('ai-utm-source does not fire on benign utm_source values', () => {
+  // Real marketing UTMs from non-AI sources should not flag.
+  const text = 'See https://example.com/article?utm_source=newsletter for the source. Padding text to clear the word-count gate so the analyzer runs the full pass cleanly across all categories without surprises.';
+  const r = AIDetector.analyzeText(text);
+  const types = new Set(r.issues.map((i) => i.type));
+  assert.ok(!types.has('ai-utm-source'), 'newsletter UTM should not flag as AI source');
+});
+
+test('severity labels are distinct across all four tiers', () => {
+  const labels = new Set(Object.values(AIDetector.SEVERITY_LABELS));
+  assert.equal(labels.size, 4, 'expected P0/P1/P2/P3 as four distinct labels');
+});
+
+// ─── v2: Tier 1 stylometric + bypass-trick detection ────────────────
+
+test('v2: zero-width chars trigger normalization-flag', () => {
+  // ZWSP between "del" and "ve" defeats naive "delve" exact-match. Pre-
+  // pass strips it, then Tier 1 fires AND normalization-flag fires.
+  const zwsp = '​';
+  const text = `In today's landscape, we del${zwsp}ve into the intricate tapestry of innovation. This robust paradigm showcases comprehensive frameworks. The framework underscores how organizations harness cutting-edge tools.`;
+  const r = AIDetector.analyzeText(text);
+  const types = new Set(r.issues.map((i) => i.type));
+  assert.ok(types.has('normalization-flag'), 'expected normalization-flag on ZWSP injection');
+  assert.ok(r.stats.normalization.zeroWidth > 0, 'norm.zeroWidth should count strip');
+});
+
+test('v2: Cyrillic homoglyph swap restores Tier 1 hit', () => {
+  // "dеlve" uses Cyrillic 'е' (U+0435). Without normalization the token
+  // 'dеlve' would not equal 'delve' and Tier 1 misses it. After
+  // normalization, the Latin form fires Tier 1 AND triggers normalization-flag.
+  const text = 'In tоday’s landscape we dеlve intо the intricate tapestry оf the rоbust ecоsystem and dеep dive intо each layer with comprehensive depth.';
+  const r = AIDetector.analyzeText(text);
+  const types = new Set(r.issues.map((i) => i.type));
+  assert.ok(types.has('normalization-flag'), 'expected normalization-flag on homoglyph cluster');
+  assert.ok(r.stats.normalization.homoglyph >= 2, `expected >=2 homoglyph swaps, got ${r.stats.normalization.homoglyph}`);
+});
+
+test('v2: formulaic opener fires', () => {
+  const text = 'In the rapidly evolving world of decentralized finance, new protocols have emerged as critical infrastructure. The market continues to expand at an unprecedented pace each quarter without fail.';
+  const r = AIDetector.analyzeText(text);
+  const types = new Set(r.issues.map((i) => i.type));
+  assert.ok(types.has('formulaic-opener'), 'expected formulaic-opener flag');
+});
+
+test('v2: parenthetical hedge fires', () => {
+  const text = 'The protocol works as intended (and increasingly, with better latency than competitors). The team has shipped consistently for six months without missing a single release cadence target.';
+  const r = AIDetector.analyzeText(text);
+  const types = new Set(r.issues.map((i) => i.type));
+  assert.ok(types.has('parenthetical-hedge'), 'expected parenthetical-hedge flag');
+});
+
+test('v2: trinary output present + FN-biased for ambiguous text', () => {
+  // A plain human bug-report should not get AI_ONLY even if score lifts.
+  const text = 'The build broke again this morning. Rolled back the auth refactor and tests pass now. Still need to figure out why the token refresh path hits a 401 for users on Safari but not Firefox — probably a cookie scope issue but I want to confirm before shipping a fix.';
+  const r = AIDetector.analyzeText(text);
+  assert.ok(r.document_classification, 'expected document_classification field');
+  assert.ok(['HUMAN_ONLY', 'MIXED'].includes(r.document_classification), `human prose got ${r.document_classification}`);
+  assert.ok(r.class_probabilities, 'expected class_probabilities');
+  const sum = r.class_probabilities.human + r.class_probabilities.mixed + r.class_probabilities.ai;
+  assert.ok(Math.abs(sum - 1) < 0.02, `probabilities should sum to ~1, got ${sum}`);
+  assert.ok(['high', 'medium', 'low'].includes(r.confidence_category), 'expected confidence_category');
+});
+
+test('v2: highly AI-marked text reaches AI_ONLY with corroborators', () => {
+  // High score + cutoff disclaimer (corroborator) → AI_ONLY at high confidence.
+  const text = [
+    "As of my last update, I don't have access to real-time data. In the rapidly evolving world of decentralized finance, we delve into the intricate tapestry of innovation.",
+    'This seamless, robust paradigm showcases a comprehensive framework. Moreover, it truly is a game-changer that underscores how we navigate the complexities of modern AI.',
+    'Furthermore, this pivotal moment marks a watershed for the industry. Let me think step by step about how to approach this systematically. I hope this helps!',
+  ].join(' ');
+  const r = AIDetector.analyzeText(text);
+  assert.equal(r.document_classification, 'AI_ONLY', `expected AI_ONLY, got ${r.document_classification} (score=${r.score})`);
+  assert.ok(['medium', 'high'].includes(r.confidence_category), `expected medium/high confidence, got ${r.confidence_category}`);
+});
+
+test('v2: highlight_sentence_for_ai returns regions with start/end offsets', () => {
+  const text = 'In the rapidly evolving world of AI, we delve into the intricate tapestry. This is a robust, comprehensive paradigm. Plain second paragraph here is just normal prose without any of the tells. The team shipped a fix on Monday afternoon after the rollback completed successfully.';
+  const r = AIDetector.analyzeText(text);
+  assert.ok(Array.isArray(r.highlight_sentence_for_ai), 'expected highlight array');
+  if (r.highlight_sentence_for_ai.length > 0) {
+    const region = r.highlight_sentence_for_ai[0];
+    assert.ok(typeof region.start === 'number', 'region has start offset');
+    assert.ok(typeof region.end === 'number', 'region has end offset');
+    assert.ok(region.end > region.start, 'end > start');
+    assert.ok(typeof region.score === 'number' && region.score >= 0 && region.score <= 1, 'region.score 0-1');
+  }
+});
+
+test('v2: context mode "technical" suppresses Title Case header flag', () => {
+  const text = 'Strategic Negotiations And Key Partnerships\n\nThe team closed three deals this quarter. Each agreement included revenue-share terms and dispute-resolution clauses. The legal review took two weeks per contract on average.';
+  const general = AIDetector.analyzeText(text, { contextMode: 'general' });
+  const technical = AIDetector.analyzeText(text, { contextMode: 'technical' });
+  const generalHas = general.issues.some((i) => i.type === 'title-case-header');
+  const technicalHas = technical.issues.some((i) => i.type === 'title-case-header');
+  assert.ok(generalHas, 'general mode should flag title-case header');
+  assert.ok(!technicalHas, 'technical mode should suppress title-case header');
+});
+
+test('v2: markdown **bold** is preserved by normalize pre-pass', () => {
+  // Regression: lookbehind/lookahead added in review fix. The pre-fix
+  // regex stripped the inner half of `**bold**` and counted each as
+  // a roleplay marker, false-positiving normalization-flag on any
+  // README / Substack post with bold runs.
+  const text = '**First bold** and **another bold** plus **a third one**.';
+  const norm = AIDetector.normalizeText(text);
+  assert.equal(norm.flags.roleplay, 0, `expected roleplay=0 on markdown bold, got ${norm.flags.roleplay}`);
+  assert.ok(norm.text.includes('**First bold**'), 'bold marker preserved');
+});
+
+test('v2: punct-distribution fires on uniform per-paragraph density', () => {
+  // Four paragraphs, each ~30 words, each with the same number of
+  // commas. Uniform punctuation density across paragraphs is the AI
+  // signature this rule catches.
+  const text = [
+    'The protocol design centers on three core principles, including modularity, composability, and forward compatibility, which together enable predictable behavior across many environments and deployment topologies.',
+    'Implementation choices reflect a deliberate preference for simplicity, including small interfaces, narrow contracts, and explicit invariants, which together make the codebase tractable for new contributors and reviewers.',
+    'Testing strategy emphasizes property-based coverage, including invariants, contract tests, and regression fixtures, which together guard against silent behavior changes in performance-critical paths across releases.',
+    'Documentation follows a layered approach, including conceptual overviews, narrative guides, and reference material, which together orient readers without forcing them through any single rigid sequence of pages.',
+  ].join('\n\n');
+  const r = AIDetector.analyzeText(text);
+  const types = new Set(r.issues.map((i) => i.type));
+  assert.ok(types.has('punct-distribution'), 'expected punct-distribution flag on uniform density');
+});
+
+test('v2: cross-para-burstiness fires on uniform sentence rhythm', () => {
+  // Four paragraphs, each with three sentences of similar length.
+  // Std-of-CV across paragraphs is low → flag fires.
+  const text = [
+    'The system processes events synchronously. Each event triggers a downstream handler. The handler updates state immediately.',
+    'The database uses optimistic locking. Concurrent writes retry transparently. The retry budget allows three attempts.',
+    'Authentication relies on signed tokens. Tokens expire after fifteen minutes. Refresh requests issue new tokens.',
+    'Logging captures every state change. The pipeline routes logs centrally. Storage retains entries for ninety days.',
+  ].join('\n\n');
+  const r = AIDetector.analyzeText(text);
+  const types = new Set(r.issues.map((i) => i.type));
+  assert.ok(types.has('cross-para-burstiness'), 'expected cross-para-burstiness on uniform rhythm');
+});
+
+test('v2: invalid contextMode falls back to general with stats.contextModeFallback set', () => {
+  const text = 'Strategic Negotiations And Key Partnerships\n\nThe team closed three deals. Each agreement included revenue-share terms. Legal review took two weeks per contract.';
+  const r = AIDetector.analyzeText(text, { contextMode: 'tecnical' });
+  assert.equal(r.stats.contextMode, 'general', 'invalid mode coerced to general');
+  assert.equal(r.stats.contextModeFallback, 'tecnical', 'fallback echoes original');
+});
+
+test('v2: trinary fields present on tooShort / tooLong / empty as UNSCORED', () => {
+  // Early-exit paths return UNSCORED (not HUMAN_ONLY) so a caller can't
+  // mistake a refused scan for a confident human verdict. A 50k-word
+  // LLM-generated document falling into tooLong is not "human."
+  const empty = AIDetector.analyzeText('');
+  const tooShort = AIDetector.analyzeText('Short text.');
+  const tooLong = AIDetector.analyzeText('word '.repeat(10001));
+  for (const [name, r] of [['empty', empty], ['tooShort', tooShort], ['tooLong', tooLong]]) {
+    assert.equal(r.document_classification, 'UNSCORED', `${name}: expected UNSCORED, got ${r.document_classification}`);
+    assert.equal(r.confidence_category, 'low', `${name}: expected low confidence`);
+    assert.ok(r.class_probabilities, `${name}: missing class_probabilities`);
+    assert.ok(Array.isArray(r.highlight_sentence_for_ai), `${name}: missing highlight array`);
+  }
+  // Empty case has empty stats so contextMode field absent is fine;
+  // tooShort/tooLong should surface contextMode for traceability.
+  assert.equal(tooShort.stats.contextMode, 'general', 'tooShort stats includes contextMode');
+  assert.equal(tooLong.stats.contextMode, 'general', 'tooLong stats includes contextMode');
+});
+
+test('v2: probability fields sum to exactly 1.000 (no float drift)', () => {
+  const texts = [
+    'In the rapidly evolving world of decentralized finance, we delve into the intricate tapestry of innovation. This seamless, robust paradigm showcases a comprehensive framework that catalyzes transformative change across the ecosystem.',
+    'The build broke. Rolled back. Tests pass. Will investigate the root cause tomorrow afternoon after the standup with the on-call engineer.',
+    'A neutral middle paragraph that mixes some flagged words like robust and comprehensive but in normal context, leveraging some technical terms in the way a real engineer might describe their implementation choices over coffee.',
+  ];
+  for (const t of texts) {
+    const r = AIDetector.analyzeText(t);
+    const sum = r.class_probabilities.human + r.class_probabilities.mixed + r.class_probabilities.ai;
+    assert.ok(Math.abs(sum - 1) < 0.0005, `probabilities should sum to exactly 1.000, got ${sum} for: ${t.slice(0, 40)}...`);
+  }
+});
+
+test('v2: mid-score isolated stylometric hits do not reach AI_ONLY', () => {
+  // Pins the FN-bias contract with fail-loud preconditions. If the corpus
+  // drifts and the preconditions break, the test fails on the precondition
+  // assertion (not silently passes). Text designed to have NO strong
+  // corroborators: no cutoff disclaimer, no chatbot artifact, no homoglyph,
+  // no dense-vocab trifecta. Should classify HUMAN_ONLY or MIXED.
+  const text = 'The team continues making progress on the platform. The framework supports many needs. Building collaboration across teams stays important. Improving the deployment path is a goal. The setup gives everyone a foundation.';
+  const r = AIDetector.analyzeText(text);
+  const hasCutoff = r.issues.some((i) => i.type === 'cutoff-disclaimer');
+  const hasReasonChat = r.issues.some((i) => i.type === 'reasoning-artifact') && r.issues.some((i) => i.type === 'chatbot');
+  const hasNorm = r.issues.some((i) => i.type === 'normalization-flag');
+  // Preconditions: assert the test corpus matches the no-strong-corroborator
+  // shape. If these fail, the corpus drifted and the test is meaningless.
+  assert.ok(!hasCutoff, 'precondition: corpus should not trigger cutoff-disclaimer');
+  assert.ok(!hasReasonChat, 'precondition: corpus should not trigger reasoning+chatbot');
+  assert.ok(!hasNorm, 'precondition: corpus should not trigger normalization-flag');
+  assert.ok(r.score < 70, `precondition: corpus score should be < 70, got ${r.score}`);
+  // Contract: without strong corroborators and below the score-only threshold,
+  // never AI_ONLY.
+  assert.notEqual(r.document_classification, 'AI_ONLY', `no-strong-corroborator below score 70 should not be AI_ONLY, got ${r.document_classification} at score ${r.score}`);
+});
+
+test('v2: humanizer bypass escalates to AI_ONLY (normalization-flag corroborator)', () => {
+  const zwsp = '​';
+  const text = `In tоday's landscape we del${zwsp}ve into the intricate tap${zwsp}estry of innovátion. This seamless, robust paradigm showcases comprehensive frameworks. The framework underscores how organizations harness cutting-edge tools to navigate complexities across the ecosystem.`;
+  const r = AIDetector.analyzeText(text);
+  assert.equal(r.document_classification, 'AI_ONLY', `bypass should reach AI_ONLY, got ${r.document_classification}`);
+  assert.ok(['medium', 'high'].includes(r.confidence_category), `bypass should not be low-confidence, got ${r.confidence_category}`);
+});
+
+test('v2: canonical saturated-AI essay reaches AI_ONLY (calibration regression)', () => {
+  // Regression for review finding: pre-recalibration this text scored
+  // ~47/MIXED. AI_ONLY was effectively dead code. Threshold now lets
+  // a saturated essay actually fire.
+  const text = 'In today\'s rapidly evolving landscape, we delve into the intricate tapestry of decentralized finance. It is important to note that this seamless, robust paradigm showcases a comprehensive framework. Moreover, this transformative ecosystem leverages cutting-edge protocols to navigate the complex multifaceted challenges of modern finance. Furthermore, the integration of innovative solutions underscores how pivotal this moment is. The future looks bright for those who embrace these emerging opportunities. By harnessing the power of blockchain technology, organizations can foster unprecedented growth and catalyze meaningful change across the ecosystem.';
+  const r = AIDetector.analyzeText(text);
+  assert.equal(r.document_classification, 'AI_ONLY', `saturated essay should AI_ONLY, got ${r.document_classification} at score ${r.score}`);
+});
+
+test('v2: legitimate *italic phrase* is NOT stripped by roleplay rule', () => {
+  // Round-2 fix: roleplay regex now requires an action-verb prefix
+  // (nods/sighs/laughs/etc.). Markdown italic with arbitrary multi-word
+  // content like *italic phrase here* should survive untouched.
+  const text = 'We use *italic phrase here* for emphasis and *another phrase too* in some places.';
+  const norm = AIDetector.normalizeText(text);
+  assert.equal(norm.flags.roleplay, 0, `expected roleplay=0 on plain italic, got ${norm.flags.roleplay}`);
+  assert.ok(norm.text.includes('*italic phrase here*'), 'italic preserved');
+});
+
+test('v2: *roleplay action verb* IS stripped', () => {
+  // The actual chat-model artifact — verb-led action description.
+  const text = 'I think about the problem *nods thoughtfully* and consider the options *sighs deeply* before answering.';
+  const norm = AIDetector.normalizeText(text);
+  assert.ok(norm.flags.roleplay >= 2, `expected ≥2 roleplay strips, got ${norm.flags.roleplay}`);
+});
+
+test('v2: single ZWSP does not flip to AI_ONLY (hair-trigger fix)', () => {
+  // Common in copy-paste from Word/Notion/Slack-rendered text. Round-1
+  // made single ZWSP a strong corroborator → AI_ONLY at score 0. Round-2
+  // raised the threshold to ≥2 for parity with homoglyph.
+  const zwsp = '​';
+  const text = `Our team shipped a fix on Monday${zwsp} afternoon. Tests pass and the deploy is green. Everything looks good. Plain human text with one accidental zero-width character pasted from a Notion doc.`;
+  const r = AIDetector.analyzeText(text);
+  assert.notEqual(r.document_classification, 'AI_ONLY', `single ZWSP should not flip to AI_ONLY, got ${r.document_classification}`);
+});
+
+test('v2: dense-AI-vocab trifecta reaches AI_ONLY (calibration regression)', () => {
+  // Saturated ChatGPT prose without cutoff/chatbot/normalization should
+  // still reach AI_ONLY via the dense-AI-vocab strong corroborator
+  // (≥4 tier1 distinct + tier2 cluster + transition). Round-1 left this
+  // class of essay stuck at MIXED.
+  const text = 'In the rapidly evolving world of decentralized finance, organizations leverage robust and comprehensive frameworks. Moreover, this seamless paradigm enables them to navigate the intricate tapestry of modern challenges. Furthermore, they harness cutting-edge tools to foster sustainable growth and catalyze transformative change. Additionally, the platform showcases meticulous attention to user experience across the ecosystem.';
+  const r = AIDetector.analyzeText(text);
+  assert.equal(r.document_classification, 'AI_ONLY', `dense AI vocab should AI_ONLY, got ${r.document_classification} at score ${r.score}`);
+});
+
+test('v2: blockquoted AI text does not penalize the human wrapper', () => {
+  // A human reacting to AI text by quoting it shouldn't have the quoted
+  // block scored against their own prose. The `> ` lines get stripped
+  // in a pre-pass and the count surfaces in stats.quotedLines.
+  const text = [
+    'I asked ChatGPT to describe my project and got this response:',
+    '',
+    '> In the rapidly evolving world of decentralized finance, we delve into the intricate tapestry of innovation.',
+    '> This seamless, robust paradigm showcases a comprehensive framework that catalyzes transformative change.',
+    '> Moreover, this represents a pivotal moment in the ecosystem.',
+    '',
+    'The response was pretty bad. I rewrote it as a normal sentence about what we actually do.',
+  ].join('\n');
+  const r = AIDetector.analyzeText(text);
+  assert.ok(r.stats.quotedLines >= 3, `expected quotedLines >= 3, got ${r.stats.quotedLines}`);
+  assert.notEqual(r.document_classification, 'AI_ONLY', `human wrapping AI quote should not classify AI_ONLY, got ${r.document_classification}`);
+});
+
+test('v2: probability sum is exactly 1 with no negative components', () => {
+  // Round-2 fix: clamp p.ai to >= 0 after the remainder calculation
+  // since toFixed(3) rounding can push human+mixed slightly above 1.
+  const texts = [
+    'In the rapidly evolving world of decentralized finance, we delve into the intricate tapestry of innovation. This seamless, robust paradigm showcases a comprehensive framework that catalyzes transformative change across the ecosystem. Furthermore, this pivotal moment marks a fundamental shift.',
+    'The build broke. Rolled back. Tests pass.',
+    'A neutral middle paragraph that mixes some words like robust and comprehensive in normal context, leveraging technical terms the way a real engineer might describe their implementation choices over coffee with a teammate.',
+    '',
+    'word '.repeat(11000),
+  ];
+  for (const t of texts) {
+    const r = AIDetector.analyzeText(t);
+    const { human, mixed, ai } = r.class_probabilities;
+    assert.ok(human >= 0, `human prob negative: ${human}`);
+    assert.ok(mixed >= 0, `mixed prob negative: ${mixed}`);
+    assert.ok(ai >= 0, `ai prob negative: ${ai}`);
+    const sum = human + mixed + ai;
+    assert.ok(Math.abs(sum - 1) < 0.002, `sum should be ~1, got ${sum} for: ${(t || '<empty>').slice(0, 40)}`);
+  }
+});
+
+test('v2: unmappedHighlights counter surfaced in stats', () => {
+  const r = AIDetector.analyzeText('We delve into the landscape of innovation and continue to navigate the comprehensive transformation.');
+  assert.equal(typeof r.stats.unmappedHighlights, 'number', 'unmappedHighlights should be numeric');
+});
+
+test('v2: real Rust technical post does NOT classify AI_ONLY (denseAIVocab FP fix)', () => {
+  // Round-3 regression: pre-fix this scored AI_ONLY at 30 because
+  // denseAIVocab required only 4 tier1 + 1 tier2 cluster + transition,
+  // which legitimate dense-jargon technical writing trips. Threshold
+  // raised to 5 tier1 + 2 tier2 clusters + 150-word gate.
+  const text = 'Rust offers a robust and comprehensive approach to systems programming. Engineers leverage zero-cost abstractions to navigate intricate memory hierarchies without runtime overhead. The borrow checker provides meticulous compile-time guarantees that catch entire categories of bugs. Furthermore, the type system encourages a holistic approach to API design where contracts are explicit. The ecosystem around cargo, crates.io, and the Rust toolchain has matured significantly over the past five years, with libraries spanning embedded systems, web servers, and game engines.';
+  const r = AIDetector.analyzeText(text);
+  assert.notEqual(r.document_classification, 'AI_ONLY', `Rust tech post should not classify AI_ONLY, got ${r.document_classification} at score ${r.score}`);
+});
+
+test('v2: canonical "As an AI language model" disclaimer fires cutoff-disclaimer + AI_ONLY', () => {
+  // Round-3 finding: this canonical LLM self-id phrase was missing
+  // entirely from CUTOFF_DISCLAIMERS.
+  const text = 'As an AI language model, I cannot provide legal advice on this matter. However, I can suggest you consult a licensed attorney. The general principle is that contract law varies by jurisdiction and specific facts matter.';
+  const r = AIDetector.analyzeText(text);
+  const types = new Set(r.issues.map((i) => i.type));
+  assert.ok(types.has('cutoff-disclaimer'), 'expected cutoff-disclaimer flag on AI language model self-id');
+  assert.equal(r.document_classification, 'AI_ONLY', `expected AI_ONLY on canonical disclaimer, got ${r.document_classification}`);
+  assert.equal(r.confidence_category, 'high', `expected high confidence on canonical disclaimer, got ${r.confidence_category}`);
+});
+
+test('v2: single-line shell prompt > is NOT stripped as blockquote', () => {
+  // Blockquote strip now requires ≥2 consecutive lines.
+  const text = 'To check the directory:\n\n> ls -la\n\nThen review the output and look for any unexpected files. The team uses this command frequently when debugging deployment issues that involve filesystem permissions.';
+  const r = AIDetector.analyzeText(text);
+  assert.equal(r.stats.quotedLines, 0, `single > line should not strip, got quotedLines=${r.stats.quotedLines}`);
+});
+
+test('v2: stats.denseAIVocab and stats.tier1Distinct surface for observability', () => {
+  const r = AIDetector.analyzeText('We delve into the landscape with robust comprehensive seamless innovative cutting-edge solutions.');
+  assert.equal(typeof r.stats.denseAIVocab, 'boolean', 'denseAIVocab should be boolean');
+  assert.equal(typeof r.stats.tier1Distinct, 'number', 'tier1Distinct should be number');
+});
+
+test('v2: backward compat — score, label, issues, stats still present', () => {
+  const r = AIDetector.analyzeText('We delve into the landscape of leveraging robust paradigms. The team continues to navigate this comprehensive transformation.');
+  assert.ok(typeof r.score === 'number', 'score still numeric');
+  assert.ok(typeof r.label === 'string', 'label still string');
+  assert.ok(Array.isArray(r.issues), 'issues still array');
+  assert.ok(r.stats && typeof r.stats === 'object', 'stats still object');
+});
+
+if (failed > 0) {
+  console.error(`\n${failed} test(s) failed`);
+  process.exit(1);
+}
+console.log('\nAll detector fixtures passed.');

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
     "node": ">=18"
   },
   "scripts": {
-    "test": "node detector/patterns.test.js"
+    "test": "node detector/patterns.test.js && node detector/categories.test.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "avoid-ai-writing-detector",
+  "version": "3.4.0",
+  "description": "Deterministic detection engine for the Avoid AI Writing skill — 43-category pattern + stylometric analysis of AI-generated text.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/conorbronsdon/avoid-ai-writing.git"
+  },
+  "main": "detector/patterns.js",
+  "files": [
+    "detector/patterns.js"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "test": "node detector/patterns.test.js"
+  }
+}


### PR DESCRIPTION
## Summary

Extracts the 43-category detection engine + its dependency-free Node test harness from the (winding-down) private web-app repo into `detector/`, making this open-source repo the canonical source of truth for **both** the human-readable rules (`SKILL.md`) and their executable expression (`detector/patterns.js`).

Previously the engine lived only in the private app, where it was wrapped by cert/attestation/x402 token-project code. That wrapper layer stays behind — `patterns.js` is a pure function with no knowledge of it.

## What's here

- **`detector/patterns.js`** — zero-dependency, build-step-free engine. Runs identically in Node (`>=18`) and the browser. Header updated to mark this repo as SSOT (tracks `SKILL.md` v3.4.0).
- **`detector/patterns.test.js`** — 60 fixtures, no deps (`node:assert/strict`).
- **`package.json` + CI** — `npm test` runs the fixtures; `.github/workflows/detector-test.yml` runs on push/PR touching `detector/`.
- **`detector/CATEGORIES.md`** — anti-drift contract mapping `SKILL.md` sections ↔ detector `type`s (34 direct maps, 5 detector-only stylometric signals, 10 LLM-only judgment rules).
- **`detector/README.md`** — full `analyzeText` API.
- **`README.md`** — adds a "Run the detector" section.

## Test plan

- [x] `npm test` → all 60 detector fixtures pass (EXIT=0)
- [x] Leak scan: no `\$avoid`/cert/attestation/x402/wallet coupling or private-repo paths in the moved files
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)