### PR TITLE
Distribute as a Claude Code / Cowork plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
+  "name": "conorbronsdon-skills",
+  "description": "Conor Bronsdon's public Claude Code / Cowork skills.",
+  "owner": {
+    "name": "Conor Bronsdon"
+  },
+  "plugins": [
+    {
+      "name": "avoid-ai-writing",
+      "source": "./plugins/avoid-ai-writing",
+      "description": "Audit & rewrite content to remove AI writing patterns (\"AI-isms\"). Supports detection-only mode.",
+      "category": "productivity",
+      "keywords": ["writing", "editing", "ai-detection", "humanize"]
+    }
+  ]
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.sh text eol=lf
+*.md text eol=lf

--- a/.github/workflows/plugin-skill-sync.yml
+++ b/.github/workflows/plugin-skill-sync.yml
@@ -1,0 +1,40 @@
+name: plugin-skill-sync
+
+on:
+  pull_request:
+    paths:
+      - "SKILL.md"
+      - "plugins/**"
+      - ".claude-plugin/**"
+      - "scripts/sync-plugin-skill.sh"
+  push:
+    branches: [main]
+    paths:
+      - "SKILL.md"
+      - "plugins/**"
+      - ".claude-plugin/**"
+      - "scripts/sync-plugin-skill.sh"
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate manifest JSON
+        run: |
+          python3 -m json.tool .claude-plugin/marketplace.json > /dev/null
+          python3 -m json.tool plugins/avoid-ai-writing/.claude-plugin/plugin.json > /dev/null
+
+      - name: Regenerate bundled skill + check version
+        run: bash scripts/sync-plugin-skill.sh
+
+      - name: Fail if the bundled skill drifted from SKILL.md
+        run: |
+          if ! git diff --quiet; then
+            echo "::error::plugins/avoid-ai-writing/skills/avoid-ai-writing/SKILL.md is out of sync with the root SKILL.md."
+            echo "Run 'bash scripts/sync-plugin-skill.sh' and commit the result."
+            git --no-pager diff --stat
+            exit 1
+          fi
+          echo "bundled skill is in sync"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A one-shot "make this sound human" prompt catches the obvious stuff. This skill 
 - **109-entry word replacement table across 3 tiers + 10 Tier 3 phrases** — not vibes-based. Every flagged word has a specific, plainer alternative. "Leverage" → "use." "Commence" → "start." Tier 1 words always flag, Tier 2 words flag when they cluster, Tier 3 words flag only at high density. Tier 3 *phrases* (multi-word boilerplate like "the integration of," "decentralized compute") flag on per-phrase repetition or when 3+ distinct phrases stack in one piece — the LLM-self-varies-boilerplate shape.
 - **42 pattern categories** — see the full list below, each with before/after examples. Includes structural detection (hashtag stuffing, bare-NP bullet lists, hedge-stacked predictions), rhythm/uniformity checks, and a rewrite-vs-patch threshold.
 - **Detect mode** — flag patterns without rewriting. See which flags are real problems vs. judgment calls. Useful when patterns might be intentional or you're auditing content you don't want altered.
-- **Works with Claude Code and OpenClaw** — single `SKILL.md` with compatible frontmatter for both platforms.
+- **Works across platforms** — one `SKILL.md` runs in Claude Code, Cowork (as a plugin), OpenClaw, and Cursor (as a ported rule). See the install paths below.
 
 ## Installation & Usage
 
@@ -74,12 +74,20 @@ Read and follow the instructions in ~/.claude/skills/avoid-ai-writing/SKILL.md
 
 Then use `/clean-ai-writing <your text>` in Claude Code.
 
-### Claude Cowork
+### Claude Cowork — install as a plugin
 
-[Cowork](https://www.anthropic.com/cowork) discovers skills only from **installed plugins** — it doesn't scan `~/.claude/skills/`, so cloning there (the Claude Code step above) won't surface the skill in a Cowork session. Two paths work:
+[Cowork](https://www.anthropic.com/cowork) loads skills only from **installed plugins** — it doesn't scan `~/.claude/skills/`, so a bare clone (the Claude Code steps above) won't be discovered there. This repo doubles as a single-plugin [marketplace](https://code.claude.com/docs/en/plugin-marketplaces), so install it as a plugin instead:
 
-- **One-off (manual reference).** Copy `SKILL.md` into a folder connected to your Cowork session, then tell the agent to follow `./SKILL.md`. No auto-trigger.
-- **Auto-trigger (wrap as a plugin).** Package `SKILL.md` into a plugin using Cowork's built-in plugin-creation tool (the "Plugin Create" plugin). Once installed, the skill fires from phrases like "remove AI-isms," same as in Claude Code.
+```bash
+/plugin marketplace add conorbronsdon/avoid-ai-writing
+/plugin install avoid-ai-writing@conorbronsdon-skills
+```
+
+In the Cowork desktop app, do the same from **Customize → Plugins → Add marketplace from GitHub** (`conorbronsdon/avoid-ai-writing`), then install **avoid-ai-writing**. The skill auto-triggers from phrases like "remove AI-isms," and `/plugin marketplace update` pulls new releases.
+
+The same plugin install works in Claude Code if you'd rather have a versioned, updatable plugin than the file clone above.
+
+> Prefer not to install a plugin? Copy `SKILL.md` into a folder connected to your Cowork session and tell the agent to follow `./SKILL.md` — works as a one-off, no auto-trigger.
 
 ### OpenClaw
 

--- a/README.md
+++ b/README.md
@@ -81,9 +81,10 @@ Then use `/clean-ai-writing <your text>` in Claude Code.
 ```bash
 /plugin marketplace add conorbronsdon/avoid-ai-writing
 /plugin install avoid-ai-writing@conorbronsdon-skills
+/reload-plugins   # or restart the session, to activate the skill
 ```
 
-In the Cowork desktop app, do the same from **Customize → Plugins → Add marketplace from GitHub** (`conorbronsdon/avoid-ai-writing`), then install **avoid-ai-writing**. The skill auto-triggers from phrases like "remove AI-isms," and `/plugin marketplace update` pulls new releases.
+In the Cowork desktop app, do the same from **Customize → Plugins → Add marketplace from GitHub** (`conorbronsdon/avoid-ai-writing`), then install **avoid-ai-writing**. The skill auto-triggers from phrases like "remove AI-isms." New releases arrive when the plugin's version is bumped — run `/plugin marketplace update` to pull them.
 
 The same plugin install works in Claude Code if you'd rather have a versioned, updatable plugin than the file clone above.
 

--- a/plugins/avoid-ai-writing/.claude-plugin/plugin.json
+++ b/plugins/avoid-ai-writing/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "avoid-ai-writing",
+  "description": "Audit & rewrite content to remove AI writing patterns (\"AI-isms\"). Supports detection-only mode.",
+  "version": "3.4.0",
+  "author": {
+    "name": "Conor Bronsdon"
+  },
+  "homepage": "https://github.com/conorbronsdon/avoid-ai-writing",
+  "repository": "https://github.com/conorbronsdon/avoid-ai-writing",
+  "license": "MIT",
+  "keywords": ["writing", "editing", "ai-detection", "humanize"]
+}

--- a/plugins/avoid-ai-writing/skills/avoid-ai-writing/SKILL.md
+++ b/plugins/avoid-ai-writing/skills/avoid-ai-writing/SKILL.md
@@ -1,0 +1,566 @@
+---
+name: avoid-ai-writing
+description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Use this skill when asked to "remove AI-isms," "clean up AI writing," "edit writing for AI patterns," "audit writing for AI tells," or "make this sound less like AI." Supports a detection-only mode that flags patterns without rewriting.
+version: 3.4.0
+license: MIT
+compatibility: Any AI coding assistant that supports agentskills.io SKILL.md format (Claude Code, Cursor, VS Code Copilot, Hermes Agent, OpenHands, etc.) or OpenClaw. No external tools or APIs required.
+metadata:
+  author: Conor Bronsdon
+  tags: writing editing voice quality
+  agentskills_spec: "1.0"
+  openclaw:
+    emoji: "\u270D\uFE0F"
+---
+
+# Avoid AI Writing — Audit & Rewrite
+
+You are editing content to remove AI writing patterns ("AI-isms") that make text sound machine-generated.
+
+## What this skill is and isn't
+
+This is a **writing-quality tool**, not a verdict. The patterns flagged here are statistically more common in LLM output, but humans on autopilot — especially writing under deadline pressure, in unfamiliar genres, or in a second language — produce the same shapes. Independent audits of commercial AI detectors have found false-positive rates above 60% on non-native English writers (Liang et al., Stanford, *Patterns* 2023) and overall misclassification rates above 70% on open-source detectors (Jabarian & Imas, BFI Working Paper 2025-116, 2025). Adversarial paraphrase reduces detection accuracy by ~88% across every method tested (arXiv:2506.07001, 2025).
+
+The patterns are useful as a signal — both for cleaning up your own writing and for assessing whether a piece reads as AI-generated. Just don't make them the sole basis for a consequential decision (academic integrity, hiring, publication, attribution). Several rules here also fire on second-language writing, deadline-pressed humans, and technical genres that compress vocabulary by design. Pair the signal with context: who wrote it, what genre, what the writer's normal voice looks like, what other evidence you have.
+
+In short: signals, not proof. Worth acting on; not worth ruining someone's day over.
+
+## Modes
+
+This skill operates in one of two modes:
+
+**`rewrite`** (default) — Flag AI-isms and rewrite the text to fix them.
+
+**`detect`** — Flag AI-isms only. No rewriting. Use this mode when:
+- The writer wants to see what's flagged and decide what to fix themselves
+- The flagged patterns might be intentional (AI patterns aren't always bad — they can be effective in small doses)
+- You're auditing text you don't want altered (published content, someone else's writing, reference material)
+- You want a quick scan without waiting for a full rewrite
+
+Trigger detect mode when the user says "detect," "flag only," "audit only," "just flag," "scan," "what AI patterns are in this," or similar. Default to rewrite mode if not specified.
+
+---
+
+In **rewrite** mode, your job is to:
+
+1. **Audit it**: identify every AI-ism present, citing the specific text
+2. **Rewrite it**: return a clean version with all AI-isms removed
+3. **Show a diff summary**: briefly list what you changed and why
+
+In **detect** mode, your job is to:
+
+1. **Audit it**: identify every AI-ism present, citing the specific text
+2. **Assess it**: note which flags are clear problems vs. patterns that may be intentional or effective in context
+
+---
+
+## What to remove or fix
+
+### Formatting
+- **Em dashes (— and --)**: Replace with commas, periods, parentheses, or rewrite as two sentences. Target: zero. Hard max: one per 1,000 words. This applies to headings and section titles too, not just body prose. Catch both the Unicode em dash (—) and the double-hyphen substitute (--).
+- **Bold overuse**: Strip bold from most phrases. One bolded phrase per major section at most, or none. If something's important enough to bold, restructure the sentence to lead with it instead.
+- **Emoji in headers**: Remove entirely. No `## 🚀 What This Means`. Exception: social posts may use one or two emoji sparingly — at the end of a line, never mid-sentence.
+- **Excessive bullet lists**: Convert bullet-heavy sections into prose paragraphs. Bullets only for genuinely list-like content (feature comparisons, step-by-step instructions, API parameters).
+
+### Sentence structure
+- **"It's not X — it's Y" / "This isn't about X, it's about Y"**: Rewrite as a direct positive statement. Max one per piece, and only if it serves the argument.
+- **Hollow intensifiers**: Cut `genuine`, `real` (as in "a real improvement"), `truly`, `quite frankly`, `to be honest`, `let's be clear`, `it's worth noting that`. Just state the fact.
+- **Vague endorsement ("worth [verb]ing")**: Cut or replace `worth reading`, `worth paying attention to`, `worth a look`, `worth exploring`, `worth checking out`, `worth your time`. These substitute a generic thumbs-up for a specific reason. Say *why* something matters instead.
+- **Hedging**: Cut `perhaps`, `could potentially`, `it's important to note that`, `to be clear`. Make the point directly.
+- **Missing bridge sentences**: Each paragraph should connect to the last. If paragraphs could be rearranged without the reader noticing, add connective tissue.
+- **Compulsive rule of three**: Vary groupings. Use two items, four items, or a full sentence instead of triads. Max one "adjective, adjective, and adjective" pattern per piece.
+
+### Words and phrases to replace
+
+Words are organized into three tiers based on how reliably they signal AI-generated text. This tiered approach — adapted from [brandonwise/humanizer](https://github.com/brandonwise/humanizer)'s vocabulary research — reduces false positives on words that are fine in isolation but suspicious in clusters.
+
+- **Tier 1 — Always flag.** These words appear 5–20x more often in AI text than human text. Replace on sight.
+- **Tier 2 — Flag in clusters.** Individually fine, but two or more in the same paragraph is a strong AI signal. Flag when they appear together.
+- **Tier 3 — Flag by density.** Common words that AI simply overuses. Only flag when they make up a noticeable fraction of the text (roughly 3%+ of total words).
+
+#### Tier 1 — Always replace
+
+| Replace | With |
+|---|---|
+| delve / delve into | explore, dig into, look at |
+| landscape (metaphor) | field, space, industry, world |
+| tapestry | (describe the actual complexity) |
+| realm | area, field, domain |
+| paradigm | model, approach, framework |
+| embark | start, begin |
+| beacon | (rewrite entirely) |
+| testament to | shows, proves, demonstrates |
+| robust | strong, reliable, solid |
+| comprehensive | thorough, complete, full |
+| cutting-edge | latest, newest, advanced |
+| leverage (verb) | use |
+| pivotal | important, key, critical |
+| underscores | highlights, shows |
+| meticulous / meticulously | careful, detailed, precise |
+| seamless / seamlessly | smooth, easy, without friction |
+| game-changer / game-changing | describe what specifically changed and why it matters |
+| hit differently / hits different | (say what specifically changed, or cut) |
+| utilize | use |
+| watershed moment | turning point, shift (or describe what changed) |
+| marking a pivotal moment | (state what happened) |
+| the future looks bright | (cut — say something specific or nothing) |
+| only time will tell | (cut — say something specific or nothing) |
+| nestled | is located, sits, is in |
+| vibrant | (describe what makes it active, or cut) |
+| thriving | growing, active (or cite a number) |
+| despite challenges… continues to thrive | (name the challenge and the response, or cut) |
+| showcasing | showing, demonstrating (or cut the clause) |
+| deep dive / dive into | look at, examine, explore |
+| unpack / unpacking | explain, break down, walk through |
+| bustling | busy, active (or cite what makes it busy) |
+| intricate / intricacies | complex, detailed (or name the specific complexity) |
+| complexities | (name the actual complexities, or use "problems" / "details") |
+| ever-evolving | changing, growing (or describe how) |
+| enduring | lasting, long-running (or cite how long) |
+| daunting | hard, difficult, challenging |
+| holistic / holistically | complete, full, whole (or describe what's included) |
+| actionable | practical, useful, concrete |
+| impactful | effective, significant (or describe the impact) |
+| learnings | lessons, findings, takeaways |
+| thought leader / thought leadership | expert, authority (or describe their actual contribution) |
+| best practices | what works, proven methods, standard approach |
+| at its core | (cut — just state the thing) |
+| synergy / synergies | (describe the actual combined effect) |
+| interplay | relationship, connection, interaction |
+| in order to | to |
+| due to the fact that | because |
+| serves as | is |
+| features (verb) | has, includes |
+| boasts | has |
+| presents (inflated) | is, shows, gives |
+| commence | start, begin |
+| ascertain | find out, determine, learn |
+| endeavor | effort, attempt, try |
+| keen (as intensifier) | interested, eager, enthusiastic (or cut — just state the interest) |
+| symphony (metaphor) | (describe the actual coordination or combination) |
+| embrace (metaphor) | adopt, accept, use, switch to |
+
+#### Tier 2 — Flag when 2+ appear in the same paragraph
+
+These words are legitimate on their own. When two or more show up together, the paragraph likely needs a rewrite.
+
+| Replace | With |
+|---|---|
+| harness | use, take advantage of |
+| navigate / navigating | work through, handle, deal with |
+| foster | encourage, support, build |
+| elevate | improve, raise, strengthen |
+| unleash | release, enable, unlock |
+| streamline | simplify, speed up |
+| empower | enable, let, allow |
+| bolster | support, strengthen, back up |
+| spearhead | lead, drive, run |
+| resonate / resonates with | connect with, appeal to, matter to |
+| revolutionize | change, transform, reshape (or describe what changed) |
+| facilitate / facilitates | enable, help, allow, run |
+| underpin | support, form the basis of |
+| nuanced | specific, subtle, detailed (or name the actual nuance) |
+| crucial | important, key, necessary |
+| multifaceted | (describe the actual facets, or cut) |
+| ecosystem (metaphor) | system, community, network, market |
+| myriad | many, numerous (or give a number) |
+| plethora | many, a lot of (or give a number) |
+| encompass | include, cover, span |
+| catalyze | start, trigger, accelerate |
+| reimagine | rethink, redesign, rebuild |
+| galvanize | motivate, rally, push |
+| augment | add to, expand, supplement |
+| cultivate | build, develop, grow |
+| illuminate | clarify, explain, show |
+| elucidate | explain, clarify, spell out |
+| juxtapose | compare, contrast, set side by side |
+| paradigm-shifting | (describe what actually shifted) |
+| transformative / transformation | (describe what changed and how) |
+| cornerstone | foundation, basis, key part |
+| paramount | most important, top priority |
+| poised (to) | ready, set, about to |
+| burgeoning | growing, emerging (or cite a number) |
+| nascent | new, early-stage, emerging |
+| quintessential | typical, classic, defining |
+| overarching | main, central, broad |
+| underpinning / underpinnings | basis, foundation, what supports |
+
+#### Tier 3 — Flag only at high density
+
+These are normal words. Only flag them when the text is saturated with them — a sign that AI filled space with vague praise instead of specifics.
+
+| Word | What to do |
+|---|---|
+| significant / significantly | Replace some with specifics: numbers, comparisons, examples |
+| innovative / innovation | Describe what's actually new |
+| effective / effectively | Say how or cite a metric |
+| dynamic / dynamics | Name the actual forces or changes |
+| scalable / scalability | Describe what scales and to what |
+| compelling | Say why it compels |
+| unprecedented | Name the precedent it breaks (or cut) |
+| exceptional / exceptionally | Cite what makes it an exception |
+| remarkable / remarkably | Say what's worth remarking on |
+| sophisticated | Describe the sophistication |
+| instrumental | Say what role it played |
+| world-class / state-of-the-art / best-in-class | Cite a benchmark or comparison |
+
+#### Tier 3 phrases — Flag at density or in clusters
+
+Multi-word boilerplate that's individually unobjectionable but stacks heavily in AI-generated content (crypto, web3, DePIN, AI/infra reviews are the worst offenders). Flag at **2+ uses of the same phrase** (the per-phrase rule — lower threshold than single-word Tier 3 because a two-word match repeated twice is already stronger evidence than re-using "significant"), *plus* a **cluster rule**: three or more *distinct* phrases from this table in one piece is a strong signal even when each phrase only appears once — that's the shape LLMs take when they vary their own boilerplate to seem less repetitive.
+
+| Phrase | What to do |
+|---|---|
+| emerging sector / emerging space / emerging category | Name the actual sector or what's emerging about it |
+| the integration of (X with Y) | Describe what's being integrated and what changes for the user |
+| the intersection of (X and Y) | Pick the specific overlap that matters or cut the framing |
+| community-driven | Name what the community does. "Community-driven" alone is filler |
+| long-term sustainability | Cite the time horizon and the constraint. "Long-term" is hand-waving |
+| user engagement | Name the action. "Engagement" is a wrapper around clicks/comments/retention |
+| decentralized compute | Specify the architecture or cut. The phrase has become a category label, not a claim |
+| (sustainable) reward emissions | Cite the emission schedule and the sink |
+| tokenized incentive structures | Describe the actual mechanism (vesting, gauge, bonded LP, etc.) |
+| designed for long-term [X] | Cut "designed for" — either it is or it isn't. Then state the property |
+
+### Template phrases (avoid)
+
+These slot-fill constructions signal that a sentence was generated, not written. If a phrase has a blank where a noun or adjective could go and still sound the same, it's too generic.
+
+- "a [adjective] step towards [adjective] AI infrastructure" → describe the specific capability, benchmark, or outcome
+- "a [adjective] step forward for [noun]" → same rule: say what actually changed
+- "Whether you're [X] or [Y]" → false-breadth construction. Pick the audience you're actually addressing, or cut. "Whether you're a startup founder or an enterprise architect" means nothing — it's just "everyone."
+- "I recently had the pleasure of [verb]-ing" → review/social AI pattern. Just say what happened: "I talked to," "I read," "I attended."
+
+### Transition phrases to remove or rewrite
+- "Moreover" / "Furthermore" / "Additionally" → restructure so the connection is obvious, or use "and," "also," "on top of that"
+- "In today's [X]" / "In an era where" → cut or state specific context
+- "It's worth noting that" / "Notably" → just state the fact
+- "Here's what's interesting" / "Here's what caught my eye" / "Here's what stood out" → reader-steering frames. Let the content signal its own importance. If you need a lead-in, make it specific: "The revenue number matters because..." not "Here's the interesting part."
+- "In conclusion" / "In summary" / "To summarize" → your conclusion should be obvious
+- "When it comes to" → just talk about the thing directly
+- "At the end of the day" → cut
+- "That said" / "That being said" → cut or use "but," "yet," or "however." Don't overuse any one of them.
+
+### Structural issues
+- **Uniform paragraph length**: Vary deliberately. Include some 1-2 sentence paragraphs and some longer ones. If every paragraph is roughly the same size, fix it.
+- **Formulaic openings**: If the piece opens with broad context before getting to the point ("In the rapidly evolving world of..."), rewrite to lead with the news or the insight. Context can come second.
+- **Suspiciously clean grammar**: Don't sand away all personality. Deliberate fragments, sentences starting with "And" or "But," comma splices for effect: if the natural voice uses them, keep them.
+
+### Significance inflation
+- Phrases like "marking a pivotal moment in the evolution of..." or "a watershed moment for the industry" inflate routine events into history-making ones. State what happened and let the reader judge significance.
+- If the sentence still works after you delete the inflation clause, delete it.
+
+### Generic future-narrative closers
+- "May become one of the most important narratives of the next market cycle," "could become the defining trend of the coming decade," "is poised to become the next major chapter in [X]." AI defaults to this shape when it needs to land a closing thought without committing to a falsifiable claim. The closer is grammatically a prediction but contains no testable content.
+- Pattern: modal (may / could / will / is poised to) + "become" + (one of) the most [adjective] + (narrative / story / trend / theme / chapter / movement / force).
+- Fix: pick the falsifiable version. "DePIN compute may exceed AWS spot pricing for embarrassingly parallel workloads by 2027" is a prediction. "The intersection of AI and DePIN may become one of the most important narratives of the next market cycle" is not.
+
+### Hedge-stacked predictions
+- Stacking a modal with a hedge adverb: "could potentially create," "may eventually unlock," "might ultimately transform." Either word alone is acceptable; the stack is the tell. Each hedge cancels the next, leaving a sentence that asserts nothing while sounding cautious and thoughtful.
+- Fix: pick one. If you mean "could create," say that. If you mean "potentially creates," say that. Both together is filler.
+
+### "Real/actual" adjective inflation
+- "Real on-chain tokenomics," "actual reward sustainability," "genuine utility," "true product-market fit." Using `real` / `actual` / `genuine` / `true` as an empty intensifier on an abstract noun implies the rest of the field is fake or superficial — without naming what makes this instance the real one. Common in crypto/AI/web3 content where the writer wants to signal sophistication.
+- Distinct from the existing "hollow intensifiers" rule (genuine / truly / quite frankly as sentence-level hedges). This is the noun-modifier form, where the intensifier latches onto an abstract noun to manufacture a contrast that goes unsaid.
+- **Carve-out — named contrast:** if the sentence explicitly names what the fake/superficial version is, leave it. "Real on-chain settlement, not bridged IOUs" or "actual revenue from paying customers, not grants" is honest contrastive writing. The AI tell is the unsaid contrast.
+- Fix when no contrast is named: drop the adjective and add the specific claim. "Reward sustainability" → "rewards funded from $X/mo in fees rather than emissions."
+
+### Hashtag stuffing
+- Long trailing hashtag blocks (6+ hashtags on a single short post) are near-universal in LLM-generated social content and rare in thoughtful human posts. The block usually mixes a project-specific tag with broad category tags (#AI #Crypto #Web3 #Innovation #FutureTech #Technology) — the categorical ones do nothing for discoverability and read as bot output.
+- **Why 6?** Empirical floor. LinkedIn and X organic engagement plateaus or declines past 3-5 tags; human posts that exceed 5 are usually launch posts trading reach for engagement, while LLM-generated posts default to 10-15. Six is the threshold where false positives on legitimate human use start dropping below false negatives on AI output. The detector treats 6+ as a hard flag; the spec treats 5+ as a soft tell worth a second look on `linkedin` and `investor-email` profiles.
+- Fix: 2-3 specific tags max, or none. If a hashtag wouldn't help a reader find related work, it's filler.
+
+### Bullet lists of bare noun phrases
+- A list of 5+ consecutive bullet items where each item is a short (≤6 word) adjective-plus-noun phrase with no verb. "Stable mining efficiency / Reliable pool connectivity / Optimized RandomX performance / Low failed share rates / Effective hardware utilization / Consistent thermal stability." Reads as a marketing one-pager because that's the shape LLMs default to when asked to summarize features.
+- The tell is the *symmetry*: every item is the same grammatical shape, every item is parallel in length, none of them assert anything checkable. A genuine list of observations would have varying length, occasional verbs, and at least one item that doesn't fit the pattern.
+- Fix: convert to prose paragraph, or rewrite items as full claims ("Failed shares stayed under 1% across a 12-hour run" beats "Low failed share rates"). If the list is genuinely the right form, vary the items so each carries a different shape of information.
+- This rule does *not* apply to genuine list content (changelog entries, todo lists, parameter docs, ingredient lists) where bare noun phrases are the correct form. The detector keys on absence of finite verbs to separate the two — but in prose audits, ask whether the bullets are summarizing claims (rewrite) or enumerating items (leave).
+
+### Copula avoidance
+- AI text avoids "is" and "has" by substituting fancier verbs: "serves as," "features," "boasts," "presents," "represents." These sound like a press release.
+- Default to "is" or "has" unless a more specific verb genuinely adds meaning.
+
+### Synonym cycling
+- AI rotates synonyms to avoid repeating a word: "developers… engineers… practitioners… builders" in the same paragraph. Human writers repeat the clearest word.
+- If the same noun or verb appears three times in a paragraph and that's the right word, keep all three. Forced variation reads as thesaurus abuse.
+
+### Vague attributions
+- "Experts believe," "Studies show," "Research suggests," "Industry leaders agree" — without naming the expert, study, or leader. Either cite a specific source or drop the attribution and state the claim directly.
+
+### Filler phrases
+- Strip mechanical padding that adds words without meaning:
+  - "It is important to note that" → (just state it)
+  - "In terms of" → (rewrite)
+  - "The reality is that" → (cut or just state the claim)
+- Note: "In order to," "Due to the fact that," and "At the end of the day" are covered in the word/phrase table and transition sections above — don't duplicate rules.
+
+### Generic conclusions
+- "The future looks bright," "Only time will tell," "One thing is certain," "As we move forward" — these are filler disguised as conclusions. Cut them. If the piece needs a closing thought, make it specific to the argument.
+
+### Chatbot artifacts
+- "I hope this helps!", "Certainly!", "Absolutely!", "Great question!", "Feel free to reach out," "Let me know if you need anything else" — these are conversational tics from chat interfaces, not writing. Remove entirely.
+- Also watch for: "In this article, we will explore…" or "Let's dive in!" — these are AI-generated meta-narration. Cut or rewrite with a direct opening.
+
+### "Let's" constructions
+- "Let's explore," "Let's take a look," "Let's break this down," "Let's examine" — AI uses "let's" as a false-collaborative opener to ease into a topic. It's filler that delays the actual point. Just start with the point. "Let's dive in" is covered above under chatbot artifacts, but the pattern is broader than that — flag any "let's + verb" that's functioning as a transition rather than a genuine invitation to act.
+
+### Notability name-dropping
+- AI text piles on prestigious citations to manufacture credibility: "cited in The New York Times, BBC, Financial Times, and The Hindu." If a source matters, use it with context: "In a 2024 NYT interview, she argued..." One specific reference beats four name-drops.
+
+### Superficial -ing analyses
+- Strings of present participles used as pseudo-analysis: "symbolizing the region's commitment to progress, reflecting decades of investment, and showcasing a new era of collaboration." These say nothing. Replace with specific facts or cut entirely.
+
+### Promotional language
+- AI defaults to tourism-brochure prose: "nestled within the breathtaking foothills," "a vibrant hub of innovation," "a thriving ecosystem." Replace with plain description: "is a town in the Gonder region," "has 12 startups." If you wouldn't say it in conversation, cut it.
+
+### Formulaic challenges
+- "Despite challenges, [subject] continues to thrive" or "While facing headwinds, the organization remains resilient." This is a non-statement. Name the actual challenge and the actual response, or cut the sentence.
+
+### False ranges
+- AI creates false breadth by pairing unrelated extremes: "from the Big Bang to dark matter," "from ancient civilizations to modern startups." These sound sweeping but say nothing. List the actual topics or pick the one that matters.
+
+### Inline-header lists
+- Bullet lists where each item starts with a bold header that repeats itself: "**Performance:** Performance improved by..." Strip the bold header and write the point directly. If the list items need headers, they should probably be paragraphs.
+
+### Title case headings
+- AI over-capitalizes headings: "Strategic Negotiations And Key Partnerships" instead of "Strategic negotiations and key partnerships." Use sentence case for subheadings. Title case only for the piece's main title, if at all.
+
+### Cutoff disclaimers
+- "While specific details are limited based on available information," "As of my last update," "I don't have access to real-time data." These are model limitations leaking into prose. Either find the information or remove the hedge. Never publish a sentence that admits the writer didn't look something up.
+
+### Unfilled placeholders
+- Bracketed slot-fillers that were meant to be replaced before publishing: `[Your Name]`, `[INSERT SOURCE URL]`, `[Describe the specific section]`, `2025-XX-XX`, `<!-- Add citation if available -->`. These are near-definitive evidence that AI-generated boilerplate was pasted without editing. Humans use placeholders in templates too, but rarely ship them. Treat any visible placeholder as a publishing bug: fill it in with real content or delete the sentence entirely.
+- Catch the obvious shapes: `\[(?:Your|Insert|Add|Enter|Describe|Specify|Choose)[^\]]+\]`, `\b\d{4}-XX-XX\b`, HTML/Markdown comments with placeholder verbs (`add`, `fill in`, `todo`, `insert`).
+
+### Chatbot citation markup leaks
+- Internal citation tokens that leak through when text is copy-pasted from chat UIs: `citeturn0search0`, `contentReference[oaicite:0]{index=0}`, `oai_citation`, `[attached_file:1]`, `grok_card`. These are not patterns — they are fingerprints. Their presence is essentially proof the text was generated by a specific chat tool and pasted without cleanup.
+- The fix is mechanical: strip every markup token. If a citation was meaningful, replace it with a real reference. Don't try to humanize the markup — delete it.
+- Adapted from `Aboudjem/humanizer-skill` P34. Worth catching even when nothing else in the text reads as AI — the token itself is enough.
+
+### AI-tool URL parameters
+- Tracking parameters that AI tools auto-append to URLs they generate, surviving copy-paste into published content: `utm_source=chatgpt.com`, `utm_source=copilot.com`, `utm_source=openai`, `utm_source=claude.ai`, `utm_source=perplexity.ai`, `referrer=grok.com`. Same logic as citation markup leaks — the presence of the parameter is the signature, regardless of what the surrounding text reads like.
+- The fix: strip the parameter from every URL. Keep the URL itself if the link is meaningful; lose the parameter entirely. Adapted from `Aboudjem/humanizer-skill` P35.
+
+### Novelty inflation
+- AI text treats established concepts as if the speaker invented or discovered them: "He introduced a term," "She coined the phrase," "a concept nobody's naming," "a failure mode nobody talks about." In reality, most ideas in a conversation are applications of existing concepts, not inventions.
+- Two problems. First, it's factually risky: if the concept already has a Wikipedia page or conference talks from last year, claiming novelty makes the writer look uninformed. Second, it flatters the subject in a way that reads as promotional rather than analytical.
+- The fix: describe what the person *did with* the concept, not that they discovered it. "Michel walked through how context poisoning works in practice" instead of "Michel introduced a term I hadn't heard before: context poisoning." If you're unsure whether something is novel, assume it isn't and frame accordingly.
+- Related patterns to flag: "the failure mode nobody's naming," "a problem nobody talks about," "the insight everyone's missing," "what nobody tells you about." These are engagement-bait framings that claim scarcity of knowledge where none exists.
+
+### Emotional flatline
+- AI claims emotions as a structural crutch without conveying them through the writing: "What surprised me most," "I was fascinated to discover," "What struck me was," "I was excited to learn," "The most interesting part," and the bare section-header variant: "Interesting part of the project:" / "Interesting thing here:" / "Interesting aspect:". The header form drops "the most" but does the same job — pre-announcing significance the writing hasn't earned.
+- Two problems. First, it's tell-don't-show: if the thing is genuinely surprising, the reader should feel that from the content, not from the writer announcing it. Second, these phrases are massively overused as list introductions and transitions. They're filler wearing an emotion costume.
+- This pattern isn't always AI. It's also a sign of lazy human writing on autopilot. Flag it either way.
+- The fix isn't "never say surprised." It's: if you claim an emotion, the writing around it should earn it. Otherwise cut the claim and present the thing directly.
+- Related pattern: "hit differently" / "hits different." AI uses trendy colloquialisms as a shortcut to sound relatable without earning the emotional beat. If something genuinely affected you, describe how. Otherwise cut.
+
+### False concession structure
+- "While X is impressive, Y remains a challenge" or "Although X has made strides, Y is still an open question." AI uses this to sound balanced without actually weighing anything. Both halves are vague. Either make the concession specific (name what's impressive, name the actual challenge) or pick a side and argue it.
+
+### Rhetorical question openers
+- "But what does this mean for developers?" / "So why should you care?" / "What's next?" � AI uses rhetorical questions to stall before the actual point. If you know the answer, just say it. Rhetorical questions are earned by strong setup, not dropped as section transitions.
+
+### Parenthetical hedging
+- "(and, increasingly, Z)" / "(or, more precisely, Y)" / "(and perhaps more importantly, W)" � AI inserts parenthetical asides to sound nuanced without committing. If the aside matters, give it its own sentence. If it doesn't, cut it.
+
+### Numbered list inflation
+- "Three key takeaways" / "Five things to know" / "Here are the top seven" � AI defaults to numbered lists because they're structurally safe. Only use numbered lists when the content genuinely has that many discrete, parallel items. If you're padding to hit a number, the list shouldn't exist.
+
+### Reasoning chain artifacts
+- "Let me think step by step," "Breaking this down," "To approach this systematically," "Step 1:," "Here's my thought process," "First, let's consider," "Working through this logically" — these are artifacts of chain-of-thought reasoning leaking into published prose. The reader doesn't need to see the scaffolding. State the conclusion, then the evidence.
+- Also watch for numbered reasoning steps that read like an internal monologue rather than an argument meant for an audience.
+
+### Sycophantic tone
+- "Great question!", "Excellent point!", "You're absolutely right!", "That's a really insightful observation" — these are conversational rewards from chat interfaces, not writing. Remove entirely.
+- Distinct from chatbot artifacts: sycophancy specifically validates the reader/questioner rather than just performing helpfulness.
+
+### Acknowledgment loops
+- "You're asking about," "The question of whether," "To answer your question," "That's a great question. The..." — AI restates the prompt before answering. In writing, this is pure filler. The reader knows what they asked. Just answer.
+- Related pattern: opening a section by summarizing what the previous section said. If the structure is clear, the reader doesn't need a recap.
+
+### Confidence calibration phrases
+- "It's worth noting that," "Interestingly," "Surprisingly," "Importantly," "Significantly," "Notably," "Certainly," "Undoubtedly," "Without a doubt" — AI uses these to signal how the reader should feel about a fact instead of letting the fact speak for itself.
+- "Here's what's interesting," "Here's the interesting part," "Here are the parts I found interesting" — reader-steering cue that pre-interprets importance. Works when followed by genuinely surprising data; fails when it introduces a restatement of something obvious (which is the AI default).
+- One "notably" in a 2,000-word piece is fine. Three in 500 words is AI-style emphasis stacking. Flag by density.
+
+### Excessive structure
+- Too many headers in short text: more than 3 headings in under 300 words is almost always AI trying to look organized. Merge sections or use prose transitions instead.
+- Too many list items: 8+ bullet points in under 200 words means the content should be a paragraph, not a list.
+- Formulaic section headers: "Overview," "Key Points," "Summary," "Conclusion," "Introduction" — these are default AI scaffolding. Use headers that tell the reader something specific about what follows.
+
+### Rhythm and uniformity
+
+These aren't individual word or phrase problems — they're patterns in how the text flows as a whole. AI text is metronomic; human text has varied rhythm.
+
+**Structure is the #1 detection signal.** AI detection tools (including Pangram, which trains a classifier on 28M human documents) weight structural regularity higher than vocabulary. Consistent sentence construction, uniform pacing, and symmetrical phrasing patterns are harder to mask than swapping out a few flagged words. If you fix every word on the Tier 1 list but leave the rhythm untouched, the text still reads as AI-generated.
+
+- **Sentence length uniformity**: If most sentences are 15–25 words, the text sounds robotic. Mix short punchy sentences (3–8 words) with longer flowing ones (20+). Fragments work. Questions break the monotony.
+- **Paragraph length uniformity**: If every paragraph is 3–5 sentences and roughly the same size, vary deliberately. Some paragraphs should be one sentence. Some should be longer.
+- **Vocabulary repetition vs. synonym cycling**: AI either repeats the same word mechanically or cycles through synonyms conspicuously. Human writers repeat when the word is right and vary when it's natural — there's no formula.
+- **Read-aloud test**: If the text sounds like it could be read by a text-to-speech engine without sounding weird, it's probably too uniform. Human writing has rhythm that resists robotic delivery.
+- **Missing first-person perspective**: Where appropriate, the writer should have opinions, preferences, and reactions. AI is relentlessly neutral. If the piece is supposed to have a voice, the absence of "I think," "in my experience," or a stated preference is itself an AI tell.
+- **Over-polishing**: Aggressively editing out every irregularity can push human writing *toward* AI statistical profiles. Natural disfluency, idiosyncratic word choices, and uneven pacing are what keep text out of the "AI-generated" classification. Don't sand away all personality in pursuit of clean prose. This skill should make writing sound more human, not less — if you apply every rule at maximum strictness, you risk creating the very uniformity you're trying to avoid.
+
+### Vocabulary diversity (stylometric)
+
+In longer pieces (200+ words), look at how much vocabulary the text actually uses. The type-token ratio (TTR) — distinct word types divided by total tokens — is a classical stylometric signal that's easy to read by eye. Human prose at this length usually lands somewhere around 0.50–0.65 in English. AI text trends flatter, sometimes drifting under 0.40 when the model gets locked on a small vocabulary loop.
+
+A very low TTR is not by itself proof of AI authorship — narrow topics, technical reference material, and second-language writing all legitimately compress vocabulary. But on general prose where you'd expect range (essays, articles, social content over ~200 words), a TTR below 0.40 is worth a second look. The fix is rarely to thesaurus the text; it's to broaden the *what* — name specific things, cite specific cases, replace a re-used abstract noun with the concrete instance behind it.
+
+This is the first of four stylometric signals on the roadmap. The others (sentence-length burstiness as a continuous measure, function-word z-scores against a human-prose reference, POS-bigram log-odds) require either a POS tagger or a reference distribution and aren't implemented as detector categories yet.
+
+### When to rewrite from scratch vs. patch
+
+If the text has 5+ flagged vocabulary hits across multiple categories, 3+ distinct pattern categories triggered, and uniform sentence/paragraph length, patching individual phrases won't fix it — the structure itself is AI-generated. Advise a full rewrite: state the core point in one sentence, then rebuild from there.
+
+---
+
+## Severity tiers
+
+Not all AI-isms are equal. When doing a quick pass or triaging a large document, prioritize by tier:
+
+### P0 — Credibility killers (fix immediately)
+- Cutoff disclaimers ("As of my last update")
+- Chatbot artifacts ("I hope this helps!", "Great question!")
+- Vague attributions without sources ("Experts believe")
+- Significance inflation on routine events
+- Hashtag stuffing on `linkedin` and `investor-email` posts (severity varies by profile — same rule, lower priority on `blog`/`technical-blog` where a launch post may legitimately stack tags; see the context-profile table below)
+
+### P1 — Obvious AI smell (fix before publishing)
+- Word-list violations (delve, leverage, harness, robust, etc.)
+- Template phrases and slot-fill constructions
+- "Let's" transition openers
+- Synonym cycling within a paragraph
+- Formulaic openings ("In the rapidly evolving world of...")
+- Bold overuse
+- Em dash frequency (above 1 per 1,000 words)
+- Generic future-narrative closers ("may become one of the most important narratives…")
+- Hedge-stacked predictions ("could potentially," "may eventually")
+- Real/actual adjective inflation ("real on-chain tokenomics")
+- Bullet lists of bare noun phrases (5+ short adj+noun items, no verbs)
+- Tier 3 phrase clustering (≥3 distinct boilerplate phrases in one piece)
+
+### P2 — Stylistic polish (fix when time allows)
+- Generic conclusions ("The future looks bright")
+- Compulsive rule of three
+- Uniform paragraph length
+- Copula avoidance (serves as, features, boasts)
+- Transition phrases (Moreover, Furthermore, Additionally)
+- Hashtag stuffing (`blog`/`technical-blog` profiles)
+- Tier 3 phrase repetition (single phrase ≥2× — fine in isolation, suspect in stacks)
+
+Use P0+P1 for quick passes. Full audit covers all three tiers.
+
+---
+
+## Self-reference escape hatch
+
+When writing *about* AI writing patterns (blog posts, tutorials, skill documentation like this file), quoted examples are exempt from flagging. Text inside quotation marks, code blocks, or explicitly marked as illustrative ("for example, AI might write...") should not be rewritten. Only flag patterns that appear in the author's own prose, not in cited examples of bad writing.
+
+---
+
+## Context profiles
+
+Pass an optional context hint to adjust rule strictness. If no context is specified, auto-detect from content cues (short + hashtags = social, code blocks = technical, salutation = email, default = blog).
+
+### Profile definitions
+
+**`linkedin`** � Short-form social. Punchy fragments, visual formatting matter.
+**`blog`** � Default. Standard long-form prose. All rules apply at full strength.
+**`technical-blog`** � Long-form with code, architecture, APIs. Technical terms get a pass.
+**`investor-email`** � High-trust audience. Tighten everything; promotional language is the biggest risk.
+**`docs`** � Documentation, READMEs, guides. Clarity over voice.
+**`casual`** � Slack messages, internal notes, quick replies. Only catch the worst offenders.
+
+### Tolerance matrix
+
+Rules not listed in the table apply at full strength across all profiles.
+
+| Rule | linkedin | blog | technical-blog | investor-email | docs | casual |
+|------|----------|------|----------------|----------------|------|--------|
+| Em dashes | relaxed (2/post OK) | strict | strict | strict | relaxed | skip |
+| Bold overuse | relaxed (bold hooks OK) | strict | strict | strict | relaxed | skip |
+| Emoji in headers | relaxed (1-2 end-of-line OK) | strict | strict | strict | skip | skip |
+| Excessive bullets | skip (lists work on LinkedIn) | strict | relaxed (technical lists OK) | strict | skip (lists are docs) | skip |
+| Hedging | strict | strict | relaxed ("may" is accurate in technical) | strict | relaxed | skip |
+| Word table (full list) | strict | strict | **partial** (see below) | strict | relaxed | P0 only |
+| Promotional language | relaxed (some sell is expected) | strict | strict | **extra strict** | strict | skip |
+| Significance inflation | strict | strict | strict | **extra strict** | relaxed | skip |
+| Copula avoidance | skip | strict | relaxed | strict | skip | skip |
+| Uniform paragraph length | skip (short-form) | strict | strict | strict | relaxed | skip |
+| Numbered list inflation | relaxed | strict | relaxed | strict | skip | skip |
+| Rhetorical questions | relaxed (1 as hook OK) | strict | strict | strict | strict | skip |
+| Transition phrases | skip (short-form) | strict | strict | strict | relaxed | skip |
+| Generic conclusions | skip | strict | strict | **extra strict** | skip | skip |
+| Hashtag stuffing | strict | strict | strict | **extra strict** | skip (no hashtags in docs) | skip |
+| Bullet-NP lists | strict | strict | relaxed (technical option lists OK) | strict | relaxed (parameter lists OK) | skip |
+| Tier 3 phrase clustering | strict | strict | strict | **extra strict** | relaxed | skip |
+| Future-narrative closers | strict | strict | strict | **extra strict** | skip | skip |
+| Hedge-stacked predictions | strict | strict | relaxed ("could" is hedged accuracy) | **extra strict** | relaxed | skip |
+| Real/actual inflation | strict | strict | strict | **extra strict** | relaxed | skip |
+
+**Technical-blog word table exceptions:** These terms have legitimate technical meaning and should not be flagged in technical context: `robust`, `comprehensive`, `seamless`, `ecosystem`, `leverage` (when discussing actual platform leverage/APIs), `facilitate`, `underpin`, `streamline`. Still flag: `delve`, `tapestry`, `beacon`, `embark`, `testament to`, `game-changer`, `harness`.
+
+**"Extra strict"** means: flag even borderline instances. In investor emails, a single "thriving ecosystem" can undermine the whole message.
+
+**"Skip"** means: don't audit this category for this profile. The rule doesn't apply or isn't worth the edit.
+
+### Auto-detection cues
+
+When no context is specified, infer from these signals:
+
+| Signal | Inferred context |
+|--------|-----------------|
+| Under 300 words + hashtags or mentions | `linkedin` |
+| Code blocks, API references, or technical architecture | `technical-blog` |
+| Salutation ("Hi [name]", "Dear") + investor/fundraising language | `investor-email` |
+| Step-by-step instructions, parameter docs, README structure | `docs` |
+| No strong signals | `blog` (safest default � all rules apply) |
+
+If auto-detection feels wrong, say which profile you're using and why. The user can override.
+
+---
+
+
+## Output format
+
+### Rewrite mode (default)
+
+Return your response in four sections:
+
+**1. Issues found**
+A bulleted list of every AI-ism identified, with the offending text quoted.
+
+**2. Rewritten version**
+The full rewritten content. Preserve the original structure, intent, and all specific technical details. Only change what the guidelines require.
+
+**3. What changed**
+A brief summary of the major edits made. Not every word, just the meaningful changes.
+
+**4. Second-pass audit**
+Re-read the rewritten version from section 2. Identify any remaining AI tells that survived the first pass — recycled transitions, lingering inflation, copula avoidance, filler phrases, or anything else from the categories above. Fix them, return the corrected text inline, and note what changed in this pass. If the rewrite is clean, say so.
+
+### Detect mode
+
+Return your response in two sections:
+
+**1. Issues found**
+A bulleted list of every AI-ism identified, with the offending text quoted. Group by severity (P0, P1, P2).
+
+**2. Assessment**
+For each flag, note whether it's a clear problem or a judgment call. Some AI-associated patterns are effective writing techniques — uniform paragraph length is a problem, but a well-placed "however" isn't. Call out which flags the writer should definitely fix vs. which ones are worth a second look but might be fine in context. If the text is clean, say so.
+
+---
+
+## Tone calibration
+
+The goal is writing that sounds like a person wrote it. Direct. Specific. The writing should demonstrate confidence, not assert it.
+
+Five principles for human-sounding rewrites:
+1. **Vary sentence length** — mix short with long. Fragments are fine.
+2. **Be concrete** — replace vague claims with numbers, names, dates, or examples.
+3. **Have a voice** — where appropriate, use first person, state preferences, show reactions.
+4. **Cut the neutrality** — humans have opinions. If the piece is supposed to take a position, take it.
+5. **Earn your emphasis** — don't tell the reader something is interesting. Make it interesting.
+
+If the original writing is already strong, say so and make only the necessary cuts. Don't over-edit for the sake of it.
+
+The replacement table provides defaults, not mandates. If a flagged word is clearly the right choice in context, preserve it.

--- a/scripts/sync-plugin-skill.sh
+++ b/scripts/sync-plugin-skill.sh
@@ -12,8 +12,8 @@ cp "$src" "$dest"
 
 # Keep plugin.json's version in lockstep with the SKILL.md frontmatter version.
 skill_version="$(sed -n 's/^version:[[:space:]]*//p' "$src" | head -n1)"
-plugin_version="$(sed -n 's/.*"version":[[:space:]]*"\([^"]*\)".*/\1/p' \
-  "$repo_root/plugins/avoid-ai-writing/.claude-plugin/plugin.json" | head -n1)"
+plugin_version="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["version"])' \
+  "$repo_root/plugins/avoid-ai-writing/.claude-plugin/plugin.json")"
 
 if [ "$skill_version" != "$plugin_version" ]; then
   echo "version mismatch: SKILL.md=$skill_version plugin.json=$plugin_version" >&2

--- a/scripts/sync-plugin-skill.sh
+++ b/scripts/sync-plugin-skill.sh
@@ -11,7 +11,13 @@ dest="$repo_root/plugins/avoid-ai-writing/skills/avoid-ai-writing/SKILL.md"
 cp "$src" "$dest"
 
 # Keep plugin.json's version in lockstep with the SKILL.md frontmatter version.
-skill_version="$(sed -n 's/^version:[[:space:]]*//p' "$src" | head -n1)"
+# Read the version only from the first YAML frontmatter block, and strip any CR
+# so a CRLF checkout can't forge a mismatch on visually-identical strings.
+skill_version="$(sed -n '/^---[[:space:]]*$/,/^---[[:space:]]*$/ s/^version:[[:space:]]*//p' "$src" | head -n1 | tr -d '\r')"
+if [ -z "$skill_version" ]; then
+  echo "could not parse 'version:' from SKILL.md frontmatter" >&2
+  exit 1
+fi
 plugin_version="$(
   python3 - "$repo_root/plugins/avoid-ai-writing/.claude-plugin/plugin.json" <<'PY'
 import json

--- a/scripts/sync-plugin-skill.sh
+++ b/scripts/sync-plugin-skill.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Regenerate the plugin's bundled skill from the canonical root SKILL.md.
+# Root SKILL.md is the single source of truth; the plugin copy is generated.
+# Run this after editing SKILL.md. CI fails if the copy is out of sync.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+src="$repo_root/SKILL.md"
+dest="$repo_root/plugins/avoid-ai-writing/skills/avoid-ai-writing/SKILL.md"
+
+cp "$src" "$dest"
+
+# Keep plugin.json's version in lockstep with the SKILL.md frontmatter version.
+skill_version="$(sed -n 's/^version:[[:space:]]*//p' "$src" | head -n1)"
+plugin_version="$(sed -n 's/.*"version":[[:space:]]*"\([^"]*\)".*/\1/p' \
+  "$repo_root/plugins/avoid-ai-writing/.claude-plugin/plugin.json" | head -n1)"
+
+if [ "$skill_version" != "$plugin_version" ]; then
+  echo "version mismatch: SKILL.md=$skill_version plugin.json=$plugin_version" >&2
+  echo "Update plugin.json \"version\" to match SKILL.md frontmatter." >&2
+  exit 1
+fi
+
+echo "synced: plugin skill + version ($skill_version)"

--- a/scripts/sync-plugin-skill.sh
+++ b/scripts/sync-plugin-skill.sh
@@ -12,8 +12,30 @@ cp "$src" "$dest"
 
 # Keep plugin.json's version in lockstep with the SKILL.md frontmatter version.
 skill_version="$(sed -n 's/^version:[[:space:]]*//p' "$src" | head -n1)"
-plugin_version="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["version"])' \
-  "$repo_root/plugins/avoid-ai-writing/.claude-plugin/plugin.json")"
+plugin_version="$(
+  python3 - "$repo_root/plugins/avoid-ai-writing/.claude-plugin/plugin.json" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+try:
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+except FileNotFoundError:
+    print(f"Missing plugin manifest: {path}", file=sys.stderr)
+    sys.exit(1)
+except json.JSONDecodeError as e:
+    print(f"Invalid JSON in plugin manifest: {path}: {e}", file=sys.stderr)
+    sys.exit(1)
+
+version = data.get("version")
+if not isinstance(version, str) or not version:
+    print(f'Invalid or missing "version" in plugin manifest: {path}', file=sys.stderr)
+    sys.exit(1)
+
+print(version)
+PY
+)"
 
 if [ "$skill_version" != "$plugin_version" ]; then
   echo "version mismatch: SKILL.md=$skill_version plugin.json=$plugin_version" >&2


### PR DESCRIPTION
## Summary

Packages the skill as a **single-plugin marketplace** so it can be installed via `/plugin` instead of a bare file clone. This is the only install path that works in **Claude Cowork**, which loads skills exclusively from installed plugins — closing the gap reported in #12.

```bash
/plugin marketplace add conorbronsdon/avoid-ai-writing
/plugin install avoid-ai-writing@conorbronsdon-skills
```

In Cowork: **Customize → Plugins → Add marketplace from GitHub** → install `avoid-ai-writing`. The skill auto-triggers from phrases like "remove AI-isms," same as in Claude Code.

## What's in here

- `.claude-plugin/marketplace.json` — single-plugin marketplace (`conorbronsdon-skills`).
- `plugins/avoid-ai-writing/` — the plugin: `.claude-plugin/plugin.json` + `skills/avoid-ai-writing/SKILL.md`.
- `scripts/sync-plugin-skill.sh` — regenerates the bundled skill from the root `SKILL.md` and enforces a matching `version`.
- `.github/workflows/plugin-skill-sync.yml` — validates manifest JSON and fails on skill drift or version mismatch.
- `.gitattributes` — pins `*.sh` to LF so the CI script can't be broken by CRLF.
- README — replaces the "wrap it yourself" Cowork note with the real plugin install.

## Single source of truth

Root `SKILL.md` stays canonical. The bundled copy at `plugins/avoid-ai-writing/skills/avoid-ai-writing/SKILL.md` is generated — edit the root, run `bash scripts/sync-plugin-skill.sh`, commit. (A copy is unavoidable: clone-to-skills-dir needs `SKILL.md` at the repo root, while plugin discovery needs `skills/<name>/SKILL.md`. The CI guard keeps them identical.)

## Verification

- `claude plugin validate .` and `claude plugin validate ./plugins/avoid-ai-writing` → both pass.
- Full local cycle: `marketplace add` → `install` → `plugin details` (reports `Skills (1): avoid-ai-writing`, v3.4.0) → `uninstall` → `marketplace remove`.
- Negative-tested the guard: a `9.9.9` plugin.json vs `3.4.0` SKILL.md fails the version check.

## Test plan

- [ ] Confirm CI `plugin-skill-sync` passes on this PR.
- [ ] (Optional) Add the marketplace in a real Cowork desktop session and confirm auto-trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)