### PR TITLE
chore: gitignore .worktrees/ (parallel session dirs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ Desktop.ini
 # Environment
 .env
 .env.local
+
+# Local git worktrees (parallel Claude Code sessions)
+.worktrees/


### PR DESCRIPTION
Adds `.worktrees/` to `.gitignore`.

Parallel Claude Code sessions create worktrees under `.worktrees/<task>`. Because that path wasn't ignored, a `git add -A` in another branch staged `.worktrees/<name>` as an embedded git repo (gitlink). This one-liner prevents that footgun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)