### PR TITLE
v3.7.2: calibrate curly-quotes rule (apply missed #15 review)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project are documented here.
 
 ---
 
+## [3.7.2] — 2026-05-28
+
+### Changed
+- **Curly quotation marks** — recalibrated per review of #15. Reframed from a "strong" tell to a **weak, corroborating** signal meaningful mainly in plain-text contexts (code comments, commit messages, plaintext drafts), since Word/Google Docs/macOS/iOS auto-curl quotes by default. Curly apostrophes (U+2019) are no longer flagged on their own (they appear in every contraction). Fixes the German low-9 example. Keeps it consistent with the deterministic detector's co-occurrence logic (#16).
+
+---
+
 ## [3.7.1] — 2026-05-28
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ A single-file writing skill (`SKILL.md`) that audits and rewrites content to rem
 
 ## Repository structure
 
-- `SKILL.md` — the skill itself (v3.7.1). This is the product. All rules, tiers, profiles, and output format live here.
+- `SKILL.md` — the skill itself (v3.7.2). This is the product. All rules, tiers, profiles, and output format live here.
 - `README.md` — public-facing docs, installation instructions, pattern reference table, full before/after example.
 - `CHANGELOG.md` — version history with what changed and why.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: avoid-ai-writing
 description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Use this skill when asked to "remove AI-isms," "clean up AI writing," "edit writing for AI patterns," "audit writing for AI tells," or "make this sound less like AI." Supports a detect-only mode, an edit-in-place mode for files, an optional voice profile (casual / professional / technical / warm / blunt), and an iterate-to-convergence pass.
-version: 3.7.1
+version: 3.7.2
 license: MIT
 compatibility: Any AI coding assistant that supports agentskills.io SKILL.md format (Claude Code, Cursor, VS Code Copilot, Hermes Agent, OpenHands, etc.) or OpenClaw. No external tools or APIs required.
 metadata:
@@ -72,7 +72,7 @@ In **edit** mode, your job is to:
 - **Bold overuse**: Strip bold from most phrases. One bolded phrase per major section at most, or none. If something's important enough to bold, restructure the sentence to lead with it instead.
 - **Emoji in headers**: Remove entirely. No `## 🚀 What This Means`. Exception: social posts may use one or two emoji sparingly — at the end of a line, never mid-sentence.
 - **Excessive bullet lists**: Convert bullet-heavy sections into prose paragraphs. Bullets only for genuinely list-like content (feature comparisons, step-by-step instructions, API parameters).
-- **Curly quotation marks (“ ” ‘ ’) and curly apostrophes**: ChatGPT and several other chat UIs emit Unicode curly quotes (U+201C / U+201D for doubles, U+2018 / U+2019 for singles) by default, even when the surrounding text is plain ASCII. Most human writers type straight quotes (`"` and `'`) unless they're publishing through a CMS that auto-substitutes them. A document that's otherwise ASCII but contains curly quotes is a strong copy-paste-from-chat signal. Replace with straight quotes. Curly and straight quotes mixed within one document are an even stronger tell — the inconsistency itself gives it away. Exception: deliberate typography in finished publications, ebooks, or print proofs where curly quotes are the house style — in those contexts they're correct and should stay. Carve-out also applies to French guillemets (« »), German low-9 quotes („ "), and other locale-correct punctuation; the flag is specifically the unexplained presence of U.S. English curly quotes in otherwise plain text.
+- **Curly quotation marks (“ ” ‘ ’) and apostrophes**: Curly quotes and apostrophes (U+201C/U+201D, U+2018/U+2019) are a *weak* paste-from-chat signal — meaningful mainly in plain-text contexts like code comments, commit messages, or plaintext drafts, where nothing auto-curls. Treat as corroborating, never conclusive: Word, Google Docs, macOS, and iOS curl quotes by default, so most human prose contains them too. Don't flag curly apostrophes (U+2019) on their own. Replace with straight quotes in plain-text/code; leave them in finished publications and locale-correct punctuation (French « », German „ “).
 
 ### Sentence structure
 - **"It's not X — it's Y" / "This isn't about X, it's about Y"**: Rewrite as a direct positive statement. Max one per piece, and only if it serves the argument.

--- a/cursor-rules/avoid-ai-writing.mdc
+++ b/cursor-rules/avoid-ai-writing.mdc
@@ -1,5 +1,5 @@
 ---
-description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Activate whenever editing prose-heavy files (Markdown, documentation, blog posts, READMEs, release notes, emails). Cursor port of the avoid-ai-writing skill v3.7.1. See https://github.com/conorbronsdon/avoid-ai-writing.
+description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Activate whenever editing prose-heavy files (Markdown, documentation, blog posts, READMEs, release notes, emails). Cursor port of the avoid-ai-writing skill v3.7.2. See https://github.com/conorbronsdon/avoid-ai-writing.
 globs: ["**/*.md", "**/*.mdx", "**/*.txt", "**/*.rst", "**/*.adoc"]
 alwaysApply: false
 ---
@@ -64,7 +64,7 @@ In **edit** mode, your job is to:
 - **Bold overuse**: Strip bold from most phrases. One bolded phrase per major section at most, or none. If something's important enough to bold, restructure the sentence to lead with it instead.
 - **Emoji in headers**: Remove entirely. No `## 🚀 What This Means`. Exception: social posts may use one or two emoji sparingly — at the end of a line, never mid-sentence.
 - **Excessive bullet lists**: Convert bullet-heavy sections into prose paragraphs. Bullets only for genuinely list-like content (feature comparisons, step-by-step instructions, API parameters).
-- **Curly quotation marks (“ ” ‘ ’) and curly apostrophes**: ChatGPT and several other chat UIs emit Unicode curly quotes (U+201C / U+201D for doubles, U+2018 / U+2019 for singles) by default, even when the surrounding text is plain ASCII. Most human writers type straight quotes (`"` and `'`) unless they're publishing through a CMS that auto-substitutes them. A document that's otherwise ASCII but contains curly quotes is a strong copy-paste-from-chat signal. Replace with straight quotes. Curly and straight quotes mixed within one document are an even stronger tell — the inconsistency itself gives it away. Exception: deliberate typography in finished publications, ebooks, or print proofs where curly quotes are the house style — in those contexts they're correct and should stay. Carve-out also applies to French guillemets (« »), German low-9 quotes („ "), and other locale-correct punctuation; the flag is specifically the unexplained presence of U.S. English curly quotes in otherwise plain text.
+- **Curly quotation marks (“ ” ‘ ’) and apostrophes**: Curly quotes and apostrophes (U+201C/U+201D, U+2018/U+2019) are a *weak* paste-from-chat signal — meaningful mainly in plain-text contexts like code comments, commit messages, or plaintext drafts, where nothing auto-curls. Treat as corroborating, never conclusive: Word, Google Docs, macOS, and iOS curl quotes by default, so most human prose contains them too. Don't flag curly apostrophes (U+2019) on their own. Replace with straight quotes in plain-text/code; leave them in finished publications and locale-correct punctuation (French « », German „ “).
 
 ### Sentence structure
 - **"It's not X — it's Y" / "This isn't about X, it's about Y"**: Rewrite as a direct positive statement. Max one per piece, and only if it serves the argument.

--- a/plugins/avoid-ai-writing/.claude-plugin/plugin.json
+++ b/plugins/avoid-ai-writing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "avoid-ai-writing",
   "description": "Audit & rewrite content to remove AI writing patterns (\"AI-isms\"). Supports detect-only and edit-in-place modes, voice profiles, and iterate-to-convergence.",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "author": {
     "name": "Conor Bronsdon"
   },

--- a/plugins/avoid-ai-writing/skills/avoid-ai-writing/SKILL.md
+++ b/plugins/avoid-ai-writing/skills/avoid-ai-writing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: avoid-ai-writing
 description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Use this skill when asked to "remove AI-isms," "clean up AI writing," "edit writing for AI patterns," "audit writing for AI tells," or "make this sound less like AI." Supports a detect-only mode, an edit-in-place mode for files, an optional voice profile (casual / professional / technical / warm / blunt), and an iterate-to-convergence pass.
-version: 3.7.1
+version: 3.7.2
 license: MIT
 compatibility: Any AI coding assistant that supports agentskills.io SKILL.md format (Claude Code, Cursor, VS Code Copilot, Hermes Agent, OpenHands, etc.) or OpenClaw. No external tools or APIs required.
 metadata:
@@ -72,7 +72,7 @@ In **edit** mode, your job is to:
 - **Bold overuse**: Strip bold from most phrases. One bolded phrase per major section at most, or none. If something's important enough to bold, restructure the sentence to lead with it instead.
 - **Emoji in headers**: Remove entirely. No `## 🚀 What This Means`. Exception: social posts may use one or two emoji sparingly — at the end of a line, never mid-sentence.
 - **Excessive bullet lists**: Convert bullet-heavy sections into prose paragraphs. Bullets only for genuinely list-like content (feature comparisons, step-by-step instructions, API parameters).
-- **Curly quotation marks (“ ” ‘ ’) and curly apostrophes**: ChatGPT and several other chat UIs emit Unicode curly quotes (U+201C / U+201D for doubles, U+2018 / U+2019 for singles) by default, even when the surrounding text is plain ASCII. Most human writers type straight quotes (`"` and `'`) unless they're publishing through a CMS that auto-substitutes them. A document that's otherwise ASCII but contains curly quotes is a strong copy-paste-from-chat signal. Replace with straight quotes. Curly and straight quotes mixed within one document are an even stronger tell — the inconsistency itself gives it away. Exception: deliberate typography in finished publications, ebooks, or print proofs where curly quotes are the house style — in those contexts they're correct and should stay. Carve-out also applies to French guillemets (« »), German low-9 quotes („ "), and other locale-correct punctuation; the flag is specifically the unexplained presence of U.S. English curly quotes in otherwise plain text.
+- **Curly quotation marks (“ ” ‘ ’) and apostrophes**: Curly quotes and apostrophes (U+201C/U+201D, U+2018/U+2019) are a *weak* paste-from-chat signal — meaningful mainly in plain-text contexts like code comments, commit messages, or plaintext drafts, where nothing auto-curls. Treat as corroborating, never conclusive: Word, Google Docs, macOS, and iOS curl quotes by default, so most human prose contains them too. Don't flag curly apostrophes (U+2019) on their own. Replace with straight quotes in plain-text/code; leave them in finished publications and locale-correct punctuation (French « », German „ “).
 
 ### Sentence structure
 - **"It's not X — it's Y" / "This isn't about X, it's about Y"**: Rewrite as a direct positive statement. Max one per piece, and only if it serves the argument.


### PR DESCRIPTION
The #15 merge shipped the curly-quotes rule **without** the inline review suggestions left on that PR — this applies them.

## What changed (verbatim from the #15 review)
- **Weak, not strong.** Reframed curly quotes/apostrophes as a *weak, corroborating* signal, meaningful mainly in **plain-text contexts** (code comments, commit messages, plaintext drafts) — because Word, Google Docs, macOS, and iOS auto-curl quotes by default, so most ordinary human prose contains them.
- **Don't flag apostrophes standalone.** U+2019 appears in every contraction/possessive, so it discriminates nothing on its own.
- **German low-9 example fixed.**
- **Consistency with #16.** Matches the deterministic detector's `smart-punct-signature` logic (co-occurrence, never standalone).

## Why a follow-up
#15 merged my reconciliation but I missed the maintainer's inline `suggestion` blocks; this is the catch-up. Credit retained: @augustasas (original rule) + the review that tightened it.

## Coordinated
Version 3.7.1 → 3.7.2; mirrored to the Cursor rule; bundled skill re-synced; CHANGELOG entry.

## Verification
`claude plugin validate .` passes; SKILL.md ≡ bundled copy; tightened rule present in both SKILL.md and the Cursor rule with no "strong"-framing leftover; no stray 3.7.1 outside CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)