### PR TITLE
docs: reconcile pattern count to 46 + CI count-guard

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "avoid-ai-writing",
       "source": "./plugins/avoid-ai-writing",
-      "description": "Audit & rewrite content to remove AI writing patterns (\"AI-isms\"). Supports detection-only mode.",
+      "description": "Audit & rewrite content to remove AI writing patterns (\"AI-isms\"). Supports detect-only and edit-in-place modes, voice profiles, and iterate-to-convergence.",
       "category": "productivity",
       "keywords": ["writing", "editing", "ai-detection", "humanize"]
     }

--- a/.github/workflows/plugin-skill-sync.yml
+++ b/.github/workflows/plugin-skill-sync.yml
@@ -4,16 +4,18 @@ on:
   pull_request:
     paths:
       - "SKILL.md"
+      - "README.md"
       - "plugins/**"
       - ".claude-plugin/**"
-      - "scripts/sync-plugin-skill.sh"
+      - "scripts/**"
   push:
     branches: [main]
     paths:
       - "SKILL.md"
+      - "README.md"
       - "plugins/**"
       - ".claude-plugin/**"
-      - "scripts/sync-plugin-skill.sh"
+      - "scripts/**"
 
 jobs:
   check:
@@ -25,6 +27,9 @@ jobs:
         run: |
           python3 -m json.tool .claude-plugin/marketplace.json > /dev/null
           python3 -m json.tool plugins/avoid-ai-writing/.claude-plugin/plugin.json > /dev/null
+
+      - name: Check README pattern count matches SKILL.md
+        run: bash scripts/check-pattern-count.sh
 
       - name: Regenerate bundled skill + check version
         run: bash scripts/sync-plugin-skill.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,14 +19,14 @@ Edit `SKILL.md` directly. There's nothing to build or test. When making changes:
 - Bump the version in the SKILL.md frontmatter (`version: X.Y.Z`)
 - Add a dated entry to CHANGELOG.md
 - Update README.md if the change affects installation, usage, feature list, or pattern count
-- Keep the README pattern count table (currently "36 Patterns Detected") in sync with actual SKILL.md categories
+- The pattern count lives in **one** place — the README "46 pattern categories" bullet — and is derived from SKILL.md's detection `###` entries. Don't restate it elsewhere; CI (`scripts/check-pattern-count.sh`) fails the build if the README number drifts from SKILL.md, so just add the new `###` entry and bump the README bullet.
 
 ## Architecture of the skill
 
 The skill has three modes (`rewrite` default, `detect` flag-only, `edit` in-place) and processes text through this pipeline:
 
 1. **Context profile detection** — auto-detects or accepts a profile hint (linkedin, blog, technical-blog, investor-email, docs, casual) that adjusts rule strictness via the tolerance matrix
-2. **Pattern matching** — 36 categories across content, language, structure, communication, and meta patterns
+2. **Pattern matching** — detection categories across content, language, structure, communication, and meta patterns (see SKILL.md for the catalog; the count is in the README bullet)
 3. **Vocabulary flagging** — 3-tier system: Tier 1 (always flag), Tier 2 (flag in clusters), Tier 3 (flag at high density)
 4. **Severity classification** — P0 (credibility killers), P1 (obvious AI smell), P2 (stylistic polish)
 5. **Output** — rewrite mode: 4 sections including a second-pass audit; detect mode: 2 sections with problem vs. judgment-call assessment

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A one-shot "make this sound human" prompt catches the obvious stuff. This skill 
 - **Structured audit** — returns identified issues with quoted text, the rewrite, a change summary, and a second-pass audit in four discrete sections. You see exactly what changed and why.
 - **Two-pass detection** — the second pass re-reads the rewrite and catches patterns that survive the first edit: recycled transitions, lingering inflation, copula swaps that snuck through.
 - **109-entry word replacement table across 3 tiers + 10 Tier 3 phrases** — not vibes-based. Every flagged word has a specific, plainer alternative. "Leverage" → "use." "Commence" → "start." Tier 1 words always flag, Tier 2 words flag when they cluster, Tier 3 words flag only at high density. Tier 3 *phrases* (multi-word boilerplate like "the integration of," "decentralized compute") flag on per-phrase repetition or when 3+ distinct phrases stack in one piece — the LLM-self-varies-boilerplate shape.
-- **42 pattern categories** — see the full list below, each with before/after examples. Includes structural detection (hashtag stuffing, bare-NP bullet lists, hedge-stacked predictions), rhythm/uniformity checks, and a rewrite-vs-patch threshold.
+- **46 pattern categories** — representative examples below, each with before/after. Includes structural detection (hashtag stuffing, bare-NP bullet lists, hedge-stacked predictions), AI-tool fingerprints (placeholders, citation markup, UTM params), rhythm/uniformity checks, and writer-side tests. The full catalog lives in [`SKILL.md`](./SKILL.md); this count is enforced against it in CI.
 - **Detect mode** — flag patterns without rewriting. See which flags are real problems vs. judgment calls. Useful when patterns might be intentional or you're auditing content you don't want altered.
 - **Works across platforms** — one `SKILL.md` runs in Claude Code, Cowork (as a plugin), OpenClaw, and Cursor (as a ported rule). See the install paths below.
 
@@ -173,9 +173,9 @@ In **detect mode**, the skill returns two sections:
 
 Trigger detect mode with: "detect," "flag only," "audit only," "just flag," "scan," or similar.
 
-## 42 Patterns Detected
+## Pattern reference
 
-> These 42 are the human-facing prose rules. The [detector engine](./detector/) implements **43 `type` categories** — a different count, because it splits the vocabulary tiers and adds stylometric/fingerprint signals (punctuation distribution, function-word entropy, bypass-trick detection) that work as math over a document rather than as a rule you'd look up. The two are mapped in [`detector/CATEGORIES.md`](./detector/CATEGORIES.md); don't "fix" one count to match the other.
+> Representative examples from the catalog — not the exhaustive list (that's [`SKILL.md`](./SKILL.md)). The skill's human-facing prose catalog and the [detector engine](./detector/) use **different counts on purpose**: the engine implements 43 `type` categories because it splits the vocabulary tiers and adds stylometric/fingerprint signals (punctuation distribution, function-word entropy, bypass-trick detection) that work as math over a document rather than as a rule you'd look up. The two are mapped in [`detector/CATEGORIES.md`](./detector/CATEGORIES.md); don't "fix" one count to match the other.
 
 ### Content Patterns
 
@@ -250,6 +250,20 @@ Added in v3.4 to catch LLM output that sidesteps the vocabulary tables by substi
 | 40 | **"Real/actual" adjective inflation** | "real on-chain tokenomics," "actual reward sustainability" | Drop the empty intensifier and add the specific claim. Carve-out: "real on-chain settlement, *not* bridged IOUs" is honest contrastive writing — the AI tell is the unsaid contrast |
 | 41 | **Hashtag stuffing** | 15-tag trailing block: `#AI #Crypto #Web3 #Innovation #FutureTech…` | 2-3 specific tags max, or none. Empirical threshold: 6+ tags is near-universal in LLM social output, rare in thoughtful human posts |
 | 42 | **Bullet lists of bare noun phrases** | `* Stable mining efficiency / Reliable pool connectivity / Optimized RandomX performance / Low failed share rates / Effective hardware utilization / Consistent thermal stability` | Convert to prose, or rewrite each item as a full claim with a verb and a number. Carve-out: genuine list content (changelogs, parameter docs, ingredient lists) where bare NPs are correct |
+
+### AI-tool fingerprints & later additions (v3.5–3.7)
+
+| # | Pattern | Before | After |
+|---|---------|--------|-------|
+| 43 | **Unfilled placeholders** | `[Your Name]`, `[INSERT SOURCE]`, `2025-XX-XX` | Fill in with real content or delete — shipped placeholders are a near-definitive tell |
+| 44 | **Chatbot citation markup** | `citeturn0search0`, `oai_citation`, `contentReference[oaicite:0]` | Strip the markup token entirely |
+| 45 | **AI-tool URL parameters** | `utm_source=chatgpt.com`, `utm_source=copilot.com` | Strip the tracking parameter; keep the URL if the link matters |
+| 46 | **Speculative gap-filling** | "maintains a low profile," "likely began his career" | Cut the guess, or replace with a sourced fact |
+| 47 | **Hyphenated-pair overuse** | "a high-quality, well-architected, future-proof solution" | Cut to the modifier that matters; no hyphen in predicate ("the report is high quality") |
+| 48 | **Infomercial engagement hooks** | "The catch?", "The kicker?", "Here's the thing." | Delete the hook, state the thing |
+| 49 | **Vocabulary diversity (low TTR)** | Narrow, repetitive word range across 200+ words | Broaden the *what* — name specific things, cite specific cases |
+
+Two writer-side **tests** round out the catalog (judgment checks, not auto-detected): **paragraph-reshuffle immunity** (can you swap two body paragraphs without breaking the piece?) and the **treadmill effect** ("what's actually new in this paragraph?").
 
 ## Full Example
 

--- a/detector/CATEGORIES.md
+++ b/detector/CATEGORIES.md
@@ -12,9 +12,10 @@ it's rules that are judgment calls a regex can't make. The three groups below
 account for every entry on both sides.
 
 Three counts coexist on purpose and should not be forced to match: the README's
-**42 patterns** are the human-facing prose catalog, the engine's **43 `type`s**
-split the vocabulary tiers and add stylometric signals, and SKILL.md's ~50
-`###` sections include meta-rules with no detectable form. The
+**pattern-category count** (the human-facing prose catalog, derived from SKILL.md
+and guarded in CI), the engine's **43 `type`s** (which split the vocabulary tiers
+and add stylometric signals), and SKILL.md's `###` sections (which also include
+writer-side tests with no detectable form). The
 `categories.test.js` check enforces only the engine ↔ this-file mapping.
 
 ## A. Direct mapping (skill rule → detector `type`)

--- a/detector/patterns.js
+++ b/detector/patterns.js
@@ -1,6 +1,6 @@
 /**
  * Avoid AI Writing — detection engine (canonical source of truth)
- * Implements 43-category pattern detection. This repo's SKILL.md (v3.4.0)
+ * Implements 43-category pattern detection. This repo's SKILL.md
  * catalogs the human-editable pattern rules; this engine is the executable
  * expression of the regex-detectable subset and extends it with stylometric and
  * AI-tool-fingerprint detectors that don't make sense as skill prose

--- a/scripts/check-pattern-count.sh
+++ b/scripts/check-pattern-count.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Guard against pattern-count drift. The count is a derived fact, so it lives in
+# exactly one user-facing place — the README "**NN pattern categories**" bullet —
+# and this script asserts it matches SKILL.md's detection catalog. Run in CI so
+# adding a pattern without bumping the README is a red check, not silent rot.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+skill="$repo_root/SKILL.md"
+readme="$repo_root/README.md"
+
+# Detection categories = the `###` entries under "## What to remove or fix",
+# minus the writer-side tests (judgment checks with no detectable form):
+# paragraph-reshuffle immunity, treadmill effect, and rewrite-vs-patch.
+detection_count="$(awk '
+  /^## What to remove or fix/ { inside = 1; next }
+  /^## / { inside = 0 }
+  inside && /^### / {
+    if ($0 ~ /\(structure test\)/) next
+    if ($0 ~ /\(content test\)/) next
+    if ($0 ~ /^### When to rewrite from scratch/) next
+    n++
+  }
+  END { print n + 0 }
+' "$skill")"
+
+# The single user-facing count literal.
+readme_count="$(sed -n 's/.*\*\*\([0-9][0-9]*\) pattern categories\*\*.*/\1/p' "$readme" | head -n1)"
+
+if [ -z "$readme_count" ]; then
+  echo "could not find the '**NN pattern categories**' bullet in README.md" >&2
+  exit 1
+fi
+
+if [ "$detection_count" != "$readme_count" ]; then
+  echo "pattern-count drift: SKILL.md has $detection_count detection categories, README says $readme_count" >&2
+  echo "Update the '**NN pattern categories**' bullet in README.md to $detection_count (or fix SKILL.md)." >&2
+  exit 1
+fi
+
+echo "pattern count in sync: $detection_count"


### PR DESCRIPTION
Comprehensive documentation review after the 3.4 → 3.7.2 churn. The headline finding: **pattern-count drift** — the catalog grew to 46 detection categories but the docs lagged (README said 42, CLAUDE.md said 36, CATEGORIES.md said 42).

## Fixes
- **Count = 46, in one place.** The single user-facing count literal is the README "**46 pattern categories**" bullet. The "## 42 Patterns Detected" heading is reframed to "## Pattern reference" (representative examples, not an exhaustive census), and the table is extended with the 7 missing categories (unfilled placeholders, citation-markup leaks, UTM params, speculative gap-filling, hyphenated-pair overuse, infomercial hooks, low-TTR), plus a note on the 2 writer-side tests.
- **De-duplicated the number.** `CLAUDE.md` and `detector/CATEGORIES.md` now *reference* SKILL.md + CI instead of restating their own (stale) counts.
- **New CI guard (`scripts/check-pattern-count.sh`).** Derives the count from SKILL.md's detection `###` entries (excluding the 3 writer-side tests) and fails the build if the README number drifts. Wired into the existing `plugin-skill-sync` workflow. Same enforcement model as the SKILL≡bundled-copy guard — drift is now a red check, not silent rot.
- **Minor:** fixed the stale `detector/patterns.js` "(v3.4.0)" comment and the `marketplace.json` description (was "detection-only mode").

## How this simplifies drift going forward
The count was a *derived* fact hand-copied into 5+ files. Now it lives in one user-facing spot, everything else points at SKILL.md, and CI enforces the match. Adding a pattern = add the `###` + bump the one README bullet; forget it and CI tells you.

## Verification
- `bash scripts/check-pattern-count.sh` → "pattern count in sync: 46".
- `claude plugin validate .` passes; no stale 42/36 counts remain in README/CLAUDE/CATEGORIES.
- No SKILL.md or version change — docs + CI only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)