### PR TITLE
Detect social endorsement closers (#29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project are documented here.
 
 ---
 
+## [3.9.0] — 2026-06-05
+
+### Added
+- **Social endorsement closers** — the curatorial sign-off LLMs append to LinkedIn/X share posts, usually a colon teeing up a link: "This one is worth your time:", "This one's a must-read:", "Do yourself a favor and read this," "You won't want to miss this one," "Thank me later," "Bookmark this," "Don't sleep on this one." Performs a recommendation without giving the reader a reason to click. Distinct from the bare "worth [verb]ing" word-table entry (a single weak word inside a sentence) and from infomercial engagement hooks (mid-flow teasers) — this is the whole closing line of a social post. Demonstrative-anchored ("THIS one is worth your time") so it stays off plain human endorsements ("the book is worth reading, but the middle drags"). Catalog goes from 47 to 48 detection categories; the detector engine gains a `social-cta-closer` `type` (43 → 44). Closes #29.
+
+---
+
 ## [3.8.0] — 2026-05-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A one-shot "make this sound human" prompt catches the obvious stuff. This skill 
 - **Structured audit** — returns identified issues with quoted text, the rewrite, a change summary, and a second-pass audit in four discrete sections. You see exactly what changed and why.
 - **Two-pass detection** — the second pass re-reads the rewrite and catches patterns that survive the first edit: recycled transitions, lingering inflation, copula swaps that snuck through.
 - **109-entry word replacement table across 3 tiers + 10 Tier 3 phrases** — not vibes-based. Every flagged word has a specific, plainer alternative. "Leverage" → "use." "Commence" → "start." Tier 1 words always flag, Tier 2 words flag when they cluster, Tier 3 words flag only at high density. Tier 3 *phrases* (multi-word boilerplate like "the integration of," "decentralized compute") flag on per-phrase repetition or when 3+ distinct phrases stack in one piece — the LLM-self-varies-boilerplate shape.
-- **47 pattern categories** — representative examples below, each with before/after. Includes structural detection (hashtag stuffing, bare-NP bullet lists, hedge-stacked predictions), AI-tool fingerprints (placeholders, citation markup, UTM params), rhythm/uniformity checks, and writer-side tests. The full catalog lives in [`SKILL.md`](./SKILL.md); this count is enforced against it in CI.
+- **48 pattern categories** — representative examples below, each with before/after. Includes structural detection (hashtag stuffing, bare-NP bullet lists, hedge-stacked predictions), AI-tool fingerprints (placeholders, citation markup, UTM params), rhythm/uniformity checks, and writer-side tests. The full catalog lives in [`SKILL.md`](./SKILL.md); this count is enforced against it in CI.
 - **Detect mode** — flag patterns without rewriting. See which flags are real problems vs. judgment calls. Useful when patterns might be intentional or you're auditing content you don't want altered.
 - **Works across platforms** — one `SKILL.md` runs in Claude Code, Cowork (as a plugin), OpenClaw, and Cursor (as a ported rule). See the install paths below.
 
@@ -175,7 +175,7 @@ Trigger detect mode with: "detect," "flag only," "audit only," "just flag," "sca
 
 ## Pattern reference
 
-> Representative examples from the catalog — not the exhaustive list (that's [`SKILL.md`](./SKILL.md)). The skill's human-facing prose catalog and the [detector engine](./detector/) use **different counts on purpose**: the engine implements 43 `type` categories because it splits the vocabulary tiers and adds stylometric/fingerprint signals (punctuation distribution, function-word entropy, bypass-trick detection) that work as math over a document rather than as a rule you'd look up. The two are mapped in [`detector/CATEGORIES.md`](./detector/CATEGORIES.md); don't "fix" one count to match the other.
+> Representative examples from the catalog — not the exhaustive list (that's [`SKILL.md`](./SKILL.md)). The skill's human-facing prose catalog and the [detector engine](./detector/) use **different counts on purpose**: the engine implements 44 `type` categories because it splits the vocabulary tiers and adds stylometric/fingerprint signals (punctuation distribution, function-word entropy, bypass-trick detection) that work as math over a document rather than as a rule you'd look up. The two are mapped in [`detector/CATEGORIES.md`](./detector/CATEGORIES.md); don't "fix" one count to match the other.
 
 ### Content Patterns
 
@@ -299,7 +299,7 @@ That's 35+ AI tells.
 ## Run the detector
 
 The skill ships a deterministic, zero-dependency detection engine in
-[`detector/`](./detector/) — the same 43-category engine the rules above
+[`detector/`](./detector/) — the same 44-category engine the rules above
 describe, as runnable code. It works in Node (`>=18`) and the browser with no
 build step.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: avoid-ai-writing
 description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Use this skill when asked to "remove AI-isms," "clean up AI writing," "edit writing for AI patterns," "audit writing for AI tells," or "make this sound less like AI." Supports a detect-only mode, an edit-in-place mode for files, an optional voice profile (casual / professional / technical / warm / blunt), and an iterate-to-convergence pass.
-version: 3.8.0
+version: 3.9.0
 license: MIT
 compatibility: Any AI coding assistant that supports agentskills.io SKILL.md format (Claude Code, Cursor, VS Code Copilot, Hermes Agent, OpenHands, etc.) or OpenClaw. No external tools or APIs required.
 metadata:
@@ -369,6 +369,12 @@ These slot-fill constructions signal that a sentence was generated, not written.
 - Punchy fragment-hooks that tee up a reveal: "The catch?", "The kicker?", "Here's the thing.", "But here's the kicker:", "The best part?", "Plot twist:", "The result?". AI uses these to fake momentum and manufacture suspense around ordinary information — the prose equivalent of a late-night infomercial.
 - Distinct from rhetorical-question openers (which stall before a point) and chatbot artifacts (which perform helpfulness): these are mid-flow teasers that pad the rhythm. The fix is to delete the hook and state the thing. "The catch? It only works on weekends." becomes "It only works on weekends." Adapted from `Aboudjem/humanizer-skill` P41.
 
+### Social endorsement closers
+- The curatorial sign-off LLMs append to LinkedIn and X posts that share or recommend something — usually a colon teeing up a link: "This one is worth your time:", "This one's a must-read:", "I highly recommend giving this a read.", "Do yourself a favor and read this.", "You won't want to miss this one.", "Save this for later.", "Bookmark this.", "Don't sleep on this one.", "Trust me, you'll want to read this.", "Thank me later."
+- Why it's a tell: it performs a recommendation without giving the reader a reason to click. The endorsement is generic and demonstrative-anchored ("THIS one is worth your time") — it could sit under any link, which is exactly why an LLM reaches for it to close a share post.
+- Distinct from the bare "worth [verb]ing" word-table entry (a single weak word inside a sentence) and from infomercial engagement hooks (mid-flow teasers like "The catch?"): this is the whole closing line of a social post.
+- The fix: say *what* the thing is and *who* it's for, then drop the CTA. "This one is worth your time:" becomes "Sarah's breakdown of why context windows leak — the clearest explanation I've found for anyone debugging RAG pipelines." If you can't name a specific reason, the share doesn't need a sign-off at all; let the link stand on its own.
+
 ### Emotional flatline
 - AI claims emotions as a structural crutch without conveying them through the writing: "What surprised me most," "I was fascinated to discover," "What struck me was," "I was excited to learn," "The most interesting part," and the bare section-header variant: "Interesting part of the project:" / "Interesting thing here:" / "Interesting aspect:". The header form drops "the most" but does the same job — pre-announcing significance the writing hasn't earned.
 - Two problems. First, it's tell-don't-show: if the thing is genuinely surprising, the reader should feel that from the content, not from the writer announcing it. Second, these phrases are massively overused as list introductions and transitions. They're filler wearing an emotion costume.
@@ -474,6 +480,7 @@ Not all AI-isms are equal. When doing a quick pass or triaging a large document,
 - Bold overuse
 - Em dash frequency (above 1 per 1,000 words)
 - Generic future-narrative closers ("may become one of the most important narratives…")
+- Social endorsement closers ("This one is worth your time:", "thank me later")
 - Hedge-stacked predictions ("could potentially," "may eventually")
 - Real/actual adjective inflation ("real on-chain tokenomics")
 - Bullet lists of bare noun phrases (5+ short adj+noun items, no verbs)
@@ -535,6 +542,7 @@ Rules not listed in the table apply at full strength across all profiles.
 | Bullet-NP lists | strict | strict | relaxed (technical option lists OK) | strict | relaxed (parameter lists OK) | skip |
 | Tier 3 phrase clustering | strict | strict | strict | **extra strict** | relaxed | skip |
 | Future-narrative closers | strict | strict | strict | **extra strict** | skip | skip |
+| Social endorsement closers | strict (the LinkedIn share-post tell) | strict | strict | strict | skip | relaxed (1 OK in a DM) |
 | Hedge-stacked predictions | strict | strict | relaxed ("could" is hedged accuracy) | **extra strict** | relaxed | skip |
 | Real/actual inflation | strict | strict | strict | **extra strict** | relaxed | skip |
 

--- a/cursor-rules/avoid-ai-writing.mdc
+++ b/cursor-rules/avoid-ai-writing.mdc
@@ -348,6 +348,12 @@ These slot-fill constructions signal that a sentence was generated, not written.
 - Punchy fragment-hooks that tee up a reveal: "The catch?", "The kicker?", "Here's the thing.", "But here's the kicker:", "The best part?", "Plot twist:", "The result?". AI uses these to fake momentum and manufacture suspense around ordinary information — the prose equivalent of a late-night infomercial.
 - Distinct from rhetorical-question openers (which stall before a point) and chatbot artifacts (which perform helpfulness): these are mid-flow teasers that pad the rhythm. The fix is to delete the hook and state the thing. "The catch? It only works on weekends." becomes "It only works on weekends." Adapted from `Aboudjem/humanizer-skill` P41.
 
+### Social endorsement closers
+- The curatorial sign-off LLMs append to LinkedIn and X posts that share or recommend something — usually a colon teeing up a link: "This one is worth your time:", "This one's a must-read:", "I highly recommend giving this a read.", "Do yourself a favor and read this.", "You won't want to miss this one.", "Save this for later.", "Bookmark this.", "Don't sleep on this one.", "Trust me, you'll want to read this.", "Thank me later."
+- Why it's a tell: it performs a recommendation without giving the reader a reason to click. The endorsement is generic and demonstrative-anchored ("THIS one is worth your time") — it could sit under any link, which is exactly why an LLM reaches for it to close a share post.
+- Distinct from the bare "worth [verb]ing" word-table entry (a single weak word inside a sentence) and from infomercial engagement hooks (mid-flow teasers like "The catch?"): this is the whole closing line of a social post.
+- The fix: say *what* the thing is and *who* it's for, then drop the CTA. "This one is worth your time:" becomes "Sarah's breakdown of why context windows leak — the clearest explanation I've found for anyone debugging RAG pipelines." If you can't name a specific reason, the share doesn't need a sign-off at all; let the link stand on its own.
+
 ### Emotional flatline
 - AI claims emotions as a structural crutch without conveying them through the writing: "What surprised me most," "I was fascinated to discover," "What struck me was," "I was excited to learn," "The most interesting part," and the bare section-header variant: "Interesting part of the project:" / "Interesting thing here:" / "Interesting aspect:". The header form drops "the most" but does the same job — pre-announcing significance the writing hasn't earned.
 - Two problems. First, it's tell-don't-show: if the thing is genuinely surprising, the reader should feel that from the content, not from the writer announcing it. Second, these phrases are massively overused as list introductions and transitions. They're filler wearing an emotion costume.
@@ -445,6 +451,7 @@ Not all AI-isms are equal. When doing a quick pass or triaging a large document,
 - Bold overuse
 - Em dash frequency (above 1 per 1,000 words)
 - Generic future-narrative closers ("may become one of the most important narratives…")
+- Social endorsement closers ("This one is worth your time:", "thank me later")
 - Hedge-stacked predictions ("could potentially," "may eventually")
 - Real/actual adjective inflation ("real on-chain tokenomics")
 - Bullet lists of bare noun phrases (5+ short adj+noun items, no verbs)

--- a/detector/CATEGORIES.md
+++ b/detector/CATEGORIES.md
@@ -6,14 +6,14 @@ the skill, decide here whether it's regex-detectable (give it a detector `type`)
 or LLM-only judgment (mark it so). When you add a detector `type`, point it back
 at the skill section it enforces.
 
-The engine exposes 43 issue `type`s (see `TYPE_LABELS` in `patterns.js`). The
+The engine exposes 44 issue `type`s (see `TYPE_LABELS` in `patterns.js`). The
 skill has more `###` sections than that — the gap is **not** missing coverage,
 it's rules that are judgment calls a regex can't make. The three groups below
 account for every entry on both sides.
 
 Three counts coexist on purpose and should not be forced to match: the README's
 **pattern-category count** (the human-facing prose catalog, derived from SKILL.md
-and guarded in CI), the engine's **43 `type`s** (which split the vocabulary tiers
+and guarded in CI), the engine's **44 `type`s** (which split the vocabulary tiers
 and add stylometric signals), and SKILL.md's `###` sections (which also include
 writer-side tests with no detectable form). The
 `categories.test.js` check enforces only the engine ↔ this-file mapping.
@@ -32,6 +32,7 @@ writer-side tests with no detectable form). The
 | `filler` | Filler phrase | Filler phrases |
 | `hollow-intensifier` | Hollow intensifier | Filler phrases (intensifiers) |
 | `generic-conclusion` | Generic conclusion | Generic conclusions |
+| `social-cta-closer` | Engagement-bait closer | Social endorsement closers |
 | `future-narrative` | Generic future narrative | Generic future-narrative closers |
 | `lets-construction` | "Let's" opener | "Let's" constructions |
 | `reasoning-artifact` | Reasoning artifact | Reasoning chain artifacts |

--- a/detector/patterns.js
+++ b/detector/patterns.js
@@ -597,21 +597,29 @@ const AIDetector = (() => {
   // and from infomercial hooks (mid-flow teasers): this is the
   // demonstrative-anchored endorsement — "THIS one is worth your time:",
   // "do yourself a favor and read this", "thank me later" — that performs
-  // a recommendation without giving the reader a reason to click. The
-  // "this one" / "do yourself a favor" / "won't want to miss" anchors keep
-  // it off the bare endorsements a human writes ("the book is worth
-  // reading, but the middle drags").
+  // a recommendation without giving the reader a reason to click.
+  //
+  // Precision-first: each pattern carries an anchor so it stays off the
+  // literal-verb prose a human writes. The demonstrative object ("read
+  // THIS", not "read the runbook"), the trailing-terminal lookahead on
+  // "miss this" / "bookmark this" (the closing-line shape, not "miss this
+  // meeting" / "bookmark this page"), and the sentence-initial lookbehind
+  // on "thank me later" / "save this for later" (the imperative CTA, not
+  // "she will thank me later") all exist to suppress false positives on
+  // ordinary instructional/conversational text. Apostrophe classes admit
+  // the curly ' (U+2019) because LinkedIn / Word / macOS auto-curl it —
+  // the straight-only form would miss the canonical "you won't" closer.
   const SOCIAL_CTA_CLOSER = [
-    /\bthis\s+one'?s?\s+(?:is\s+)?(?:well\s+|totally\s+|absolutely\s+|definitely\s+|really\s+|truly\s+|easily\s+|more\s+than\s+)?worth\s+(?:your\s+time|the\s+read|a\s+read|every\s+(?:minute|second)|reading|watching|a\s+listen|a\s+watch|a\s+look|it)\b/gi,
-    /\bthis\s+one'?s?\s+(?:is\s+)?a\s+must-?(?:read|watch|listen|see)\b/gi,
-    /\b(?:highly|strongly|can'?t|cannot)\s+recommend\w*\s+(?:giving\s+)?(?:this|it)\s+(?:one\s+)?a\s+(?:read|listen|watch|look|go)\b/gi,
-    /\bdo\s+yourself\s+a\s+favou?r\s+and\s+(?:read|watch|listen|check|give)\b/gi,
-    /\byou\s+(?:really\s+)?(?:won'?t|do\s*n'?t|will\s+not|do\s+not)\s+want\s+to\s+miss\s+this\b/gi,
-    /\b(?:you\s+can\s+)?thank\s+me\s+later\b/gi,
-    /\bsave\s+this\s+(?:one\s+)?for\s+later\b/gi,
-    /\bbookmark\s+this(?:\s+(?:one|post|thread))?\b/gi,
-    /\bdo\s*n'?t\s+sleep\s+on\s+this\b/gi,
-    /\btrust\s+me,?\s+(?:on\s+this|you'?ll|this\s+one)\b/gi,
+    /\bthis\s+one['’]?s?\s+(?:is\s+)?(?:well\s+|totally\s+|absolutely\s+|definitely\s+|really\s+|truly\s+|easily\s+|more\s+than\s+)?worth\s+(?:your\s+time|the\s+read|a\s+read|every\s+(?:minute|second)|reading|watching|a\s+listen|a\s+watch|a\s+look|it)\b/gi,
+    /\bthis\s+one['’]?s?\s+(?:is\s+)?a\s+must[-\s]?(?:read|watch|listen|see)\b/gi,
+    /\b(?:highly|strongly|can['’]?t|cannot)\s+recommend\w*\s+(?:giving\s+)?(?:this|it)\s+(?:one\s+)?a\s+(?:read|listen|watch|look|go)\b/gi,
+    /\bdo\s+yourself\s+a\s+favou?r\s+and\s+(?:read|watch|check\s+out)\s+(?:this|it)\b/gi,
+    /\byou\s+(?:really\s+)?(?:won['’]?t|do\s*n['’]?t|will\s+not|do\s+not)\s+want\s+to\s+miss\s+this(?:\s+one)?(?=\s*(?:[:.!\n]|$))/gi,
+    /(?<=^|[,.!?:\n]\s{0,4})(?:you\s+can\s+)?thank\s+me\s+later\b/gim,
+    /(?<=^|[.!?:\n]\s{0,4})save\s+this\s+(?:one\s+)?for\s+later\b/gim,
+    /\bbookmark\s+this(?:\s+(?:one|post|thread))?(?=\s*(?:[:.!\n]|$))/gi,
+    /\bdo\s*n['’]?t\s+sleep\s+on\s+this\b/gi,
+    /\btrust\s+me,?\s+(?:on\s+this|you['’]?ll)\b/gi,
   ];
 
   // ═══ Helpers ═══════════════════════════════════════════════════════

--- a/detector/patterns.js
+++ b/detector/patterns.js
@@ -1,6 +1,6 @@
 /**
  * Avoid AI Writing — detection engine (canonical source of truth)
- * Implements 43-category pattern detection. This repo's SKILL.md
+ * Implements 44-category pattern detection. This repo's SKILL.md
  * catalogs the human-editable pattern rules; this engine is the executable
  * expression of the regex-detectable subset and extends it with stylometric and
  * AI-tool-fingerprint detectors that don't make sense as skill prose
@@ -272,6 +272,10 @@ const AIDetector = (() => {
     'hedge-stack': 6,
     'future-narrative': 12,
     'real-actual-inflation': 5,
+    // Social endorsement / CTA closer. Weighted like formulaic-opener: a
+    // strong single-hit social tell that the length divisor would
+    // otherwise wash out on a short LinkedIn-length post.
+    'social-cta-closer': 8,
     'formulaic-opener': 8,
     'title-case-header': 4,
     'parenthetical-hedge': 3,
@@ -586,6 +590,30 @@ const AIDetector = (() => {
     /\bwithout\s+a\s+doubt\b/gi,
   ];
 
+  // ─── Social endorsement / CTA closers ──────────────────────────────
+  // The curatorial sign-off LLMs append to LinkedIn / X posts that share
+  // or recommend something — usually a colon teeing up a link. Distinct
+  // from the bare "worth reading" word-table entry (a single weak word)
+  // and from infomercial hooks (mid-flow teasers): this is the
+  // demonstrative-anchored endorsement — "THIS one is worth your time:",
+  // "do yourself a favor and read this", "thank me later" — that performs
+  // a recommendation without giving the reader a reason to click. The
+  // "this one" / "do yourself a favor" / "won't want to miss" anchors keep
+  // it off the bare endorsements a human writes ("the book is worth
+  // reading, but the middle drags").
+  const SOCIAL_CTA_CLOSER = [
+    /\bthis\s+one'?s?\s+(?:is\s+)?(?:well\s+|totally\s+|absolutely\s+|definitely\s+|really\s+|truly\s+|easily\s+|more\s+than\s+)?worth\s+(?:your\s+time|the\s+read|a\s+read|every\s+(?:minute|second)|reading|watching|a\s+listen|a\s+watch|a\s+look|it)\b/gi,
+    /\bthis\s+one'?s?\s+(?:is\s+)?a\s+must-?(?:read|watch|listen|see)\b/gi,
+    /\b(?:highly|strongly|can'?t|cannot)\s+recommend\w*\s+(?:giving\s+)?(?:this|it)\s+(?:one\s+)?a\s+(?:read|listen|watch|look|go)\b/gi,
+    /\bdo\s+yourself\s+a\s+favou?r\s+and\s+(?:read|watch|listen|check|give)\b/gi,
+    /\byou\s+(?:really\s+)?(?:won'?t|do\s*n'?t|will\s+not|do\s+not)\s+want\s+to\s+miss\s+this\b/gi,
+    /\b(?:you\s+can\s+)?thank\s+me\s+later\b/gi,
+    /\bsave\s+this\s+(?:one\s+)?for\s+later\b/gi,
+    /\bbookmark\s+this(?:\s+(?:one|post|thread))?\b/gi,
+    /\bdo\s*n'?t\s+sleep\s+on\s+this\b/gi,
+    /\btrust\s+me,?\s+(?:on\s+this|you'?ll|this\s+one)\b/gi,
+  ];
+
   // ═══ Helpers ═══════════════════════════════════════════════════════
 
   function tokenize(text) {
@@ -819,6 +847,7 @@ const AIDetector = (() => {
     issues.push(...matchPatterns(text, HEDGE_STACK, 'hedge-stack', 'high'));
     issues.push(...matchPatterns(text, FUTURE_NARRATIVE, 'future-narrative', 'high'));
     issues.push(...matchPatterns(text, REAL_ACTUAL_INFLATION, 'real-actual-inflation', 'medium'));
+    issues.push(...matchPatterns(text, SOCIAL_CTA_CLOSER, 'social-cta-closer', 'high'));
 
     // ── Tier 1 v2: formulaic openers + parenthetical hedges ──────────
     issues.push(...matchPatterns(text, FORMULAIC_OPENERS, 'formulaic-opener', 'high'));
@@ -1594,6 +1623,7 @@ const AIDetector = (() => {
     'hedge-stack': 'Hedge-stacked prediction',
     'future-narrative': 'Generic future narrative',
     'real-actual-inflation': '"Real/actual" inflation',
+    'social-cta-closer': 'Engagement-bait closer',
     'formulaic-opener': 'Formulaic opener',
     'title-case-header': 'Title Case header',
     'parenthetical-hedge': 'Parenthetical hedge',

--- a/detector/patterns.test.js
+++ b/detector/patterns.test.js
@@ -426,12 +426,21 @@ test('v2: social endorsement closer fires on LinkedIn-style share post', () => {
   assert.ok(types.has('social-cta-closer'), 'expected social-cta-closer flag');
 });
 
-test('v2: social endorsement closer catches the bare-CTA variants', () => {
+test('v2: social endorsement closer covers every regex branch', () => {
+  // One positive per branch so a typo in any single pattern fails loudly
+  // instead of shipping green. Each string is padded to clear the 10-word
+  // floor and sit amid normal prose, the shape analyzeText actually sees.
   const variants = [
-    'Do yourself a favor and read this when you get a chance today.',
-    'New episode dropped this morning. You won\'t want to miss this one.',
-    'Saved my whole afternoon of debugging. Thank me later, seriously.',
-    'I cannot recommend this one a read enough for anyone shipping agents.',
+    'Sarah broke down the whole eviction policy in plain terms. This one is worth your time:',          // worth-endorsement
+    'New deep dive on agent memory just dropped today. This one is a must-read for the whole team.',     // must-read
+    'I read the entire thing twice this weekend. I highly recommend giving this a read soon.',           // recommend-a-read
+    'The setup is fiddly but the payoff is huge here. Do yourself a favor and read this tonight.',       // do-yourself-a-favor
+    'The agenda is packed and the speakers are all sharp. You won\'t want to miss this one.',             // won't-want-to-miss
+    'It saved me an entire afternoon of painful debugging. Thank me later, seriously, you will.',        // thank-me-later
+    'It is the cleanest reference I have found all year. Save this one for later when you ship.',        // save-for-later
+    'Everything you need for the whole migration is in this one. Bookmark this post.',                   // bookmark-this
+    'The benchmarks completely flip the usual assumptions. Don\'t sleep on this one, honestly.',         // don't-sleep-on
+    'The framing reframed the entire debate for me cleanly. Trust me, you\'ll want to read this.',       // trust-me-you'll
   ];
   for (const text of variants) {
     const r = AIDetector.analyzeText(text);
@@ -440,13 +449,41 @@ test('v2: social endorsement closer catches the bare-CTA variants', () => {
   }
 });
 
-test('v2: social endorsement closer does NOT fire on plain human endorsement', () => {
-  // Bare "worth reading" is a word-table judgment call, not the demonstrative
-  // closer — the detector should leave normal human prose alone.
-  const text = 'The book is worth reading if you have the time, but the middle third drags and I almost put it down before the payoff in the final chapters.';
-  const r = AIDetector.analyzeText(text);
-  const types = new Set(r.issues.map((i) => i.type));
-  assert.ok(!types.has('social-cta-closer'), 'plain endorsement should not trip the closer detector');
+test('v2: social endorsement closer matches curly-apostrophe forms', () => {
+  // LinkedIn / Word / macOS auto-curl apostrophes, so the canonical
+  // "you won't" / "don't" / "you'll" closers ship with U+2019, not ASCII.
+  // A straight-only class would miss the dominant real-world input.
+  const curly = [
+    'The agenda is packed and the speakers are all sharp. You won’t want to miss this one.',
+    'The benchmarks completely flip the usual assumptions. Don’t sleep on this one, honestly.',
+    'The framing reframed the entire debate for me cleanly. Trust me, you’ll want to read this.',
+  ];
+  for (const text of curly) {
+    const r = AIDetector.analyzeText(text);
+    const types = new Set(r.issues.map((i) => i.type));
+    assert.ok(types.has('social-cta-closer'), `expected social-cta-closer on curly form: ${text}`);
+  }
+});
+
+test('v2: social endorsement closer leaves literal-verb human prose alone', () => {
+  // The anchors (demonstrative object, terminal lookahead, sentence-initial
+  // lookbehind) exist to keep the detector off ordinary instructional and
+  // conversational text. Each of these uses a trigger word in its literal
+  // sense and must stay clean.
+  const clean = [
+    'The book is worth reading if you have the time, but the middle third drags and I almost put it down.',
+    'Bookmark this page so you can find the API reference later when you are wiring up the client.',
+    'I usually save this for later in the sprint when the review queue has finally cleared out a bit.',
+    'Do yourself a favor and read the runbook before you ever go on call for this service again.',
+    'You will not want to miss this design review tomorrow because the API contract is changing under us.',
+    'She will thank me later for the heads up once the deploy window actually closes without incident.',
+    'Trust me, this one took an entire afternoon to track down and it was a single off-by-one in the loop.',
+  ];
+  for (const text of clean) {
+    const r = AIDetector.analyzeText(text);
+    const types = new Set(r.issues.map((i) => i.type));
+    assert.ok(!types.has('social-cta-closer'), `false positive on literal prose: ${text}`);
+  }
 });
 
 test('v2: trinary output present + FN-biased for ambiguous text', () => {

--- a/detector/patterns.test.js
+++ b/detector/patterns.test.js
@@ -419,6 +419,36 @@ test('v2: parenthetical hedge fires', () => {
   assert.ok(types.has('parenthetical-hedge'), 'expected parenthetical-hedge flag');
 });
 
+test('v2: social endorsement closer fires on LinkedIn-style share post', () => {
+  const text = 'Just finished Sarah\'s deep dive on why context windows leak in long agent runs. She walks through the eviction policy line by line and shows where the tokens actually go. This one is worth your time:';
+  const r = AIDetector.analyzeText(text);
+  const types = new Set(r.issues.map((i) => i.type));
+  assert.ok(types.has('social-cta-closer'), 'expected social-cta-closer flag');
+});
+
+test('v2: social endorsement closer catches the bare-CTA variants', () => {
+  const variants = [
+    'Do yourself a favor and read this when you get a chance today.',
+    'New episode dropped this morning. You won\'t want to miss this one.',
+    'Saved my whole afternoon of debugging. Thank me later, seriously.',
+    'I cannot recommend this one a read enough for anyone shipping agents.',
+  ];
+  for (const text of variants) {
+    const r = AIDetector.analyzeText(text);
+    const types = new Set(r.issues.map((i) => i.type));
+    assert.ok(types.has('social-cta-closer'), `expected social-cta-closer on: ${text}`);
+  }
+});
+
+test('v2: social endorsement closer does NOT fire on plain human endorsement', () => {
+  // Bare "worth reading" is a word-table judgment call, not the demonstrative
+  // closer — the detector should leave normal human prose alone.
+  const text = 'The book is worth reading if you have the time, but the middle third drags and I almost put it down before the payoff in the final chapters.';
+  const r = AIDetector.analyzeText(text);
+  const types = new Set(r.issues.map((i) => i.type));
+  assert.ok(!types.has('social-cta-closer'), 'plain endorsement should not trip the closer detector');
+});
+
 test('v2: trinary output present + FN-biased for ambiguous text', () => {
   // A plain human bug-report should not get AI_ONLY even if score lifts.
   const text = 'The build broke again this morning. Rolled back the auth refactor and tests pass now. Still need to figure out why the token refresh path hits a 401 for users on Safari but not Firefox — probably a cookie scope issue but I want to confirm before shipping a fix.';

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "avoid-ai-writing-detector",
-  "version": "3.4.0",
-  "description": "Deterministic detection engine for the Avoid AI Writing skill — 43-category pattern + stylometric analysis of AI-generated text.",
+  "version": "3.5.0",
+  "description": "Deterministic detection engine for the Avoid AI Writing skill — 44-category pattern + stylometric analysis of AI-generated text.",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/plugins/avoid-ai-writing/.claude-plugin/plugin.json
+++ b/plugins/avoid-ai-writing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "avoid-ai-writing",
   "description": "Audit & rewrite content to remove AI writing patterns (\"AI-isms\"). Supports detect-only and edit-in-place modes, voice profiles, and iterate-to-convergence.",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "author": {
     "name": "Conor Bronsdon"
   },

--- a/plugins/avoid-ai-writing/skills/avoid-ai-writing/SKILL.md
+++ b/plugins/avoid-ai-writing/skills/avoid-ai-writing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: avoid-ai-writing
 description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Use this skill when asked to "remove AI-isms," "clean up AI writing," "edit writing for AI patterns," "audit writing for AI tells," or "make this sound less like AI." Supports a detect-only mode, an edit-in-place mode for files, an optional voice profile (casual / professional / technical / warm / blunt), and an iterate-to-convergence pass.
-version: 3.8.0
+version: 3.9.0
 license: MIT
 compatibility: Any AI coding assistant that supports agentskills.io SKILL.md format (Claude Code, Cursor, VS Code Copilot, Hermes Agent, OpenHands, etc.) or OpenClaw. No external tools or APIs required.
 metadata:
@@ -369,6 +369,12 @@ These slot-fill constructions signal that a sentence was generated, not written.
 - Punchy fragment-hooks that tee up a reveal: "The catch?", "The kicker?", "Here's the thing.", "But here's the kicker:", "The best part?", "Plot twist:", "The result?". AI uses these to fake momentum and manufacture suspense around ordinary information — the prose equivalent of a late-night infomercial.
 - Distinct from rhetorical-question openers (which stall before a point) and chatbot artifacts (which perform helpfulness): these are mid-flow teasers that pad the rhythm. The fix is to delete the hook and state the thing. "The catch? It only works on weekends." becomes "It only works on weekends." Adapted from `Aboudjem/humanizer-skill` P41.
 
+### Social endorsement closers
+- The curatorial sign-off LLMs append to LinkedIn and X posts that share or recommend something — usually a colon teeing up a link: "This one is worth your time:", "This one's a must-read:", "I highly recommend giving this a read.", "Do yourself a favor and read this.", "You won't want to miss this one.", "Save this for later.", "Bookmark this.", "Don't sleep on this one.", "Trust me, you'll want to read this.", "Thank me later."
+- Why it's a tell: it performs a recommendation without giving the reader a reason to click. The endorsement is generic and demonstrative-anchored ("THIS one is worth your time") — it could sit under any link, which is exactly why an LLM reaches for it to close a share post.
+- Distinct from the bare "worth [verb]ing" word-table entry (a single weak word inside a sentence) and from infomercial engagement hooks (mid-flow teasers like "The catch?"): this is the whole closing line of a social post.
+- The fix: say *what* the thing is and *who* it's for, then drop the CTA. "This one is worth your time:" becomes "Sarah's breakdown of why context windows leak — the clearest explanation I've found for anyone debugging RAG pipelines." If you can't name a specific reason, the share doesn't need a sign-off at all; let the link stand on its own.
+
 ### Emotional flatline
 - AI claims emotions as a structural crutch without conveying them through the writing: "What surprised me most," "I was fascinated to discover," "What struck me was," "I was excited to learn," "The most interesting part," and the bare section-header variant: "Interesting part of the project:" / "Interesting thing here:" / "Interesting aspect:". The header form drops "the most" but does the same job — pre-announcing significance the writing hasn't earned.
 - Two problems. First, it's tell-don't-show: if the thing is genuinely surprising, the reader should feel that from the content, not from the writer announcing it. Second, these phrases are massively overused as list introductions and transitions. They're filler wearing an emotion costume.
@@ -474,6 +480,7 @@ Not all AI-isms are equal. When doing a quick pass or triaging a large document,
 - Bold overuse
 - Em dash frequency (above 1 per 1,000 words)
 - Generic future-narrative closers ("may become one of the most important narratives…")
+- Social endorsement closers ("This one is worth your time:", "thank me later")
 - Hedge-stacked predictions ("could potentially," "may eventually")
 - Real/actual adjective inflation ("real on-chain tokenomics")
 - Bullet lists of bare noun phrases (5+ short adj+noun items, no verbs)
@@ -535,6 +542,7 @@ Rules not listed in the table apply at full strength across all profiles.
 | Bullet-NP lists | strict | strict | relaxed (technical option lists OK) | strict | relaxed (parameter lists OK) | skip |
 | Tier 3 phrase clustering | strict | strict | strict | **extra strict** | relaxed | skip |
 | Future-narrative closers | strict | strict | strict | **extra strict** | skip | skip |
+| Social endorsement closers | strict (the LinkedIn share-post tell) | strict | strict | strict | skip | relaxed (1 OK in a DM) |
 | Hedge-stacked predictions | strict | strict | relaxed ("could" is hedged accuracy) | **extra strict** | relaxed | skip |
 | Real/actual inflation | strict | strict | strict | **extra strict** | relaxed | skip |
 


### PR DESCRIPTION
Closes #29.

## What

LLMs love to close a LinkedIn/X share post with a generic curatorial sign-off teeing up a link — "This one is worth your time:", "This one's a must-read:", "Do yourself a favor and read this", "You won't want to miss this one", "Thank me later", "Bookmark this", "Don't sleep on this one". The endorsement is demonstrative-anchored ("**this one** is worth your time") and could sit under any link without changing — that interchangeability is the tell. It performs a recommendation without ever giving the reader a reason to click.

## Why it's its own category

- The bare word-table entry `worth [verb]ing` (line ~80 of SKILL.md) catches a single weak word inside a sentence. This is the whole closing line of a social post — a distinct structural shape.
- Infomercial engagement hooks ("The catch?", "The kicker?") are mid-flow teasers that pad rhythm. These are end-of-post CTAs.

## How it stays off human writing

The patterns require a demonstrative/CTA anchor — `this one`, `do yourself a favor and`, `won't want to miss this`, `thank me later`, `don't sleep on this`. Plain human endorsements like "the book is worth reading, but the middle drags" don't trip it (covered by a negative test).

## Changes

- **Detector:** new `social-cta-closer` `type` in `detector/patterns.js` (engine 43 → 44 types), weighted 8 like `formulaic-opener` so the `log2(words/50)` length divisor doesn't wash it out on a short post. Severity high.
- **Skill:** new "Social endorsement closers" section in `SKILL.md` (catalog 47 → 48), plus a P1-severity entry and a tolerance-matrix row (strict on `linkedin`, where it shows up most). Version 3.8.0 → 3.9.0.
- **Tests:** three fixtures in `patterns.test.js` — a LinkedIn-style share post, the bare-CTA variants, and a human-prose negative.
- **Sync:** mirrored into `cursor-rules/`, regenerated the bundled plugin skill, and updated the engine-count references across `README.md`, `CATEGORIES.md`, and `package.json`.

## Verification

```
npm test                       # all detector + contract fixtures pass (incl. 3 new)
bash scripts/check-pattern-count.sh   # pattern count in sync: 48
bash scripts/sync-plugin-skill.sh     # synced: plugin skill + version (3.9.0)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)