### PR TITLE
chore: Node 24-ready action bumps

### DIFF
--- a/.github/workflows/detector-test.yml
+++ b/.github/workflows/detector-test.yml
@@ -16,8 +16,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
       - run: npm test

--- a/.github/workflows/plugin-skill-sync.yml
+++ b/.github/workflows/plugin-skill-sync.yml
@@ -21,7 +21,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Validate manifest JSON
         run: |


### PR DESCRIPTION
GitHub is force-migrating Node 20 JavaScript actions to Node 24 on **June 16, 2026** (deprecation warnings already showing in CI logs). This bumps the workflow action pins in this repo to their current Node 24-ready major versions.

## Bumps
- `actions/checkout@v4` -> `actions/checkout@v6`
- `actions/setup-node@v4` -> `actions/setup-node@v6`

Each target major was verified Node 24-ready via `runs.using: node24` in the action's `action.yml` at its latest release tag. Version pins only — no other workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
