### PR TITLE
Add "match inflected forms" rule to word-replacement section

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -90,6 +90,8 @@ Words are organized into three tiers based on how reliably they signal AI-genera
 - **Tier 2 — Flag in clusters.** Individually fine, but two or more in the same paragraph is a strong AI signal. Flag when they appear together.
 - **Tier 3 — Flag by density.** Common words that AI simply overuses. Only flag when they make up a noticeable fraction of the text (roughly 3%+ of total words).
 
+**Match inflected forms.** Each entry below covers the listed word *and its morphological variants* — adverb (`-ly`), gerund/participle (`-ing`), plural, comparative/superlative, and verb conjugations — unless a variant carries a distinct, legitimate meaning. So `genuine` also flags `genuinely`, `leverage` also flags `leveraging` / `leveraged`, `delve` covers `delving`, and `meticulous` covers `meticulously`. When a variant has a separate honest sense (e.g. `real` meaning factual, not the intensifier in "a real improvement"), judge by context rather than matching blindly.
+
 #### Tier 1 — Always replace
 
 | Replace | With |

--- a/cursor-rules/avoid-ai-writing.mdc
+++ b/cursor-rules/avoid-ai-writing.mdc
@@ -82,6 +82,8 @@ Words are organized into three tiers based on how reliably they signal AI-genera
 - **Tier 2 — Flag in clusters.** Individually fine, but two or more in the same paragraph is a strong AI signal. Flag when they appear together.
 - **Tier 3 — Flag by density.** Common words that AI simply overuses. Only flag when they make up a noticeable fraction of the text (roughly 3%+ of total words).
 
+**Match inflected forms.** Each entry below covers the listed word *and its morphological variants* — adverb (`-ly`), gerund/participle (`-ing`), plural, comparative/superlative, and verb conjugations — unless a variant carries a distinct, legitimate meaning. So `genuine` also flags `genuinely`, `leverage` also flags `leveraging` / `leveraged`, `delve` covers `delving`, and `meticulous` covers `meticulously`. When a variant has a separate honest sense (e.g. `real` meaning factual, not the intensifier in "a real improvement"), judge by context rather than matching blindly.
+
 #### Tier 1 — Always replace
 
 | Replace | With |

--- a/plugins/avoid-ai-writing/skills/avoid-ai-writing/SKILL.md
+++ b/plugins/avoid-ai-writing/skills/avoid-ai-writing/SKILL.md
@@ -90,6 +90,8 @@ Words are organized into three tiers based on how reliably they signal AI-genera
 - **Tier 2 — Flag in clusters.** Individually fine, but two or more in the same paragraph is a strong AI signal. Flag when they appear together.
 - **Tier 3 — Flag by density.** Common words that AI simply overuses. Only flag when they make up a noticeable fraction of the text (roughly 3%+ of total words).
 
+**Match inflected forms.** Each entry below covers the listed word *and its morphological variants* — adverb (`-ly`), gerund/participle (`-ing`), plural, comparative/superlative, and verb conjugations — unless a variant carries a distinct, legitimate meaning. So `genuine` also flags `genuinely`, `leverage` also flags `leveraging` / `leveraged`, `delve` covers `delving`, and `meticulous` covers `meticulously`. When a variant has a separate honest sense (e.g. `real` meaning factual, not the intensifier in "a real improvement"), judge by context rather than matching blindly.
+
 #### Tier 1 — Always replace
 
 | Replace | With |


### PR DESCRIPTION
## What

Adds one interpretive rule to the top of the "Words and phrases to replace" section: each entry covers the listed word **and its morphological variants** (adverb `-ly`, gerund/participle `-ing`, plural, comparative/superlative, verb conjugations), unless a variant carries a distinct legitimate meaning, judged by context.

## Why

The table half-covered variants and was inconsistent: some rows spell out the pair (`meticulous / meticulously`, `seamless / seamlessly`, `delve / delve into`), most don't. So an auditor reading `genuine`, `leverage`, or `robust` had no instruction to extend to `genuinely`, `leveraging`, `robustly`. That's exactly the gap that let "genuinely" through in #35. Enumerating every inflection per row is whack-a-mole; one principle scales and future-proofs new entries.

The judgment carve-out ("distinct legitimate meaning, judged by context") is why this belongs in the LLM-read prose rather than as blind matching: e.g. `real` = factual vs. the intensifier in "a real improvement".

## Scope

This fixes the `/clean-ai-writing` (LLM/prose) path. The `detector/patterns.js` regex matches variants case-by-case (`genuine(?:ly)?`, `meticulous(?:ly)?`) and won't inherit the principle automatically; bringing the detector to parity is a separate follow-up PR.

## Files

Applied to `SKILL.md`, `cursor-rules/avoid-ai-writing.mdc`, and the synced plugin copy. Version left unchanged for maintainer to set on review.