### PR TITLE
Catch the split-sentence 'It's not X, it's Y' variant (#39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project are documented here.
 
 ---
 
+## [3.11.0] — 2026-07-05
+
+### Changed
+- **"It's not X — it's Y" contrastive rule** — broadened to name the **split-sentence variant**, where the negation and the correction land in two separate sentences ("The headline isn't the speed. The real story is Y.") rather than pivoting on a single dash or comma. The joined form was the rule's implicit template, so the two-sentence split — which reads as two innocent declaratives — was slipping through. Same move, now flagged. LLM-judgment rule; catalog stays at 49 categories. Addresses #39.
+
+---
+
 ## [3.10.0] — 2026-06-10
 
 ### Added

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: avoid-ai-writing
 description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Use this skill when asked to "remove AI-isms," "clean up AI writing," "edit writing for AI patterns," "audit writing for AI tells," or "make this sound less like AI." Supports a detect-only mode, an edit-in-place mode for files, an optional voice profile (casual / professional / technical / warm / blunt), and an iterate-to-convergence pass.
-version: 3.10.0
+version: 3.11.0
 license: MIT
 compatibility: Any AI coding assistant that supports agentskills.io SKILL.md format (Claude Code, Cursor, VS Code Copilot, Hermes Agent, OpenHands, etc.) or OpenClaw. No external tools or APIs required.
 metadata:
@@ -75,7 +75,7 @@ In **edit** mode, your job is to:
 - **Curly quotation marks (“ ” ‘ ’) and apostrophes**: Curly quotes and apostrophes (U+201C/U+201D, U+2018/U+2019) are a *weak* paste-from-chat signal — meaningful mainly in plain-text contexts like code comments, commit messages, or plaintext drafts, where nothing auto-curls. Treat as corroborating, never conclusive: Word, Google Docs, macOS, and iOS curl quotes by default, so most human prose contains them too. Don't flag curly apostrophes (U+2019) on their own. Replace with straight quotes in plain-text/code; leave them in finished publications and locale-correct punctuation (French « », German „ “).
 
 ### Sentence structure
-- **"It's not X — it's Y" / "This isn't about X, it's about Y"**: Rewrite as a direct positive statement. Max one per piece, and only if it serves the argument.
+- **"It's not X — it's Y" / "This isn't about X, it's about Y"**: Rewrite as a direct positive statement. Max one per piece, and only if it serves the argument. This includes the **split-sentence form**, where the negation and the correction fall in two separate sentences rather than pivoting on a single dash or comma: "The headline isn't the speed. The real story is Y." Read on its own, each sentence looks like an innocent declarative, which is exactly why the split version slips past a check tuned to the joined phrasing — flag it the same way.
 - **Hollow intensifiers**: Cut `genuine` / `genuinely`, `real` (as in "a real improvement"), `truly`, `quite frankly`, `to be honest`, `let's be clear`, `it's worth noting that`. Just state the fact.
 - **Vague endorsement ("worth [verb]ing")**: Cut or replace `worth reading`, `worth paying attention to`, `worth a look`, `worth exploring`, `worth checking out`, `worth your time`. These substitute a generic thumbs-up for a specific reason. Say *why* something matters instead.
 - **Hedging**: Cut `perhaps`, `could potentially`, `it's important to note that`, `to be clear`. Make the point directly.


### PR DESCRIPTION
The example in #39 slipped past the skill because the contrastive-negation rule (SKILL.md, Sentence structure) was written around the *joined* form — "It's not X — it's Y" pivoting on one dash or comma. The passage that got through uses the **split-sentence** version: `The headline isn't the speed. The real story is Y.` The negation and the correction sit in separate sentences, so each reads as an innocent declarative and nothing fires.

This extends the existing rule to name the split variant explicitly, with the #39 example, so the auditor treats it the same as the joined form. LLM-judgment rule; no new category (catalog stays at 49). Version 3.10.0 → 3.11.0 + changelog.

Left as a follow-up (not in this PR): hiSandog's suggestion on #39 to add a distinct "vague third-party validation / proof-point" category — that's a new pattern with real false-positive surface, worth its own considered rule (and its own carve-out, mirroring the named-contrast exception).

🤖 Generated with [Claude Code](https://claude.com/claude-code)