### PR TITLE
Add "quietly" to Tier 2 word table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project are documented here.
 
 ---
 
+## [3.12.0] — 2026-07-06
+
+### Added
+- **"quietly" to Tier 2 word table** — AI uses "quietly" as a significance adverb to imply underdog credibility without evidence: "quietly building," "quietly reshaping," "quietly becoming." On its own in a sentence it's fine; in a paragraph already leaning on other Tier 2 words it's a cluster tell. Added to both the SKILL.md Tier 2 table and the detector engine. The detector fires when "quietly" appears alongside one other Tier 2 word in the same paragraph. Replacement: cut the adverb, or name the concrete contrast. Source: tropes.fyi/tropes ("Quietly" and Other Magic Adverbs).
+
+---
+
 ## [3.11.0] — 2026-07-05
 
 ### Changed

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: avoid-ai-writing
 description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Use this skill when asked to "remove AI-isms," "clean up AI writing," "edit writing for AI patterns," "audit writing for AI tells," or "make this sound less like AI." Supports a detect-only mode, an edit-in-place mode for files, an optional voice profile (casual / professional / technical / warm / blunt), and an iterate-to-convergence pass.
-version: 3.11.0
+version: 3.12.0
 license: MIT
 compatibility: Any AI coding assistant that supports agentskills.io SKILL.md format (Claude Code, Cursor, VS Code Copilot, Hermes Agent, OpenHands, etc.) or OpenClaw. No external tools or APIs required.
 metadata:
@@ -198,6 +198,7 @@ These words are legitimate on their own. When two or more show up together, the 
 | nascent | new, early-stage, emerging |
 | quintessential | typical, classic, defining |
 | overarching | main, central, broad |
+| quietly | cut, or name the concrete contrast |
 | underpinning / underpinnings | basis, foundation, what supports |
 
 #### Tier 3 — Flag only at high density

--- a/detector/patterns.js
+++ b/detector/patterns.js
@@ -187,6 +187,7 @@ const AIDetector = (() => {
     'nascent': 'new, early-stage',
     'quintessential': 'typical, classic, defining',
     'overarching': 'main, central, broad',
+    'quietly': 'cut, or name the concrete contrast',
     'underpinning': 'basis, foundation',
     'underpinnings': 'basis, foundations',
     'paradigm-shifting': 'describe what shifted',

--- a/detector/patterns.test.js
+++ b/detector/patterns.test.js
@@ -168,6 +168,18 @@ test('hashtag-stuff does not fire on prose with 2-3 hashtags', () => {
   assert.ok(!types.has('hashtag-stuff'), 'should not flag 2 hashtags as hashtag-stuff');
 });
 
+test('"quietly" clusters with another Tier 2 word flags tier2', () => {
+  // "quietly" alone in a paragraph should not fire; paired with another
+  // Tier 2 word in the same paragraph it should produce a tier2 issue.
+  const single = AIDetector.analyzeText('The team quietly shipped the update last week without any announcement.');
+  const singleTypes = new Set(single.issues.map((i) => i.type));
+  assert.ok(!singleTypes.has('tier2'), 'single "quietly" should not fire tier2 on its own');
+
+  const clustered = AIDetector.analyzeText('The team quietly worked to harness new opportunities, building the platform without any announcement.');
+  const clusteredTypes = new Set(clustered.issues.map((i) => i.type));
+  assert.ok(clusteredTypes.has('tier2'), 'expected tier2 flag when "quietly" clusters with another Tier 2 word');
+});
+
 test('bullet-np-list does not fire on prose containing short verb-form bullets', () => {
   // Genuine list items with finite verbs should not trip the bare-NP
   // detector. The verb-token guard is what keeps todo lists, changelog

--- a/plugins/avoid-ai-writing/.claude-plugin/plugin.json
+++ b/plugins/avoid-ai-writing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "avoid-ai-writing",
   "description": "Audit & rewrite content to remove AI writing patterns (\"AI-isms\"). Supports detect-only and edit-in-place modes, voice profiles, and iterate-to-convergence.",
-  "version": "3.10.0",
+  "version": "3.12.0",
   "author": {
     "name": "Conor Bronsdon"
   },

--- a/plugins/avoid-ai-writing/skills/avoid-ai-writing/SKILL.md
+++ b/plugins/avoid-ai-writing/skills/avoid-ai-writing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: avoid-ai-writing
 description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Use this skill when asked to "remove AI-isms," "clean up AI writing," "edit writing for AI patterns," "audit writing for AI tells," or "make this sound less like AI." Supports a detect-only mode, an edit-in-place mode for files, an optional voice profile (casual / professional / technical / warm / blunt), and an iterate-to-convergence pass.
-version: 3.10.0
+version: 3.12.0
 license: MIT
 compatibility: Any AI coding assistant that supports agentskills.io SKILL.md format (Claude Code, Cursor, VS Code Copilot, Hermes Agent, OpenHands, etc.) or OpenClaw. No external tools or APIs required.
 metadata:
@@ -75,7 +75,7 @@ In **edit** mode, your job is to:
 - **Curly quotation marks (“ ” ‘ ’) and apostrophes**: Curly quotes and apostrophes (U+201C/U+201D, U+2018/U+2019) are a *weak* paste-from-chat signal — meaningful mainly in plain-text contexts like code comments, commit messages, or plaintext drafts, where nothing auto-curls. Treat as corroborating, never conclusive: Word, Google Docs, macOS, and iOS curl quotes by default, so most human prose contains them too. Don't flag curly apostrophes (U+2019) on their own. Replace with straight quotes in plain-text/code; leave them in finished publications and locale-correct punctuation (French « », German „ “).
 
 ### Sentence structure
-- **"It's not X — it's Y" / "This isn't about X, it's about Y"**: Rewrite as a direct positive statement. Max one per piece, and only if it serves the argument.
+- **"It's not X — it's Y" / "This isn't about X, it's about Y"**: Rewrite as a direct positive statement. Max one per piece, and only if it serves the argument. This includes the **split-sentence form**, where the negation and the correction fall in two separate sentences rather than pivoting on a single dash or comma: "The headline isn't the speed. The real story is Y." Read on its own, each sentence looks like an innocent declarative, which is exactly why the split version slips past a check tuned to the joined phrasing — flag it the same way.
 - **Hollow intensifiers**: Cut `genuine` / `genuinely`, `real` (as in "a real improvement"), `truly`, `quite frankly`, `to be honest`, `let's be clear`, `it's worth noting that`. Just state the fact.
 - **Vague endorsement ("worth [verb]ing")**: Cut or replace `worth reading`, `worth paying attention to`, `worth a look`, `worth exploring`, `worth checking out`, `worth your time`. These substitute a generic thumbs-up for a specific reason. Say *why* something matters instead.
 - **Hedging**: Cut `perhaps`, `could potentially`, `it's important to note that`, `to be clear`. Make the point directly.
@@ -198,6 +198,7 @@ These words are legitimate on their own. When two or more show up together, the 
 | nascent | new, early-stage, emerging |
 | quintessential | typical, classic, defining |
 | overarching | main, central, broad |
+| quietly | cut, or name the concrete contrast |
 | underpinning / underpinnings | basis, foundation, what supports |
 
 #### Tier 3 — Flag only at high density


### PR DESCRIPTION
## Summary

Adds `quietly` to the Tier 2 word table and detector engine.

`quietly` is legitimate on its own, so this keeps it cluster-gated: a lone use does not flag, but it contributes to a Tier 2 issue when paired with another Tier 2 word in the same paragraph.

## Why

Recent AI-written prose often uses `quietly` as a significance adverb: “quietly building,” “quietly reshaping,” “quietly becoming.” The word implies understated importance or underdog credibility without adding evidence.

References:
- https://tropes.fyi/tropes/quietly-adverb
- https://www.linkedin.com/posts/eliana-cline_genuine-question-why-is-claude-fixated-on-activity-7459884566405890049-E2uB
- https://sulliwrites.medium.com/if-i-see-the-words-quiet-quietly-one-more-time-im-going-to-lose-it-dd0c6206bf96

## Changes

- `SKILL.md`: adds `quietly` to Tier 2 and bumps the skill version to `3.12.0`
- `detector/patterns.js`: adds `quietly` to the Tier 2 detector table
- `detector/patterns.test.js`: adds coverage for the cluster boundary
- `CHANGELOG.md`: documents the new rule

I left the Cursor port alone for now because it is already several versions behind, and other PRs do not always update it directly. Happy to sync the Cursor port if you want this PR to include that too.


## Checklist

- [x] `npm test` passes (engine fixtures + `CATEGORIES.md` contract check)
- [x] If I added a detector `type`: it's documented in `detector/CATEGORIES.md` and has a fixture in `detector/patterns.test.js` (a true positive **and** a must-not-fire case)
- [x] If I added a judgment-only rule: it's listed under "Skill-only" in `detector/CATEGORIES.md`
- [x] I considered false positives and added carve-outs for legitimate human writing
- [x] Any factual claim about how AI or humans write (e.g. "ChatGPT emits X", "humans rarely do Y") cites a source
- [x] The prose I added passes the skill's own audit (no AI-writing tells, terse bullets, no hollow intensifiers)
- [x] `CHANGELOG.md` entry added under a dated `## [X.Y.Z]` heading, and `SKILL.md` `version:` bumped if a rule changed
