### PR TITLE
Fix package.json version drift (3.5.0 -> 3.14.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "avoid-ai-writing-detector",
-  "version": "3.5.0",
-  "description": "Deterministic detection engine for the Avoid AI Writing skill — 44-category pattern + stylometric analysis of AI-generated text.",
+  "version": "3.14.0",
+  "description": "Deterministic detection engine for the Avoid AI Writing skill — 45-type pattern + stylometric analysis of AI-generated text.",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- `package.json`'s `version` field was stuck at `3.5.0` (last touched in the 3.5.0 release, 2026-05-27) while `CHANGELOG.md`, the git tags, and `plugins/avoid-ai-writing/.claude-plugin/plugin.json` have all moved on to `3.14.0`.
- Also fixes the adjacent stale `"44-category"` wording in the same description string — the engine is currently at 45 detector types per `detector/CATEGORIES.md`'s anti-drift contract.
- `grep -rn "3\.5\.0"` across the repo now only matches the historical `CHANGELOG.md` entry for the 3.5.0 release itself, which is correct and untouched.

## Why this doesn't just rot again
Confirmed what actually reads `package.json`'s version before touching it:
- **Not published to npm** (`avoid-ai-writing-detector` 404s on the registry) — no external consumer pins against it.
- `.github/workflows/release.yml` (added in #50, the CHANGELOG-driven release cutter) reads CHANGELOG.md as the authoritative version source for tagging and releases, and only emits a **non-blocking warning** if `package.json` disagrees — it explicitly says "This is pre-existing drift, not something this workflow fixes." This PR clears that warning.
- `scripts/sync-plugin-skill.sh` keeps `plugin.json`'s version in lockstep with `SKILL.md`'s frontmatter (already correct at 3.14.0) — it does not touch `package.json`.

## Test plan
- [x] `npm test` — detector fixtures + CATEGORIES.md anti-drift contract, both pass
- [x] `bash scripts/check-pattern-count.sh` — pattern count in sync: 51
- [x] `bash scripts/sync-plugin-skill.sh` — synced, no diff (plugin.json already at 3.14.0)
- [x] `grep -rn "3\.5\.0"` — only the historical CHANGELOG entry remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)