### PR TITLE
Add lingering-attention claims rule (v3.20.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project are documented here.
 
 ---
 
+## [3.20.0] — 2026-07-29
+
+### Added
+
+One rule with detector coverage, found while drafting a podcast teaser post. Catalog goes from 59 to 60 detection categories; the engine goes from 45 to 46 `type`s.
+
+- **Lingering-attention claims** (`lingering-attention`) — the share-post frame that claims a thing has occupied the writer's mind rather than saying anything about the thing: `"the line I keep coming back to"`, `"I can't stop thinking about this"`, `"still thinking about this one"`, `"rattling around in my head all week"`, `"I've been chewing on this"`. Sits next to **emotional flatline** in the catalog but is a separate claim: flatline claims a *feeling* ("What surprised me most"), this claims *duration* of attention, which is unfalsifiable and self-flattering in a way a feeling isn't. It also opens a share post where **social endorsement closers** close one. Added to the P1 severity tier.
+- **Precision carve-out.** The bare verb phrase `"I keep coming back to X"` deliberately does *not* fire, because it is legitimate whenever a reason follows ("I keep coming back to the exit-voice framing because it predicts which engineers quit"), and the reason clause is not reliably regex-detectable. Only the noun-anchored frame (`the line/quote/bit/idea ... I keep coming back to`) is matched — the shape that introduces a subject instead of asserting something about it. The bare form stays an LLM-judgment call in the skill prose. Fixtures cover both directions, including the must-not-fire case.
+
+---
+
 ## [3.19.0] — 2026-07-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ A one-shot "make this sound human" prompt catches the obvious stuff. This skill 
 - **Structured audit** — returns identified issues with quoted text, the rewrite, a change summary, and a second-pass audit in four discrete sections. You see exactly what changed and why.
 - **Two-pass detection** — the second pass re-reads the rewrite and catches patterns that survive the first edit: recycled transitions, lingering inflation, copula swaps that snuck through.
 - **112-entry word replacement table across 3 tiers + 10 Tier 3 phrases** — not vibes-based. Every flagged word has a specific, plainer alternative. "Leverage" → "use." "Commence" → "start." Tier 1 words always flag, Tier 2 words flag when they cluster, Tier 3 words flag only at high density. Tier 3 *phrases* (multi-word boilerplate like "the integration of," "decentralized compute") flag on per-phrase repetition or when 3+ distinct phrases stack in one piece — the LLM-self-varies-boilerplate shape.
-- **59 pattern categories** — representative examples below, each with before/after. Includes structural detection (hashtag stuffing, bare-NP bullet lists, hedge-stacked predictions), AI-tool fingerprints (placeholders, citation markup, UTM params), rhythm/uniformity checks, conversational-register tells, and writer-side tests. The full catalog lives in [`SKILL.md`](./SKILL.md); this count is enforced against it in CI.
+- **60 pattern categories** — representative examples below, each with before/after. Includes structural detection (hashtag stuffing, bare-NP bullet lists, hedge-stacked predictions), AI-tool fingerprints (placeholders, citation markup, UTM params), rhythm/uniformity checks, conversational-register tells, and writer-side tests. The full catalog lives in [`SKILL.md`](./SKILL.md); this count is enforced against it in CI.
 - **Detect mode** — flag patterns without rewriting. See which flags are real problems vs. judgment calls. Useful when patterns might be intentional or you're auditing content you don't want altered.
 - **Works across platforms** — one `SKILL.md` runs in Claude Code, Cowork (as a plugin), OpenClaw, and Cursor (as a ported rule). See the install paths below.
 
@@ -275,6 +275,12 @@ Added after a real-world exchange in which a maintainer called out an assisted-s
 |---|---------|--------|-------|
 | 52 | **Wall-of-text replies** | A 4+ sentence, sub-150-word reply delivered as one unbroken paragraph with no line breaks — the shape LLMs default to in issue/PR comments, chat, and DMs | Break at thought boundaries. One idea per line-group, the way a person actually types a reply |
 | 53 | **Recap-flattery opener** | "Thanks for all the legwork here — the migration script and the rollback plan you worked through are what made this possible." | Substance first. If thanks is warranted, one plain clause without the recap: "Thanks for the legwork — this looks right to me" |
+
+### Share-post framing (v3.20)
+
+| # | Pattern | Before | After |
+|---|---------|--------|-------|
+| 54 | **Lingering-attention claims** | "The line I keep coming back to:", "I can't stop thinking about this," "this has been rattling around in my head all week" | Open on the thing itself. Carve-out: keep the frame when a reason follows ("I keep coming back to exit-voice because it predicts who quits") |
 
 Two writer-side **tests** round out the catalog (judgment checks, not auto-detected): **paragraph-reshuffle immunity** (can you swap two body paragraphs without breaking the piece?) and the **treadmill effect** ("what's actually new in this paragraph?").
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: avoid-ai-writing
 description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Use this skill when asked to "remove AI-isms," "clean up AI writing," "edit writing for AI patterns," "audit writing for AI tells," or "make this sound less like AI." Supports a detect-only mode, an edit-in-place mode for files, an optional voice profile (casual / professional / technical / warm / blunt), and an iterate-to-convergence pass.
-version: 3.19.0
+version: 3.20.0
 license: MIT
 compatibility: Any AI coding assistant that supports agentskills.io SKILL.md format (Claude Code, Cursor, VS Code Copilot, Hermes Agent, OpenHands, etc.) or OpenClaw. No external tools or APIs required.
 metadata:
@@ -428,6 +428,12 @@ These slot-fill constructions signal that a sentence was generated, not written.
 - The fix isn't "never say surprised." It's: if you claim an emotion, the writing around it should earn it. Otherwise cut the claim and present the thing directly.
 - Related pattern: "hit differently" / "hits different." AI uses trendy colloquialisms as a shortcut to sound relatable without earning the emotional beat. If something genuinely affected you, describe how. Otherwise cut.
 
+### Lingering-attention claims
+- The share-post frame that claims a thing has occupied the writer's mind: "the line I keep coming back to," "I can't stop thinking about this," "still thinking about this one," "this has been rattling around in my head all week," "I've been chewing on this since Tuesday." The claim is about the writer's attention, not about the thing, and it arrives *before* the reader has any reason to care.
+- Distinct from emotional flatline, which claims a **feeling** ("What surprised me most"). This claims **duration** of attention, which is unfalsifiable and self-flattering in a way a feeling isn't: nobody can check whether you kept coming back to it, and the frame implies the quote earned repeat visits without showing what it earned them with. Also distinct from social endorsement closers, which vouch for a link at the end of a post; this opens one.
+- **Carve-out — reason attached.** Leave it when the sentence says *why* the thing recurred: "I keep coming back to Hirschman's exit-voice framing because it predicts which engineers quit and which ones file the RFC." That's a claim about the idea's explanatory reach. The tell is the bare frame with the reason missing.
+- Fix: delete the frame and open on the thing itself. "The line I keep coming back to: agents are teenagers." becomes "Jeetu describes AI agents as teenagers." The quote either lands or it doesn't, and the frame doesn't change which.
+
 ### False concession structure
 - "While X is impressive, Y remains a challenge" or "Although X has made strides, Y is still an open question." AI uses this to sound balanced without actually weighing anything. Both halves are vague. Either make the concession specific (name what's impressive, name the actual challenge) or pick a side and argue it.
 
@@ -556,6 +562,7 @@ Not all AI-isms are equal. When doing a quick pass or triaging a large document,
 - Em dash frequency (above 1 per 1,000 words)
 - Generic future-narrative closers ("may become one of the most important narratives…")
 - Social endorsement closers ("This one is worth your time:", "thank me later")
+- Lingering-attention claims ("the line I keep coming back to," "I can't stop thinking about this")
 - Hedge-stacked predictions ("could potentially," "may eventually")
 - Real/actual adjective inflation ("real on-chain tokenomics")
 - Moral-adjective category errors ("honest shape," "flagged honestly")

--- a/detector/CATEGORIES.md
+++ b/detector/CATEGORIES.md
@@ -6,14 +6,14 @@ the skill, decide here whether it's regex-detectable (give it a detector `type`)
 or LLM-only judgment (mark it so). When you add a detector `type`, point it back
 at the skill section it enforces.
 
-The engine exposes 45 issue `type`s (see `TYPE_LABELS` in `patterns.js`). The
+The engine exposes 46 issue `type`s (see `TYPE_LABELS` in `patterns.js`). The
 skill has more `###` sections than that — the gap is **not** missing coverage,
 it's rules that are judgment calls a regex can't make. The three groups below
 account for every entry on both sides.
 
 Three counts coexist on purpose and should not be forced to match: the README's
 **pattern-category count** (the human-facing prose catalog, derived from SKILL.md
-and guarded in CI), the engine's **45 `type`s** (which split the vocabulary tiers
+and guarded in CI), the engine's **46 `type`s** (which split the vocabulary tiers
 and add stylometric signals), and SKILL.md's `###` sections (which also include
 writer-side tests with no detectable form). The
 `categories.test.js` check enforces only the engine ↔ this-file mapping.
@@ -41,6 +41,7 @@ writer-side tests with no detectable form). The
 | `real-actual-inflation` | "Real/actual" inflation | "Real/actual" adjective inflation |
 | `vague-attribution` | Vague attribution | Vague attributions |
 | `emotional-flatline` | Emotional flatline | Emotional flatline / Superficial -ing analyses |
+| `lingering-attention` | Lingering-attention claim | Lingering-attention claims *(noun-anchored frames only — the bare "I keep coming back to X" stays LLM-judgment, since a following reason clause makes it legitimate and isn't regex-detectable)* |
 | `cutoff-disclaimer` | Cutoff disclaimer | Cutoff disclaimers |
 | `false-concession` | False concession | False concession structure |
 | `rhetorical-question` | Rhetorical question | Rhetorical question openers |

--- a/detector/patterns.js
+++ b/detector/patterns.js
@@ -286,6 +286,7 @@ const AIDetector = (() => {
     'vague-attribution': 5,
     'hollow-intensifier': 2,
     'emotional-flatline': 2,
+    'lingering-attention': 3,
     'novelty-inflation': 3,
     'cutoff-disclaimer': 10,
     'template-phrase': 3,
@@ -461,6 +462,30 @@ const AIDetector = (() => {
     // `(?:^|\n)` form silently missed bare openers at the very start of
     // input — caught by silent-failure audit 2026-05-16.
     /^\s*interesting\s+(?:part|thing|aspect|piece)(?:\s+of\s+(?:the\s+)?\w+)?\s*:/gim,
+  ];
+
+  // ─── Lingering-attention claims ────────────────────────────────────
+  // The share-post opener that claims duration of attention instead of
+  // saying anything about the thing ("the line I keep coming back to").
+  //
+  // Precision note: the bare verb phrase "I keep coming back to X" is NOT
+  // matched on its own, because it is legitimate whenever a reason follows
+  // ("I keep coming back to Hirschman because it predicts who quits"), and
+  // the reason clause is not reliably detectable by regex. Only the
+  // noun-anchored frame ("the line/quote/bit ... I keep coming back to")
+  // fires, which is the shape that introduces a subject rather than
+  // asserting something about it. The bare form stays a skill-prose
+  // judgment call. See SKILL.md §Lingering-attention claims carve-out.
+  const LINGERING_ATTENTION = [
+    // "the line I keep coming back to", "the one quote that I keep coming back to"
+    // Noun-anchored frame only. "can't stop thinking about" is deliberately
+    // left to its own pattern below rather than folded into this alternation,
+    // so "the line I can't stop thinking about" scores once, not twice.
+    /\b(?:the|that|this)\s+(?:one\s+)?(?:line|quote|bit|part|idea|point|framing|comment|thing)\s+(?:that\s+)?i\s+keep\s+(?:coming\s+back\s+to|thinking\s+about)\b/gi,
+    /\bi\s+can'?t\s+stop\s+thinking\s+about\b/gi,
+    /\bstill\s+thinking\s+about\s+(?:this|that)\s+one\b/gi,
+    /\b(?:been|be)\s+rattling\s+around\s+(?:in\s+)?my\s+(?:head|brain)\b/gi,
+    /\bi'?ve\s+been\s+chewing\s+on\s+(?:this|that)\b/gi,
   ];
 
   // ─── Novelty inflation ─────────────────────────────────────────────
@@ -910,6 +935,7 @@ const AIDetector = (() => {
     issues.push(...matchPatterns(text, VAGUE_ATTRIBUTIONS, 'vague-attribution', 'critical'));
     issues.push(...matchPatterns(text, HOLLOW_INTENSIFIERS, 'hollow-intensifier', 'medium'));
     issues.push(...matchPatterns(text, EMOTIONAL_FLATLINE, 'emotional-flatline', 'low'));
+    issues.push(...matchPatterns(text, LINGERING_ATTENTION, 'lingering-attention', 'medium'));
     issues.push(...matchPatterns(text, NOVELTY_INFLATION, 'novelty-inflation', 'medium'));
     issues.push(...matchPatterns(text, CUTOFF_DISCLAIMERS, 'cutoff-disclaimer', 'critical'));
     issues.push(...matchPatterns(text, AI_PLACEHOLDERS, 'ai-placeholder', 'critical'));
@@ -1712,6 +1738,7 @@ const AIDetector = (() => {
     'vague-attribution': 'Vague attribution',
     'hollow-intensifier': 'Hollow intensifier',
     'emotional-flatline': 'Emotional flatline',
+    'lingering-attention': 'Lingering-attention claim',
     'novelty-inflation': 'Novelty inflation',
     'cutoff-disclaimer': 'Cutoff disclaimer',
     'template-phrase': 'Template phrase',

--- a/detector/patterns.test.js
+++ b/detector/patterns.test.js
@@ -214,6 +214,29 @@ test('"Interesting part of the project:" header opener flags emotional-flatline'
   assert.ok(types.has('emotional-flatline'), 'expected emotional-flatline flag');
 });
 
+test('"the line I keep coming back to" flags lingering-attention', () => {
+  const text = 'Recorded with a guest yesterday. The line I keep coming back to is that agents behave like teenagers on an unbounded goal.';
+  const r = AIDetector.analyzeText(text);
+  const types = new Set(r.issues.map((i) => i.type));
+  assert.ok(types.has('lingering-attention'), 'expected lingering-attention flag');
+});
+
+test('"I cannot stop thinking about" flags lingering-attention', () => {
+  const text = "I can't stop thinking about the runtime guardrail argument he made near the end of our conversation about agent drift.";
+  const r = AIDetector.analyzeText(text);
+  const types = new Set(r.issues.map((i) => i.type));
+  assert.ok(types.has('lingering-attention'), 'expected lingering-attention flag');
+});
+
+test('bare "I keep coming back to X because ..." does NOT flag lingering-attention', () => {
+  // Precision carve-out: the bare verb phrase with a reason attached is
+  // legitimate analytical writing, so only the noun-anchored frame fires.
+  const text = 'I keep coming back to the exit-voice framing because it predicts which engineers quit and which ones file the RFC instead.';
+  const r = AIDetector.analyzeText(text);
+  const types = new Set(r.issues.map((i) => i.type));
+  assert.ok(!types.has('lingering-attention'), 'bare reasoned form must not flag');
+});
+
 test('"real on-chain tokenomics" flags real-actual-inflation', () => {
   const text = 'The team is researching real on-chain tokenomics and actual reward sustainability versus electricity cost across the network deployment phase.';
   const r = AIDetector.analyzeText(text);

--- a/plugins/avoid-ai-writing/.claude-plugin/plugin.json
+++ b/plugins/avoid-ai-writing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "avoid-ai-writing",
   "description": "Audit & rewrite content to remove AI writing patterns (\"AI-isms\"). Supports detect-only and edit-in-place modes, voice profiles, and iterate-to-convergence.",
-  "version": "3.19.0",
+  "version": "3.20.0",
   "author": {
     "name": "Conor Bronsdon"
   },

--- a/plugins/avoid-ai-writing/skills/avoid-ai-writing/SKILL.md
+++ b/plugins/avoid-ai-writing/skills/avoid-ai-writing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: avoid-ai-writing
 description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Use this skill when asked to "remove AI-isms," "clean up AI writing," "edit writing for AI patterns," "audit writing for AI tells," or "make this sound less like AI." Supports a detect-only mode, an edit-in-place mode for files, an optional voice profile (casual / professional / technical / warm / blunt), and an iterate-to-convergence pass.
-version: 3.19.0
+version: 3.20.0
 license: MIT
 compatibility: Any AI coding assistant that supports agentskills.io SKILL.md format (Claude Code, Cursor, VS Code Copilot, Hermes Agent, OpenHands, etc.) or OpenClaw. No external tools or APIs required.
 metadata:
@@ -428,6 +428,12 @@ These slot-fill constructions signal that a sentence was generated, not written.
 - The fix isn't "never say surprised." It's: if you claim an emotion, the writing around it should earn it. Otherwise cut the claim and present the thing directly.
 - Related pattern: "hit differently" / "hits different." AI uses trendy colloquialisms as a shortcut to sound relatable without earning the emotional beat. If something genuinely affected you, describe how. Otherwise cut.
 
+### Lingering-attention claims
+- The share-post frame that claims a thing has occupied the writer's mind: "the line I keep coming back to," "I can't stop thinking about this," "still thinking about this one," "this has been rattling around in my head all week," "I've been chewing on this since Tuesday." The claim is about the writer's attention, not about the thing, and it arrives *before* the reader has any reason to care.
+- Distinct from emotional flatline, which claims a **feeling** ("What surprised me most"). This claims **duration** of attention, which is unfalsifiable and self-flattering in a way a feeling isn't: nobody can check whether you kept coming back to it, and the frame implies the quote earned repeat visits without showing what it earned them with. Also distinct from social endorsement closers, which vouch for a link at the end of a post; this opens one.
+- **Carve-out — reason attached.** Leave it when the sentence says *why* the thing recurred: "I keep coming back to Hirschman's exit-voice framing because it predicts which engineers quit and which ones file the RFC." That's a claim about the idea's explanatory reach. The tell is the bare frame with the reason missing.
+- Fix: delete the frame and open on the thing itself. "The line I keep coming back to: agents are teenagers." becomes "Jeetu describes AI agents as teenagers." The quote either lands or it doesn't, and the frame doesn't change which.
+
 ### False concession structure
 - "While X is impressive, Y remains a challenge" or "Although X has made strides, Y is still an open question." AI uses this to sound balanced without actually weighing anything. Both halves are vague. Either make the concession specific (name what's impressive, name the actual challenge) or pick a side and argue it.
 
@@ -556,6 +562,7 @@ Not all AI-isms are equal. When doing a quick pass or triaging a large document,
 - Em dash frequency (above 1 per 1,000 words)
 - Generic future-narrative closers ("may become one of the most important narratives…")
 - Social endorsement closers ("This one is worth your time:", "thank me later")
+- Lingering-attention claims ("the line I keep coming back to," "I can't stop thinking about this")
 - Hedge-stacked predictions ("could potentially," "may eventually")
 - Real/actual adjective inflation ("real on-chain tokenomics")
 - Moral-adjective category errors ("honest shape," "flagged honestly")


### PR DESCRIPTION
## What

Adds one detection category, **lingering-attention claims**, with detector coverage. Catalog 59 → 60; engine 45 → 46 `type`s. Version 3.20.0.

The rule covers the share-post frame that claims a thing has occupied the writer's mind rather than saying anything about the thing:

- "the line I keep coming back to"
- "I can't stop thinking about this"
- "still thinking about this one"
- "this has been rattling around in my head all week"
- "I've been chewing on this since Tuesday"

## Why it isn't just emotional flatline

Emotional flatline claims a **feeling** ("What surprised me most"). This claims **duration of attention**, which is a different and worse move: nobody can check whether you kept coming back to something, and the frame implies the quote earned repeat visits without showing what it earned them with. It also sits at the *opening* of a share post, where social endorsement closers sit at the close, so neither existing category catches it.

Found in the wild the ordinary way: it turned up in a first-draft podcast teaser post, got called out as an obvious tell, and wasn't in the catalog.

## Precision

Per CONTRIBUTING's precision-over-recall bias, the bare verb phrase **"I keep coming back to X" deliberately does not fire**. It's legitimate whenever a reason follows, and the reason clause isn't reliably regex-detectable:

> I keep coming back to the exit-voice framing because it predicts which engineers quit and which ones file the RFC.

Only the noun-anchored frame matches (`the line/quote/bit/idea/point/framing/comment/thing ... I keep coming back to`) — the shape that introduces a subject instead of asserting something about it. The bare form stays an LLM-judgment call, documented as a carve-out in the skill prose and noted in `CATEGORIES.md`.

"can't stop thinking about" is kept as its own pattern rather than folded into the noun-anchored alternation, so "the line I can't stop thinking about" scores once, not twice.

## Verification

```
npm test                          # all fixtures + CATEGORIES contract pass
bash scripts/check-pattern-count.sh   # pattern count in sync: 60
bash scripts/sync-plugin-skill.sh     # synced: plugin skill + version (3.20.0)
```

Spot-checked behavior:

| Input | Flags |
|---|---|
| "The line I can't stop thinking about is that agents behave like teenagers…" | 1 |
| "The line I keep coming back to is that agents behave like teenagers…" | 1 |
| "This has been rattling around in my head all week since we finished recording…" | 1 |
| "I keep coming back to the exit-voice framing because it predicts which engineers quit…" | 0 |
| "Jeetu describes AI agents as teenagers. Profoundly intelligent, extremely resourceful…" | 0 |

Fixtures cover both true positives and the must-not-fire carve-out.

## No source citation

The rule rests on the mechanism (it's the duration-claim sibling of two already-documented tell-don't-show categories), not on an empirical claim about frequency, so there's nothing to cite. If you'd rather see a corpus count before this lands, say so and I'll drop it to judgment-only prose without a detector type.

## Left alone

`cursor-rules/avoid-ai-writing.mdc` is a manual port still labeled v3.16.0, three minor versions behind and not covered by CI. Adding this one rule there would make it look current while three versions of drift remain, so it's untouched. Worth a separate catch-up pass or a sync script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
