### PR TITLE
Add UTM tags to chainofthought.show and conorbronsdon.com links

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ Pattern research informed by:
 - [brandonwise/humanizer](https://github.com/brandonwise/humanizer) — tiered vocabulary system, statistical analysis research (burstiness, sentence length variation, trigram repetition), and rewrite philosophy
 - [OpenClaw](https://github.com/openclaw/openclaw) humanizer skill ecosystem — community patterns and vocabulary research
 
-Authored by [Conor Bronsdon](https://github.com/conorbronsdon) · [LinkedIn](https://www.linkedin.com/in/conorbronsdon/) · [Chain of Thought podcast](https://chainofthought.show)
+Authored by [Conor Bronsdon](https://github.com/conorbronsdon) · [LinkedIn](https://www.linkedin.com/in/conorbronsdon/) · [Chain of Thought podcast](https://chainofthought.show/?utm_source=github&utm_medium=referral&utm_campaign=repo-readme&utm_content=avoid-ai-writing)
 
 ## Community / Multilingual
 


### PR DESCRIPTION
Part of the repo-wide sweep in conorbronsdon/cot-production#115.

Tags the 1 link(s) in this repo's markdown so referral traffic to the show and to conorbronsdon.com is attributable:

```
?utm_source=github&utm_medium=referral&utm_campaign=repo-readme&utm_content=avoid-ai-writing
```

Untagged, every repo's About footer and Chain of Thought badge lands in GA4's **Direct** bucket, indistinguishable from every other repo. `utm_content` carries the repo name so this one reports as its own row.

Applied by `scripts/utm-tag-links.py` in cot-production; `--check` exits 0 on this branch. Link targets and anchor text are unchanged — only the query string is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)