### PR TITLE
package: version had drifted six releases behind the skill

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avoid-ai-writing-detector",
-  "version": "3.16.0",
+  "version": "3.22.1",
   "description": "Deterministic detection engine for the Avoid AI Writing skill — 45-type pattern + stylometric analysis of AI-generated text.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Caught while preparing the first npm publish of `avoid-ai-writing-detector`.

`package.json` said **3.16.0**. `SKILL.md` frontmatter and the top of `CHANGELOG.md` both say **3.22.1**. Six releases of drift on a fact this repo owns.

Nothing downstream was wrong, because the package has never been published — but publishing would have put `3.16.0` metadata on npm against `3.22.1` code, and **npm versions cannot be rewritten**. That would have been permanent.

This is precisely the failure mode `ssot-check` exists to catch, on a version string that lives in three files. Worth considering whether the package version belongs in this repo's `.ssot.yaml` manifest with `SKILL.md` as canonical.

Verification — full suite green:

```
npm test  ->  detector/patterns.test.js, detector/categories.test.js,
              detector/validate.test.js, scripts/corpus.test.js
              all corpus tests passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)