### PR TITLE
Record the field-guide disclosure as a repo constraint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ The skill has three modes (`rewrite` default, `detect` flag-only, `edit` in-plac
 - The self-reference escape hatch (quoted examples exempt from flagging) must be preserved — without it the skill flags its own documentation
 - Technical-blog profile has explicit word table exceptions (e.g., "robust" and "ecosystem" are legitimate in technical contexts)
 - "Extra strict" and "skip" in the tolerance matrix have specific meanings defined in the file
+- The `ai-writing-skill-field-guide` survey ranks this repo first on upkeep, and its author filed #12 here. Any public citation of that ranking has to carry the disclosure with it
 
 ## Compatibility
 


### PR DESCRIPTION
Splitting conorbronsdon/personal-context#119 into issues here (#81–#86) and closing it. One item in that issue was a standing conditional rather than a task, so it needed a home that is not an issue that can never be closed.

From #119's Notes:

> The field guide's author filed issue #12 on `avoid-ai-writing` and discloses it. If we ever cite the survey's A+ ranking publicly, the disclosure travels with the citation.

`CLAUDE.md` → Key constraints is where it fires: anyone drafting README or launch copy in this repo reads that file first. One line, no enforcement machinery, nothing to maintain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)