### PR TITLE
readme: say what this skill does not do, and where house style lives

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,26 @@ documentation with this repo's detector and publishes the result, including two
 defects the scan found in our own work. `npm run self-scan` reproduces it, and
 CI fails when a document drifts past its budget.
 
+## House style is a different job
+
+This skill removes AI-writing tells. It doesn't enforce a house style guide, and
+it ships no style guides of its own.
+
+If you want Google, Microsoft, Red Hat, or Salesforce style checked in CI,
+[Vale](https://github.com/vale-cli/vale) already covers that. Its
+[package registry](https://github.com/vale-cli/packages) carries
+Vale-compatible implementations of those guides alongside `proselint`,
+`write-good`, and `alex`, each MIT-licensed and attributed to the guide it
+implements. The two tools do different things and compose fine: Vale flags
+violations in CI, this skill rewrites prose while you draft.
+
+Paywalled guides (Chicago, APA, MLA, AP) have no machine-readable
+implementation here or in Vale, and won't get one here. Nothing in this repo
+could verify that a rewrite is Chicago-compliant, so claiming it would fail the
+same bar [`PROOF.md`](./PROOF.md) holds every other number to. The
+[license audit](https://github.com/conorbronsdon/avoid-ai-writing/issues/88)
+behind that line is public.
+
 ## Credits
 
 Pattern research informed by:

--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ CI fails when a document drifts past its budget.
 ## House style is a different job
 
 This skill removes AI-writing tells. It doesn't enforce a house style guide, and
-it ships no style guides of its own.
+it ships no style guides of its own. However, you should be able to provide your agent with style guides alongside your preferred voice profile to improve results. 
 
 If you want Google, Microsoft, Red Hat, or Salesforce style checked in CI,
 [Vale](https://github.com/vale-cli/vale) already covers that. Its

--- a/README.md
+++ b/README.md
@@ -360,15 +360,18 @@ CI fails when a document drifts past its budget.
 ## House style is a different job
 
 This skill removes AI-writing tells. It doesn't enforce a house style guide, and
-it ships no style guides of its own. However, you should be able to provide your agent with style guides alongside your preferred voice profile to improve results. 
+it ships no style guides of its own. You can still hand your agent a style guide
+alongside a voice profile and it will use both, which is usually the fastest way
+to get house style and a de-AI pass in one go.
 
 If you want Google, Microsoft, Red Hat, or Salesforce style checked in CI,
 [Vale](https://github.com/vale-cli/vale) already covers that. Its
 [package registry](https://github.com/vale-cli/packages) carries
-Vale-compatible implementations of those guides alongside `proselint`,
-`write-good`, and `alex`, each MIT-licensed and attributed to the guide it
-implements. The two tools do different things and compose fine: Vale flags
-violations in CI, this skill rewrites prose while you draft.
+Vale-compatible implementations of those four, alongside ports of `proselint`,
+`write-good`, and `alex`. The four style-guide packages are MIT-licensed; the
+linter ports vary, and proselint's is BSD-3-Clause. The two tools do different
+jobs and compose: Vale gates a document against a rule set, applying fixes one
+alert at a time, while this skill rewrites whole passages as you draft.
 
 Paywalled guides (Chicago, APA, MLA, AP) have no machine-readable
 implementation here or in Vale, and won't get one here. Nothing in this repo

--- a/README.md
+++ b/README.md
@@ -360,18 +360,20 @@ CI fails when a document drifts past its budget.
 ## House style is a different job
 
 This skill removes AI-writing tells. It doesn't enforce a house style guide, and
-it ships no style guides of its own. You can still hand your agent a style guide
-alongside a voice profile and it will use both, which is usually the fastest way
-to get house style and a de-AI pass in one go.
+it ships no style guides of its own. There's no `--style` input. If you want
+house style applied in the same pass, put the guide in your agent's context
+alongside a [voice profile](#triggering-the-skill) and it should follow both,
+as instructions rather than as a checked rule set.
 
 If you want Google, Microsoft, Red Hat, or Salesforce style checked in CI,
 [Vale](https://github.com/vale-cli/vale) already covers that. Its
 [package registry](https://github.com/vale-cli/packages) carries
 Vale-compatible implementations of those four, alongside ports of `proselint`,
-`write-good`, and `alex`. The four style-guide packages are MIT-licensed; the
-linter ports vary, and proselint's is BSD-3-Clause. The two tools do different
-jobs and compose: Vale gates a document against a rule set, applying fixes one
-alert at a time, while this skill rewrites whole passages as you draft.
+`write-good`, and `alex`. The four style-guide packages are MIT-licensed, though
+the guides they implement are not always (see the audit below); the linter ports
+vary, and proselint's is BSD-3-Clause. The two tools do different jobs and
+compose: Vale gates a document against a rule set, applying fixes one alert at a
+time, while this skill rewrites whole passages as you draft.
 
 Paywalled guides (Chicago, APA, MLA, AP) have no machine-readable
 implementation here or in Vale, and won't get one here. Nothing in this repo


### PR DESCRIPTION
Adds one README section between "Run the detector" and "Credits", answering a question the repo currently has no answer to: does this support Chicago / Google / a house style guide?

The answer is two pointers rather than an apology.

- [Vale](https://github.com/vale-cli/vale) already ships Google, Microsoft, Red Hat, and Salesforce as maintained MIT packages, attributed to the guides they implement. Vale flags in CI, this skill rewrites while drafting. They do different jobs and compose.
- The paywalled guides have no machine-readable implementation here or in Vale, and won't get one here, because nothing in this repo could verify a compliance claim about them. That's the bar `PROOF.md` already holds every other number to.

Implements the first action item in #88, which records the license audit: Google, Microsoft, and GOV.UK are CC BY 4.0 or OGL v3.0, 18F is CC0, Red Hat and Canonical are CC BY-SA 4.0 (ShareAlike conflicts with this repo's MIT), and Mailchimp is CC BY-**NC** 4.0, which surprised me. Every license was read from the project's `LICENSE` file or page footer.

The `examples/` half of that action item waits on the config-driven `--style` layer, since that directory doesn't exist upstream yet. This half stands alone.

## Verification

```
self-scan:check   README.md  4118 words  raw 64  exempt 21  budget 30   PASS
npm test          detector, categories, validate, corpus               PASS
check-pattern-count.sh   pattern 61 · word-table 112 (59+40+13)        in sync
```

Detector diff against `main`: raw 65 to 64, no new flag types. The new section scores 0/100 on its own.

One thing worth a separate look. My first draft linked the issue as `[#88](...)` and the detector flagged it `hashtag-stuff`. An issue reference in GitHub prose is not hashtag stuffing, so that rule may want a carve-out for `#\d+`. I reworded around it here rather than widen the scope of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
