### PR TITLE
Drop the $avoid token link from the Community section

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,6 @@ Authored by [Conor Bronsdon](https://github.com/conorbronsdon) · [LinkedIn](htt
 Things the community has built around this skill:
 
 - **[avoid-ai-writing-multilingual](https://github.com/jurigis/avoid-ai-writing-multilingual)** by [Jürgen Kraus](https://github.com/jurigis) — German (`SKILL-DE.md`) and Romanian (`SKILL-RO.md`) adaptations, grounded in native-language research rather than translated from English. French and Spanish planned.
-- **[$avoid token + burn web app](https://avoid-ai-writing-app.vercel.app)** — a community-built Solana token (`$avoid`) and token-burn web app around this project (2026), now in maintenance mode.
 
 Built something on top of this skill? Open an issue — happy to link it here.
 


### PR DESCRIPTION
The Community section linked a community-built Solana token and token-burn web app, marked "now in maintenance mode."

## Why this is a distribution problem, not a taste one

This repo is the most distributed artifact here — 2,764 stars, and the thing going into the Anthropic plugin directory, ClawHub, `davila7/claude-code-templates#773`, `wshobson/agents#645`, and the awesome-copilot listing that follows `github/awesome-copilot#2524`. Its README is **one hop from every one of those**. A reviewer clicking through from any listing reaches token marketing.

It is a concrete rejection risk, not a hypothetical. `wshobson/agents`' CONTRIBUTING:

> Plugin content must not funnel users to paid products, affiliate programs, or revenue-sharing services. Submissions whose primary purpose is promotion are closed as spam.

That submission had to point its plugin `homepage` away from this repo to avoid the hop — leaving the link reachable, just via a disclosure paragraph. A workaround, not a fix, and it only covers one of five channels.

## Removed rather than de-linked

The alternative was keeping the mention without the URL. The project is in maintenance mode, it is not ours, and a bare mention with no destination serves nobody.

**Jürgen Kraus's multilingual adaptation stays.** That is community work worth crediting and carries no funnel.

## Verification

```
token references in README.md   ->  0
multilingual credit intact      ->  1
check-pattern-count.sh          ->  pattern count in sync: 61
                                    word-table count in sync: 112 (59 + 40 + 13)
npm test                        ->  all corpus tests passed
1 file changed, 1 deletion(-)
```

The other `Solana` hit in the repo is a hashtag-spam string in `detector/patterns.test.js` — a test fixture for the detector. Left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)