### PR TITLE
check-pattern-count: assert CLAUDE.md's category-count copy on every push

### DIFF
--- a/.github/workflows/plugin-skill-sync.yml
+++ b/.github/workflows/plugin-skill-sync.yml
@@ -5,6 +5,10 @@ on:
     paths:
       - "SKILL.md"
       - "README.md"
+      # CLAUDE.md carries a checked copy of the pattern count; without this
+      # path the count guard never runs on a CLAUDE.md-only edit (PR #106
+      # had zero check runs - review finding on #111).
+      - "CLAUDE.md"
       - "plugins/**"
       - ".claude-plugin/**"
       - "cursor-rules/**"
@@ -14,6 +18,10 @@ on:
     paths:
       - "SKILL.md"
       - "README.md"
+      # CLAUDE.md carries a checked copy of the pattern count; without this
+      # path the count guard never runs on a CLAUDE.md-only edit (PR #106
+      # had zero check runs - review finding on #111).
+      - "CLAUDE.md"
       - "plugins/**"
       - ".claude-plugin/**"
       - "cursor-rules/**"

--- a/scripts/check-pattern-count.sh
+++ b/scripts/check-pattern-count.sh
@@ -47,11 +47,19 @@ echo "pattern count in sync: $detection_count"
 # The count has one same-repo copy: CLAUDE.md's "don't restate it" sentence
 # quotes the README bullet. .ssot.yaml tracks that copy, but the manifest only
 # runs on release / weekly cron (promo-drift), so a same-repo edit could sit
-# stale for up to a week. Asserting it here closes the window on every push.
-# The sed pattern mirrors .ssot.yaml's regex for the copy, so the two guards
-# cannot read different sentences.
+# stale for up to a week. Asserting it in CI closes the window. Extraction is
+# grep -o + head, which takes the FIRST match in file order — the same match
+# a standard first-match regex engine reading .ssot.yaml's pattern would take
+# (a greedy sed s/.*…/ would silently take the LAST match on a line instead).
 claudemd="$repo_root/CLAUDE.md"
-claude_count="$(sed -n 's/.*README "\([0-9][0-9]*\) pattern categories" bullet.*/\1/p' "$claudemd" | head -n1)"
+
+if [ ! -f "$claudemd" ]; then
+  echo "CLAUDE.md not found — it carries a tracked copy of the pattern count (.ssot.yaml)." >&2
+  echo "If it was deliberately removed, drop the copy from .ssot.yaml and this check together." >&2
+  exit 1
+fi
+
+claude_count="$(grep -o 'README "[0-9][0-9]* pattern categories" bullet' "$claudemd" | head -n1 | tr -cd '0-9' || true)"
 
 if [ -z "$claude_count" ]; then
   echo "could not find the 'README \"NN pattern categories\" bullet' sentence in CLAUDE.md" >&2

--- a/scripts/check-pattern-count.sh
+++ b/scripts/check-pattern-count.sh
@@ -44,6 +44,29 @@ fi
 
 echo "pattern count in sync: $detection_count"
 
+# The count has one same-repo copy: CLAUDE.md's "don't restate it" sentence
+# quotes the README bullet. .ssot.yaml tracks that copy, but the manifest only
+# runs on release / weekly cron (promo-drift), so a same-repo edit could sit
+# stale for up to a week. Asserting it here closes the window on every push.
+# The sed pattern mirrors .ssot.yaml's regex for the copy, so the two guards
+# cannot read different sentences.
+claudemd="$repo_root/CLAUDE.md"
+claude_count="$(sed -n 's/.*README "\([0-9][0-9]*\) pattern categories" bullet.*/\1/p' "$claudemd" | head -n1)"
+
+if [ -z "$claude_count" ]; then
+  echo "could not find the 'README \"NN pattern categories\" bullet' sentence in CLAUDE.md" >&2
+  echo "If the sentence was reworded, update this check AND the CLAUDE.md copy in .ssot.yaml together." >&2
+  exit 1
+fi
+
+if [ "$claude_count" != "$detection_count" ]; then
+  echo "pattern-count drift: CLAUDE.md quotes $claude_count, SKILL.md derives $detection_count" >&2
+  echo "Update the count in CLAUDE.md's pattern-count sentence to $detection_count." >&2
+  exit 1
+fi
+
+echo "CLAUDE.md copy in sync: $claude_count"
+
 # Word-table entries = data rows across the Tier 1/2/3 word tables. The Tier 3
 # *phrases* table is counted separately in the README bullet, so it is excluded.
 #


### PR DESCRIPTION
## Summary

Closes the latency gap noted while reviewing #106: CLAUDE.md's pattern-count copy is tracked by `.ssot.yaml`, but that manifest only runs at release / weekly cron (promo-drift), so a same-repo edit can sit stale for up to a week — the exact rot #95 documented. `check-pattern-count.sh` now asserts the copy in CI, and after the review-round fix the workflow actually triggers on the edits the guard exists to catch: `CLAUDE.md` joined `plugin-skill-sync.yml`'s `paths:` filter on both the PR trigger and the push-to-main trigger (previously a CLAUDE.md-only change ran zero checks — verified on PR #106).

Extraction is `grep -o | head -n1` (first match in file order — the same match a first-match regex engine reading `.ssot.yaml`'s pattern takes; the first draft's greedy sed would have taken the *last* match on a line). A missing CLAUDE.md gets its own message and exit 1 instead of dying on sed's raw error, since the file is a tracked `.ssot.yaml` copy and a fork that deletes it should update both together.

## Testing (exit codes checked unpiped)

```
clean tree                        pattern 61 · CLAUDE.md copy 61 · word-table 112   exit 0
CLAUDE.md 61 -> 62                "CLAUDE.md quotes 62, SKILL.md derives 61"        exit 1
sentence reworded                 "could not find ... update .ssot.yaml together"   exit 1
CLAUDE.md deleted                 "CLAUDE.md not found — tracked copy (.ssot.yaml)" exit 1
same line mentions 61 then 46     first match wins: copy reads 61                   exit 0
```

`npm test` unaffected (no detector or SKILL.md change; catalog stays 61 / 112). No CHANGELOG entry or version bump — build tooling only, matching #96/#98/#110 precedent.

Review history: the adversarial pass on the first draft found the workflow-trigger gap (HIGH), the dead missing-file branch (MEDIUM), and the greedy-sed last-match semantics (LOW) — all fixed in `237a089`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKwz2XfwaMD6uR5ABmVaKq