### PR TITLE
detector: Object.hasOwn tier lookups — 'constructor' in prose no longer flags (#109)

### DIFF
--- a/detector/patterns.js
+++ b/detector/patterns.js
@@ -956,7 +956,7 @@ const AIDetector = (() => {
     // ── 1. Tier 1 words ──────────────────────────────────────────
     const tier1Found = new Set();
     for (const token of tokens) {
-      if (TIER1[token] && !tier1Found.has(token)) {
+      if (Object.hasOwn(TIER1, token) && !tier1Found.has(token)) {
         tier1Found.add(token);
         issues.push({
           type: 'tier1',
@@ -995,7 +995,7 @@ const AIDetector = (() => {
       const found = [];
       const suggestions = {};
       for (const token of paraTokens) {
-        if (TIER2[token] && !found.includes(token)) {
+        if (Object.hasOwn(TIER2, token) && !found.includes(token)) {
           found.push(token);
           suggestions[token] = TIER2[token];
         }

--- a/detector/patterns.test.js
+++ b/detector/patterns.test.js
@@ -1317,6 +1317,27 @@ test('v2: backward compat — score, label, issues, stats still present', () => 
   assert.ok(r.stats && typeof r.stats === 'object', 'stats still object');
 });
 
+test('#109: Object.prototype names in prose do not fire tier lookups', () => {
+  // Plain-object membership tests made TIER1['constructor'] resolve to
+  // Object.prototype.constructor (truthy), flagging ordinary prose.
+  const text =
+    'The class constructor takes nine arguments in this codebase. Review the constructor before calling it, and check that its prototype chain and toString output match what the documentation describes for each valueOf call.';
+  const r = AIDetector.analyzeText(text);
+  const protoHits = r.issues.filter(
+    (i) => ['constructor', 'prototype', 'tostring', 'valueof', 'hasownproperty'].includes(String(i.text).toLowerCase())
+  );
+  assert.equal(protoHits.length, 0, `prototype-name tokens flagged: ${JSON.stringify(protoHits)}`);
+});
+
+test('#109 complement: real tier1 vocabulary still fires after the hasOwn guard', () => {
+  const r = AIDetector.analyzeText(
+    'We delve into the constructor design of this system. The team continues to navigate this comprehensive transformation across every module boundary.'
+  );
+  const tier1Texts = r.issues.filter((i) => i.type === 'tier1').map((i) => String(i.text).toLowerCase());
+  assert.ok(tier1Texts.includes('delve'), `expected 'delve' to still fire, got tier1=${JSON.stringify(tier1Texts)}`);
+  assert.ok(!tier1Texts.includes('constructor'), 'constructor must not ride along in tier1');
+});
+
 if (failed > 0) {
   console.error(`\n${failed} test(s) failed`);
   process.exit(1);


### PR DESCRIPTION
Fixes #109. `TIER1[token]` / `TIER2[token]` are plain-object literals, so any token naming an `Object.prototype` member resolved truthy — `TIER1['constructor']` returned the built-in constructor function, flagging ordinary prose exactly as the issue's repro shows (and the tier1 `suggestion` field would have carried a function reference). Both membership tests now use `Object.hasOwn` (Node 16.9+; `engines` pins `>=18`). The two remaining bracket reads (`TIER1[token]` for the suggestion, `suggestions[token] = TIER2[token]`) sit behind the new guards, and `found`/`suggestions` only ever receive catalog words after this change.

Verification:
- New regression tests exercise the real analyzer in both directions: prose containing `constructor` / `prototype` / `toString` / `valueOf` produces zero tier hits, and the complement — `delve` in the same sentence as `constructor` — still fires tier1 without `constructor` riding along.
- Both tests verified **red on the unfixed code** (reverted `patterns.js` to main, reran, 2 failures; re-applied fix) before trusting them.
- Full `npm test` chain green (patterns, categories, validate, corpus, check-style).

Left as-is deliberately: `TIER2_CONDITIONAL` is an array walked with regexes (no object lookup), and cluster/boilerplate passes iterate their own catalogs rather than indexing by user token — no other membership test in the scoring path indexes a plain object with untrusted strings (swept `\[(token|word|w|t)\]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
