### PR TITLE
matrix: pin the multi-ref hit count (#110 review finding 3)

### DIFF
--- a/scripts/sync-cursor-rules.sh
+++ b/scripts/sync-cursor-rules.sh
@@ -182,6 +182,13 @@ for case in MUST_BLOCK:
 for case in MUST_PASS:
     assert not scan_line(case), f"gate self-test: expected a pass, got a block: {case!r}"
 
+# The error message's count comes from len(hits), so scan_line must report
+# every ref on a line, not just the first (#110 review, finding 3). A
+# reversion to first-match-only scanning goes red here, not just quieter.
+multi_ref = "run scripts/check-style.js then see detector/CATEGORIES.md"
+assert len(scan_line(multi_ref)) == 2, \
+    f"gate self-test: expected 2 hits on a two-ref line, got {scan_line(multi_ref)!r}"
+
 leaks = []
 for n, line in enumerate(body.split("\n"), 1):
     hits = scan_line(line)


### PR DESCRIPTION
Closes the one gap the #110/#114 coverage audit found: the `finditer` undercount fix landed in #114 without a test that can fail, so a reversion to first-match-only scanning would stay green. One assertion in the self-test matrix pins it — a two-ref line must report 2 hits.

Verified: intact script passes; mutating `scan_line` to first-match-only fails with `expected 2 hits on a two-ref line, got ['scripts/check-style.js']`. The regenerated `.mdc` is byte-identical, so the change is script-only.