### PR TITLE
release: 3.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project are documented here.
 
 ---
 
+## [3.23.1] — 2026-08-05
+
+### Fixed
+
+- **`constructor` in prose no longer fires the detector.** Tier lookups now use
+  `Object.hasOwn`, so words that collide with `Object.prototype` property names
+  can't false-positive (#109, #112).
+
+### Changed
+
+- **npm publishing is automated, guarded, and carries provenance.** Merging a
+  version bump to main creates the GitHub release and publishes to npm in one
+  pipeline: package.json and CHANGELOG.md must agree on the version, the run
+  must be the exact commit the release tag names (so npm content can't drift
+  from the GitHub release and `--provenance` can't attest the wrong commit),
+  and duplicate runs queue and no-op (#113).
+- **The cursor-rules leak gate closed its nested-path hole**, self-tests a
+  review matrix on every run, and the README pattern-count copy is asserted in
+  CI (#110, #111, #114, #115).
+
+---
+
 ## [3.23.0] — 2026-08-03
 
 ### Added

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: avoid-ai-writing
 description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Use this skill when asked to "remove AI-isms," "clean up AI writing," "edit writing for AI patterns," "audit writing for AI tells," or "make this sound less like AI." Supports a detect-only mode, an edit-in-place mode for files, an optional voice profile (casual / professional / technical / warm / blunt), and an iterate-to-convergence pass.
-version: 3.23.0
+version: 3.23.1
 license: MIT
 compatibility: Any AI coding assistant that supports agentskills.io SKILL.md format (Claude Code, Cursor, VS Code Copilot, Hermes Agent, OpenHands, etc.) or OpenClaw. No external tools or APIs required.
 metadata:

--- a/cursor-rules/avoid-ai-writing.mdc
+++ b/cursor-rules/avoid-ai-writing.mdc
@@ -1,5 +1,5 @@
 ---
-description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Activate whenever editing prose-heavy files (Markdown, documentation, blog posts, READMEs, release notes, emails). Cursor port of the avoid-ai-writing skill v3.23.0. See https://github.com/conorbronsdon/avoid-ai-writing.
+description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Activate whenever editing prose-heavy files (Markdown, documentation, blog posts, READMEs, release notes, emails). Cursor port of the avoid-ai-writing skill v3.23.1. See https://github.com/conorbronsdon/avoid-ai-writing.
 globs: ["**/*.md", "**/*.mdx", "**/*.txt", "**/*.rst", "**/*.adoc"]
 alwaysApply: false
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avoid-ai-writing-detector",
-  "version": "3.23.0",
+  "version": "3.23.1",
   "description": "Deterministic detection engine for the Avoid AI Writing skill — pattern + stylometric analysis of AI-generated text.",
   "license": "MIT",
   "repository": {

--- a/plugins/avoid-ai-writing/.claude-plugin/plugin.json
+++ b/plugins/avoid-ai-writing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "avoid-ai-writing",
   "description": "Audit & rewrite content to remove AI writing patterns (\"AI-isms\"). Supports detect-only and edit-in-place modes, voice profiles, and iterate-to-convergence.",
-  "version": "3.23.0",
+  "version": "3.23.1",
   "author": {
     "name": "Conor Bronsdon"
   },

--- a/plugins/avoid-ai-writing/skills/avoid-ai-writing/SKILL.md
+++ b/plugins/avoid-ai-writing/skills/avoid-ai-writing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: avoid-ai-writing
 description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Use this skill when asked to "remove AI-isms," "clean up AI writing," "edit writing for AI patterns," "audit writing for AI tells," or "make this sound less like AI." Supports a detect-only mode, an edit-in-place mode for files, an optional voice profile (casual / professional / technical / warm / blunt), and an iterate-to-convergence pass.
-version: 3.23.0
+version: 3.23.1
 license: MIT
 compatibility: Any AI coding assistant that supports agentskills.io SKILL.md format (Claude Code, Cursor, VS Code Copilot, Hermes Agent, OpenHands, etc.) or OpenClaw. No external tools or APIs required.
 metadata:


### PR DESCRIPTION
The Object.hasOwn constructor fix (#112) plus everything since v3.23.0, as the first release through #113's guarded pipeline. All five version sites bumped and the sync scripts run; npm test green (39 checks), pattern counts in sync (61/112).

Merging this triggers the release workflow: tag v3.23.1, GitHub release, npm publish with provenance.