### PR TITLE
Write the openclaw emoji literally so org plugin sync accepts the skill

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -9,7 +9,7 @@ metadata:
   tags: writing editing voice quality
   agentskills_spec: "1.0"
   openclaw:
-    emoji: "\u270D\uFE0F"
+    emoji: "✍️"
 ---
 
 # Avoid AI Writing — Audit & Rewrite

--- a/plugins/avoid-ai-writing/skills/avoid-ai-writing/SKILL.md
+++ b/plugins/avoid-ai-writing/skills/avoid-ai-writing/SKILL.md
@@ -9,7 +9,7 @@ metadata:
   tags: writing editing voice quality
   agentskills_spec: "1.0"
   openclaw:
-    emoji: "\u270D\uFE0F"
+    emoji: "✍️"
 ---
 
 # Avoid AI Writing — Audit & Rewrite


### PR DESCRIPTION
## Summary

The plugin can't be distributed through Claude **Organization settings > Plugins** on Team and Enterprise plans. Org sync skips it with:

> Skill 'skills/avoid-ai-writing' contains a hex/unicode escape or an escaped line break in its SKILL.md frontmatter, which can spell keys some parsers see and others don't. Write the text literally.

The cause is one line of frontmatter:

```yaml
metadata:
  openclaw:
    emoji: "✍️"
```

Org sync rejects escapes in frontmatter because an escaped *key* can parse differently across parsers — one parser sees a key another doesn't. Reasonable rule, and the escape here is incidental rather than intentional.

This PR writes the character instead:

```yaml
    emoji: "✍️"
```

Same emoji, identical once parsed. Only the source representation changes.

## Scope

Two files, one line each. `SKILL.md` is the canonical edit; the plugin copy was regenerated with `scripts/sync-plugin-skill.sh` rather than edited by hand.

The escape has been present since #17 first packaged the project as a plugin, so every released version is affected — pinning to an earlier tag isn't a workaround for anyone hitting this. Only `metadata.openclaw.emoji` is affected; no other escape appears in either frontmatter block.

## Deliberately not included: the version bump and CHANGELOG entry

The checklist asks for both. I've left them out on purpose: merging a version bump to `main` triggers your automated release and npm publish, and `package.json` and `CHANGELOG.md` have to agree on the version for that pipeline to pass. Which version this rides in, and when, is your call — happy to add the entry if you'd rather it came in with the PR.

Nothing else here changes behaviour: no rule added or altered, no detector `type` touched.

## Checklist

- [x] `npm test` passes (39 check-style + engine fixtures + `CATEGORIES.md` contract check), Node 24.13.0
- [ ] N/A — no detector `type` added
- [ ] N/A — no judgment-only rule added
- [x] No false-positive surface: packaging metadata only
- [x] No factual claim about how AI or humans write
- [x] No prose added
- [ ] Deferred to the maintainer — see above

## Context

Found while distributing this skill to a team through org plugin sync, pointing a private marketplace at `plugins/avoid-ai-writing` via a `git-subdir` source. We're running a patched mirror in the meantime and would much rather go back to tracking upstream.