### PR TITLE
feat: detect unnecessary hyphenation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to this project are documented here.
 
 ---
 
+## [3.24.0] — 2026-08-07
+
+### Added
+
+- **Unnecessary hyphenation is now a P2 copyedit with deterministic detector
+  coverage (#107).** The rule handles three bounded subclasses: welded open
+  noun phrases (`research-impact aggregator` → `research impact aggregator`),
+  compounds with an established closed form (`code-base` → `codebase`), and
+  attributive compounds used adverbially (`in real-time` → `in real time`,
+  while `real-time analytics` stays unchanged). The catalog goes from 61 to 62
+  categories and the engine from 47 to 48 `type`s.
+- **Protected spans and legitimate compounds stay out of the detector.** It
+  masks fenced and inline code, quotes, Markdown blockquotes, URLs, paths,
+  filenames, and command flags. Fixtures preserve `high-quality`,
+  `family-owned`, `third-party`, `real-time dashboard`, `long-term plan`, and
+  `out-of-the-box support`.
+- **The general grammar call remains editorial judgment.** Open-ended compound
+  detection would flag ordinary technical writing, so the engine uses a curated
+  list and reports suggestions instead of rewriting text. The optional `-ly`
+  adverb cleanup discussed in #107 is deliberately absent from this release;
+  the issue agreement allowed it to ship later as opt-out style cleanup rather
+  than as an AI tell.
+
+### Changed
+
+- **Hyphenated-pair overuse is now named hyphenated modifier stacking.** Its
+  signal is the density of otherwise valid compounds, not the correctness of
+  each hyphen. Incorrect but deterministic forms belong to the new rule.
+
+---
+
 ## [3.23.1] — 2026-08-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ All notable changes to this project are documented here.
   categories and the engine from 47 to 48 `type`s.
 - **Protected spans and legitimate compounds stay out of the detector.** It
   masks fenced and inline code, quotes, Markdown blockquotes, URLs, paths,
-  filenames, and command flags. Fixtures preserve `high-quality`,
+  filenames, command flags, identifiers, version strings, YAML metadata,
+  Markdown tables, and HTML attributes. Fixtures preserve `high-quality`,
   `family-owned`, `third-party`, `real-time dashboard`, `long-term plan`, and
   `out-of-the-box support`.
 - **The general grammar call remains editorial judgment.** Open-ended compound
@@ -32,6 +33,15 @@ All notable changes to this project are documented here.
 - **Hyphenated-pair overuse is now named hyphenated modifier stacking.** Its
   signal is the density of otherwise valid compounds, not the correctness of
   each hyphen. Incorrect but deterministic forms belong to the new rule.
+- **P2 hyphenation copyedits do not contribute to the AI score.** They remain
+  visible as editing suggestions without changing the label, class
+  probabilities, or trinary classification in short documents.
+
+### Fixed
+
+- **Path and filename masking remains linear on adversarial input.** Bounded
+  path components remove the superlinear backtracking exposed by long kebab
+  identifiers, with a timing regression fixture covering the failure shape.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Edit `SKILL.md` directly. When making changes:
 - Run `npm test` to exercise the detector, category contract, validator, corpus helpers, and style checks.
 - Add a dated entry to CHANGELOG.md
 - Update README.md if the change affects installation, usage, feature list, or pattern count
-- The pattern count lives in **one** place — the README "61 pattern categories" bullet — and is derived from SKILL.md's detection `###` entries. Don't restate it elsewhere; CI (`scripts/check-pattern-count.sh`) fails the build if the README number drifts from SKILL.md, so just add the new `###` entry and bump the README bullet.
+- The pattern count lives in **one** place — the README "62 pattern categories" bullet — and is derived from SKILL.md's detection `###` entries. Don't restate it elsewhere; CI (`scripts/check-pattern-count.sh`) fails the build if the README number drifts from SKILL.md, so just add the new `###` entry and bump the README bullet.
 
 ## Architecture of the skill
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ A one-shot "make this sound human" prompt catches the obvious stuff. This skill 
 - **Structured audit** — returns identified issues with quoted text, the rewrite, a change summary, and a second-pass audit in four discrete sections. You see exactly what changed and why.
 - **Two-pass detection** — the second pass re-reads the rewrite and catches patterns that survive the first edit: recycled transitions, lingering inflation, copula swaps that snuck through.
 - **112-entry word replacement table across 3 tiers + 10 Tier 3 phrases** — not vibes-based. Every flagged word has a specific, plainer alternative. "Leverage" → "use." "Commence" → "start." Tier 1 words always flag, Tier 2 words flag when they cluster, Tier 3 words flag only at high density. Tier 1 itself splits into **1A frequency markers** (`delve`, `tapestry`) and **1B clarity edits** (`in order to`, `utilize`) — same fix, but only 1A is evidence about how a passage was produced, and 1B is weighted lower so a wordiness fix cannot push a document toward an AI classification. Tier 3 *phrases* (multi-word boilerplate like "the integration of," "decentralized compute") flag on per-phrase repetition or when 3+ distinct phrases stack in one piece — the LLM-self-varies-boilerplate shape.
-- **61 pattern categories** — representative examples below, each with before/after. Includes structural detection (hashtag stuffing, bare-NP bullet lists, hedge-stacked predictions), AI-tool fingerprints (placeholders, citation markup, UTM params), rhythm/uniformity checks, conversational-register tells, and writer-side tests. The full catalog lives in [`SKILL.md`](./SKILL.md); this count is enforced against it in CI.
+- **62 pattern categories** — representative examples below, each with before/after. Includes structural detection (hashtag stuffing, bare-NP bullet lists, hedge-stacked predictions), AI-tool fingerprints (placeholders, citation markup, UTM params), rhythm/uniformity checks, conversational-register tells, and writer-side tests. The full catalog lives in [`SKILL.md`](./SKILL.md); this count is enforced against it in CI.
 - **Detect mode** — flag patterns without rewriting. See which flags are real problems vs. judgment calls. Useful when patterns might be intentional or you're auditing content you don't want altered.
 - **Works across platforms** — one `SKILL.md` runs in Claude Code, Cowork (as a plugin), OpenClaw, and Cursor (as a ported rule). See the install paths below.
 
@@ -177,7 +177,7 @@ Trigger detect mode with: "detect," "flag only," "audit only," "just flag," "sca
 
 ## Pattern reference
 
-> Representative examples from the catalog — not the exhaustive list (that's [`SKILL.md`](./SKILL.md)). The skill's human-facing prose catalog and the [detector engine](./detector/) use **different counts on purpose**: the engine implements 47 `type` categories because it splits the vocabulary tiers and adds stylometric/fingerprint signals (punctuation distribution, function-word entropy, bypass-trick detection) that work as math over a document rather than as a rule you'd look up. The two are mapped in [`detector/CATEGORIES.md`](./detector/CATEGORIES.md); don't "fix" one count to match the other.
+> Representative examples from the catalog — not the exhaustive list (that's [`SKILL.md`](./SKILL.md)). The skill's human-facing prose catalog and the [detector engine](./detector/) use **different counts on purpose**: the engine implements 48 `type` categories because it splits the vocabulary tiers and adds stylometric/fingerprint signals (punctuation distribution, function-word entropy, bypass-trick detection) that work as math over a document rather than as a rule you'd look up. The two are mapped in [`detector/CATEGORIES.md`](./detector/CATEGORIES.md); don't "fix" one count to match the other.
 
 ### Content Patterns
 
@@ -261,7 +261,7 @@ Added in v3.4 to catch LLM output that sidesteps the vocabulary tables by substi
 | 44 | **Chatbot citation markup** | `citeturn0search0`, `oai_citation`, `contentReference[oaicite:0]` | Strip the markup token entirely |
 | 45 | **AI-tool URL parameters** | `utm_source=chatgpt.com`, `utm_source=copilot.com` | Strip the tracking parameter; keep the URL if the link matters |
 | 46 | **Speculative gap-filling** | "maintains a low profile," "likely began his career" | Cut the guess, or replace with a sourced fact |
-| 47 | **Hyphenated-pair overuse** | "a high-quality, well-architected, future-proof solution" | Cut to the modifier that matters; no hyphen in predicate ("the report is high quality") |
+| 47 | **Hyphenated modifier stacking** | "a high-quality, well-architected, future-proof solution" | Cut to the modifier that matters; the individual hyphens may be correct |
 | 48 | **Infomercial engagement hooks** | "The catch?", "The kicker?", "Here's the thing." | Delete the hook, state the thing |
 | 49 | **Vocabulary diversity (low TTR)** | Narrow, repetitive word range across 200+ words | Broaden the *what* — name specific things, cite specific cases |
 | 50 | **Self-labeling significance** | "That last move is the contrarian one," "This is the interesting part" | Cut the label; let the explanation carry the weight, or reposition the item so it stands out on its own |
@@ -287,6 +287,12 @@ Added after a real-world exchange in which a maintainer called out an assisted-s
 | # | Pattern | Before | After |
 |---|---------|--------|-------|
 | 55 | **Narrated candor** | "Two caveats I would rather flag than let you discover later:", "I want to be upfront:" | State the caveats. Judgment-only: the same words carry real content in conflict-of-interest disclosure ("in the interest of full disclosure, I own shares in…"), which a regex cannot separate from the empty frame |
+
+### Unnecessary hyphenation (v3.24)
+
+| # | Pattern | Before | After |
+|---|---------|--------|-------|
+| 56 | **Unnecessary hyphenation** | "research-impact aggregator," "code-base," "in real-time," "works out-of-the-box" | "research impact aggregator," "codebase," "in real time," "works out of the box." Preserve legitimate modifiers such as "real-time analytics" |
 
 Two writer-side **tests** round out the catalog (judgment checks, not auto-detected): **paragraph-reshuffle immunity** (can you swap two body paragraphs without breaking the piece?) and the **treadmill effect** ("what's actually new in this paragraph?").
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: avoid-ai-writing
 description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Use this skill when asked to "remove AI-isms," "clean up AI writing," "edit writing for AI patterns," "audit writing for AI tells," or "make this sound less like AI." Supports a detect-only mode, an edit-in-place mode for files, an optional voice profile (casual / professional / technical / warm / blunt), and an iterate-to-convergence pass.
-version: 3.23.1
+version: 3.24.0
 license: MIT
 compatibility: Any AI coding assistant that supports agentskills.io SKILL.md format (Claude Code, Cursor, VS Code Copilot, Hermes Agent, OpenHands, etc.) or OpenClaw. No external tools or APIs required.
 metadata:
@@ -401,8 +401,15 @@ These slot-fill constructions signal that a sentence was generated, not written.
 ### Title case headings
 - AI over-capitalizes headings: "Strategic Negotiations And Key Partnerships" instead of "Strategic negotiations and key partnerships." Use sentence case for subheadings. Title case only for the piece's main title, if at all.
 
-### Hyphenated-pair overuse
-- AI stacks compound modifiers: "a high-quality, well-architected, future-proof solution." Two distinct problems. First, density — strings of hyphenated adjectives piled on one noun; cut to the modifier that actually matters. Second, the attributive/predicate error: a compound is hyphenated *before* the noun ("a high-quality report") but not *after* a linking verb ("the report is high quality," no hyphen). AI frequently hyphenates the predicate form; fix it to two words. Adapted from `blader/humanizer` P26.
+### Hyphenated modifier stacking
+- AI stacks compound modifiers: "a high-quality, well-architected, future-proof solution." The individual hyphens may be correct; the tell is the density. Cut to the modifier that matters. Adapted from `blader/humanizer` P26.
+
+### Unnecessary hyphenation
+- Check welded open noun phrases: "research-impact aggregator" becomes "research impact aggregator," "data-source strategy" becomes "data source strategy," and "Python-package usage" becomes "Python package usage."
+- Close compounds whose standard form is one word: "code-base," "data-set," "time-frame," and "road-map" become "codebase," "dataset," "timeframe," and "roadmap."
+- Remove attributive hyphens when the phrase is used adverbially or as a noun: "in real-time" becomes "in real time" and "works out-of-the-box" becomes "works out of the box." Keep the same compounds before a noun: "real-time analytics," "long-term plan," and "out-of-the-box support."
+- Preserve established and technical compounds such as "high-quality," "open-access," "third-party," "machine-readable," "server-side," "field-normalized," and "family-owned." Spelling varies by dialect and house style, so ambiguous pairs are judgment calls rather than automatic rewrites.
+- Treat a clear hit as P2 copyediting, not evidence of machine authorship. The deterministic detector uses a curated list and excludes code, quoted material, URLs, paths, filenames, and command flags. General attributive-versus-predicate cases stay judgment-only.
 
 ### Cutoff disclaimers
 - "While specific details are limited based on available information," "As of my last update," "I don't have access to real-time data." These are model limitations leaking into prose. Either find the information or remove the hedge. Never publish a sentence that admits the writer didn't look something up.
@@ -609,6 +616,7 @@ Not all AI-isms are equal. When doing a quick pass or triaging a large document,
 - Transition phrases (Moreover, Furthermore, Additionally)
 - Hashtag stuffing (`blog`/`technical-blog` profiles)
 - Tier 3 phrase repetition (single phrase ≥2× — fine in isolation, suspect in stacks)
+- Unnecessary hyphenation (curated open, closed, and position-dependent compounds)
 
 Use P0+P1 for quick passes. Full audit covers all three tiers.
 

--- a/cursor-rules/avoid-ai-writing.mdc
+++ b/cursor-rules/avoid-ai-writing.mdc
@@ -1,5 +1,5 @@
 ---
-description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Activate whenever editing prose-heavy files (Markdown, documentation, blog posts, READMEs, release notes, emails). Cursor port of the avoid-ai-writing skill v3.23.1. See https://github.com/conorbronsdon/avoid-ai-writing.
+description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Activate whenever editing prose-heavy files (Markdown, documentation, blog posts, READMEs, release notes, emails). Cursor port of the avoid-ai-writing skill v3.24.0. See https://github.com/conorbronsdon/avoid-ai-writing.
 globs: ["**/*.md", "**/*.mdx", "**/*.txt", "**/*.rst", "**/*.adoc"]
 alwaysApply: false
 ---
@@ -396,8 +396,15 @@ These slot-fill constructions signal that a sentence was generated, not written.
 ### Title case headings
 - AI over-capitalizes headings: "Strategic Negotiations And Key Partnerships" instead of "Strategic negotiations and key partnerships." Use sentence case for subheadings. Title case only for the piece's main title, if at all.
 
-### Hyphenated-pair overuse
-- AI stacks compound modifiers: "a high-quality, well-architected, future-proof solution." Two distinct problems. First, density — strings of hyphenated adjectives piled on one noun; cut to the modifier that actually matters. Second, the attributive/predicate error: a compound is hyphenated *before* the noun ("a high-quality report") but not *after* a linking verb ("the report is high quality," no hyphen). AI frequently hyphenates the predicate form; fix it to two words. Adapted from `blader/humanizer` P26.
+### Hyphenated modifier stacking
+- AI stacks compound modifiers: "a high-quality, well-architected, future-proof solution." The individual hyphens may be correct; the tell is the density. Cut to the modifier that matters. Adapted from `blader/humanizer` P26.
+
+### Unnecessary hyphenation
+- Check welded open noun phrases: "research-impact aggregator" becomes "research impact aggregator," "data-source strategy" becomes "data source strategy," and "Python-package usage" becomes "Python package usage."
+- Close compounds whose standard form is one word: "code-base," "data-set," "time-frame," and "road-map" become "codebase," "dataset," "timeframe," and "roadmap."
+- Remove attributive hyphens when the phrase is used adverbially or as a noun: "in real-time" becomes "in real time" and "works out-of-the-box" becomes "works out of the box." Keep the same compounds before a noun: "real-time analytics," "long-term plan," and "out-of-the-box support."
+- Preserve established and technical compounds such as "high-quality," "open-access," "third-party," "machine-readable," "server-side," "field-normalized," and "family-owned." Spelling varies by dialect and house style, so ambiguous pairs are judgment calls rather than automatic rewrites.
+- Treat a clear hit as P2 copyediting, not evidence of machine authorship. The deterministic detector uses a curated list and excludes code, quoted material, URLs, paths, filenames, and command flags. General attributive-versus-predicate cases stay judgment-only.
 
 ### Cutoff disclaimers
 - "While specific details are limited based on available information," "As of my last update," "I don't have access to real-time data." These are model limitations leaking into prose. Either find the information or remove the hedge. Never publish a sentence that admits the writer didn't look something up.
@@ -604,6 +611,7 @@ Not all AI-isms are equal. When doing a quick pass or triaging a large document,
 - Transition phrases (Moreover, Furthermore, Additionally)
 - Hashtag stuffing (`blog`/`technical-blog` profiles)
 - Tier 3 phrase repetition (single phrase ≥2× — fine in isolation, suspect in stacks)
+- Unnecessary hyphenation (curated open, closed, and position-dependent compounds)
 
 Use P0+P1 for quick passes. Full audit covers all three tiers.
 

--- a/detector/CATEGORIES.md
+++ b/detector/CATEGORIES.md
@@ -6,14 +6,14 @@ the skill, decide here whether it's regex-detectable (give it a detector `type`)
 or LLM-only judgment (mark it so). When you add a detector `type`, point it back
 at the skill section it enforces.
 
-The engine exposes 47 issue `type`s (see `TYPE_LABELS` in `patterns.js`). The
+The engine exposes 48 issue `type`s (see `TYPE_LABELS` in `patterns.js`). The
 skill has more `###` sections than that — the gap is **not** missing coverage,
 it's rules that are judgment calls a regex can't make. The three groups below
 account for every entry on both sides.
 
 Three counts coexist on purpose and should not be forced to match: the README's
 **pattern-category count** (the human-facing prose catalog, derived from SKILL.md
-and guarded in CI), the engine's **47 `type`s** (which split the vocabulary tiers
+and guarded in CI), the engine's **48 `type`s** (which split the vocabulary tiers
 and add stylometric signals), and SKILL.md's `###` sections (which also include
 writer-side tests with no detectable form). The
 `categories.test.js` enforces the engine ↔ this-file mapping, and checks every
@@ -62,6 +62,7 @@ prose statement of the engine `type` total against `TYPE_LABELS`.
 | `ai-citation-markup` | Chatbot citation markup leak | Chatbot citation markup leaks |
 | `ai-utm-source` | AI-tool URL parameter | AI-tool URL parameters |
 | `smart-punct-signature` | Smart-punct signature | Formatting (curly quotation marks) — *partial* |
+| `unnecessary-hyphenation` | Unnecessary hyphenation | Unnecessary hyphenation *(curated open, closed, and position-dependent subclasses only)* |
 
 > **Partial map:** `smart-punct-signature` fires only when curly quotes co-occur
 > with an em-dash, an Oxford comma, and clean typing (≥80 words) — never on curly
@@ -95,6 +96,8 @@ mistake their absence for a coverage gap:
 - Structural issues / Excessive structure / Inline-header lists / Numbered list inflation
 - Moral-adjective category errors (including ontological slop on assumptions, gratuitous universal quantifiers)
 - Invented contrast-pair mirroring
+- Hyphenated modifier stacking
+- Unnecessary hyphenation outside the detector's curated subclasses
 - False ranges
 - Notability name-dropping
 - Vague third-party validation

--- a/detector/patterns.js
+++ b/detector/patterns.js
@@ -342,10 +342,10 @@ const AIDetector = (() => {
     'ai-placeholder': 10,
     'ai-citation-markup': 15,
     'ai-utm-source': 12,
-    // Curated copyedits, not authorship evidence. These contribute the same
-    // modest weight as other P2 language cleanups and never act as a trinary
-    // classifier corroborator.
-    'unnecessary-hyphenation': 2,
+    // Curated P2 copyedits, not authorship evidence. Keep them visible in the
+    // issue list without moving the AI score, label, probabilities, or
+    // trinary classification on short documents.
+    'unnecessary-hyphenation': 0,
   };
 
   // ─── Transition phrases ────────────────────────────────────────────
@@ -749,12 +749,107 @@ const AIDetector = (() => {
     }
   }
 
+  function maskYamlFrontmatter(chars) {
+    const lines = chars.join('').split('\n');
+    const bare = (line) => line.replace(/\r$/, '');
+    const first = bare(lines[0]).replace(/^\uFEFF/, '');
+    if (first !== '---' || lines.length < 2 || /^\s*$/.test(bare(lines[1]))) return;
+
+    let closingLine = -1;
+    for (let i = 1; i < lines.length; i += 1) {
+      if (bare(lines[i]) === '---') {
+        closingLine = i;
+        break;
+      }
+    }
+    if (closingLine === -1) return;
+
+    let end = 0;
+    for (let i = 0; i <= closingLine; i += 1) {
+      end += lines[i].length;
+      if (i < lines.length - 1) end += 1;
+    }
+    blankRange(chars, 0, end);
+  }
+
+  function maskYamlMetadata(chars) {
+    const lines = chars.join('').split('\n');
+    let offset = 0;
+    let nestedAfterIndent = null;
+    for (const line of lines) {
+      const bare = line.replace(/\r$/, '');
+      // Lowercase keys are the common unfenced-YAML shape. Keeping this
+      // case-sensitive prevents prose labels such as "Note: ..." from being
+      // mistaken for metadata and silencing a real copyedit on the line.
+      const key = bare.match(/^([ \t]*)(?:-[ \t]+)?[a-z_][a-z0-9_.-]*[ \t]*:(.*)$/);
+      const indentation = (bare.match(/^[ \t]*/) || [''])[0].length;
+      let shouldMask = false;
+
+      if (key) {
+        shouldMask = true;
+        nestedAfterIndent = key[2].trim() === '' ? key[1].length : null;
+      } else if (nestedAfterIndent !== null && bare.trim() !== '' && indentation > nestedAfterIndent) {
+        shouldMask = true;
+      } else if (bare.trim() === '') {
+        nestedAfterIndent = null;
+      } else {
+        nestedAfterIndent = null;
+      }
+
+      if (shouldMask) blankRange(chars, offset, offset + line.length);
+      offset += line.length + 1;
+    }
+  }
+
+  function maskMarkdownTables(chars) {
+    const lines = chars.join('').split('\n');
+    const delimiter = /^\s*\|?\s*:?-{3,}:?\s*(?:\|\s*:?-{3,}:?\s*)+\|?\s*\r?$/;
+    const rows = new Set();
+    for (let i = 0; i < lines.length; i += 1) {
+      if (!delimiter.test(lines[i])) continue;
+      if (i > 0 && lines[i - 1].includes('|')) rows.add(i - 1);
+      rows.add(i);
+      for (let j = i + 1; j < lines.length && lines[j].includes('|'); j += 1) rows.add(j);
+    }
+
+    let offset = 0;
+    for (let i = 0; i < lines.length; i += 1) {
+      if (rows.has(i)) blankRange(chars, offset, offset + lines[i].length);
+      offset += lines[i].length + 1;
+    }
+  }
+
+  function maskDelimitedQuotes(chars, open, close, apostropheAware = false) {
+    const isWord = (char) => char !== undefined && /[a-z0-9]/i.test(char);
+    const isEscaped = (index) => {
+      let slashes = 0;
+      for (let i = index - 1; i >= 0 && chars[i] === '\\'; i -= 1) slashes += 1;
+      return slashes % 2 === 1;
+    };
+    let start = -1;
+    for (let i = 0; i < chars.length; i += 1) {
+      if (start === -1) {
+        if (chars[i] === open && !isEscaped(i) && (!apostropheAware || !isWord(chars[i - 1]))) start = i;
+      } else if (chars[i] === close && !isEscaped(i) && (!apostropheAware || !isWord(chars[i + 1]))) {
+        blankRange(chars, start, i + 1);
+        start = -1;
+      }
+    }
+  }
+
   // Additional protected spans for the hyphenation copyedit. Unlike general
   // AI-tell matching, this rule must not "correct" a literal spelling in a
   // quote, URL, path, filename, command flag, or Markdown blockquote.
   function maskHyphenationProtected(text) {
     const chars = maskCode(text).split('');
     maskTopLevelIndentedCode(chars);
+    maskYamlFrontmatter(chars);
+    maskYamlMetadata(chars);
+    maskMarkdownTables(chars);
+    maskDelimitedQuotes(chars, '"', '"');
+    maskDelimitedQuotes(chars, '“', '”');
+    maskDelimitedQuotes(chars, "'", "'", true);
+    maskDelimitedQuotes(chars, '‘', '’', true);
     const maskMatches = (regex) => {
       const source = chars.join('');
       let match;
@@ -764,11 +859,31 @@ const AIDetector = (() => {
     };
 
     maskMatches(/^[ \t]*>[^\n]*$/gm);
-    maskMatches(/"[^"\n]+"|“[^”\n]+”|(?<![a-z0-9])'(?:[^'\n]|(?<=[a-z0-9])'(?=[a-z0-9]))+'(?![a-z0-9])|‘(?:[^’\n]|(?<=[a-z0-9])’(?=[a-z0-9]))+’/gi);
-    maskMatches(/\b(?:https?:\/\/|www\.)[^\s<>()]+/gi);
-    maskMatches(/(?<!\S)--?[a-z0-9][a-z0-9-]*/gi);
-    maskMatches(/(?:[a-z]:[\\/]|(?:\.\.?[\\/])?)(?:[a-z0-9_.-]+[\\/])+[a-z0-9_.-]+/gi);
-    maskMatches(/\b[a-z0-9_.-]+-[a-z0-9_.-]+\.[a-z0-9]{1,16}\b/gi);
+    maskMatches(/\b(?:https?:\/\/|www\.)[^\s<>]+/gi);
+    maskMatches(/<[!?/]?[a-z][^>\n]*>/gi);
+    maskMatches(/(?<![a-z0-9_-])--?[a-z0-9][a-z0-9-]{0,127}/gi);
+
+    // Paths and filenames use bounded components. Besides preventing
+    // superlinear backtracking on long kebab blobs, the explicit prefix and
+    // trailing-slash forms cover single-component paths such as C:\\code-base,
+    // ~/code-base, /code-base, and code-base/.
+    maskMatches(/(?:[a-z]:[\\/]|\.{1,2}[\\/]|~[\\/]|[\\/])[a-z0-9_.-]{1,64}/gi);
+    maskMatches(/(?:[a-z]:[\\/]|(?:\.\.?[\\/])?)(?:[a-z0-9_.-]{1,64}[\\/]){1,128}[a-z0-9_.-]{1,64}/gi);
+    maskMatches(/\b[a-z0-9_.]{0,63}-[a-z0-9_.-]{1,64}[\\/]/gi);
+    maskMatches(/\b[a-z0-9_.-]{1,64}-[a-z0-9_.-]{1,64}\.[a-z0-9]{1,16}\b/gi);
+
+    // Technical identifiers that are distinguishable from ordinary prose:
+    // selectors, scoped packages, versioned tokens, assignments, and kebab
+    // names next to an explicit identifier cue. Plain lowercase compounds
+    // remain visible to the curated copyedit patterns below.
+    maskMatches(/[.#][a-z_][a-z0-9_.-]{0,63}-[a-z0-9_.-]{1,64}\b/gi);
+    maskMatches(/@[a-z0-9_.-]{1,64}\/[a-z0-9_.-]{1,64}-[a-z0-9_.-]{1,64}(?:@[^\s,;)\]}]{1,32})?/gi);
+    maskMatches(/\b[a-z0-9_.-]{1,64}-[a-z0-9_.-]{1,64}@[~^]?v?\d[a-z0-9*_.+-]{0,31}\b/gi);
+    maskMatches(/\b(?:[a-z0-9_.-]{0,64}\d[a-z0-9_.-]{0,64}-[a-z0-9_.-]{1,64}|[a-z0-9_.-]{1,64}-[a-z0-9_.-]{0,64}\d[a-z0-9_.-]{0,64})\b/gi);
+    maskMatches(/\b[a-z_][a-z0-9_.]{0,63}(?:-[a-z0-9_.]{1,64}){1,8}(?=[ \t]*[=:])/gi);
+    maskMatches(/\b[a-z_][a-z0-9_.]{0,63}(?:-[a-z0-9_.]{1,64}){1,8}(?=[ \t]+(?:npm[ \t]+)?(?:package|module|class|selector|config(?:uration)?[ \t]+key|key|identifier|property|setting|token|slug|command|option)\b)/gi);
+    maskMatches(/\b(?:(?:file(?:name)?|directory|folder|package|module|class|selector|config(?:uration)?[ \t]+key|identifier|property|setting|token|slug|command|option)(?:[ \t]+(?:named|called|is|was))?|key[ \t]+(?:named|called|is|was))[ \t]+(?:@[a-z0-9_.-]{1,64}\/)?[a-z_][a-z0-9_.]{0,63}(?:-[a-z0-9_.]{1,64}){1,8}\b/gi);
+    maskMatches(/\b(?:npm|pnpm|yarn)[ \t]+(?:add|install)[ \t]+(?:@[a-z0-9_.-]{1,64}\/)?[a-z0-9_.]{1,64}(?:-[a-z0-9_.]{1,64}){1,8}/gi);
 
     return chars.join('');
   }
@@ -783,7 +898,6 @@ const AIDetector = (() => {
         issues.push({
           type: 'unnecessary-hyphenation',
           text: match[0],
-          index: match.index,
           severity: 'medium',
           suggestion: typeof entry.suggestion === 'function'
             ? entry.suggestion(match[0])
@@ -899,30 +1013,30 @@ const AIDetector = (() => {
   const UNNECESSARY_HYPHENATION = [
     // Welded open noun phrases reported in #107. Match the complete phrase so
     // a project-specific spelling of the pair in another role is not swept in.
-    { pattern: /\bresearch-impact\s+aggregat(?:or|ion)s?\b/gi, suggestion: (match) => match.replace(/research-impact/i, 'research impact') },
-    { pattern: /\bdata-source\s+strateg(?:y|ies)\b/gi, suggestion: (match) => match.replace(/data-source/i, 'data source') },
+    { pattern: /\bresearch-impact\s+aggregat(?:or|ion)s?\b/g, suggestion: (match) => match.replace('research-impact', 'research impact') },
+    { pattern: /\bdata-source\s+strateg(?:y|ies)\b/g, suggestion: (match) => match.replace('data-source', 'data source') },
     { pattern: /\bPython-package\s+usage\b/g, suggestion: (match) => match.replace('Python-package', 'Python package') },
     { pattern: /\bRust-crate\s+usage\b/g, suggestion: (match) => match.replace('Rust-crate', 'Rust crate') },
     { pattern: /\bsingle-Project\s+Manifest\b/g, suggestion: (match) => match.replace('single-Project', 'single Project') },
-    { pattern: /\btotal-downloads\s+figures?\b/gi, suggestion: (match) => match.replace(/total-downloads/i, 'total downloads') },
-    { pattern: /\blife-sciences-native\s+citation\s+count\b/gi, suggestion: 'citation count from a life sciences source' },
+    { pattern: /\btotal-downloads\s+figures?\b/g, suggestion: (match) => match.replace('total-downloads', 'total downloads') },
+    { pattern: /\blife-sciences-native\s+citation\s+count\b/g, suggestion: 'citation count from a life sciences source' },
 
     // Compounds whose standard spelling is closed. Kept as a small curated
     // list rather than guessing that every noun-noun pair should close up.
-    { pattern: /\bcode-base\b/gi, suggestion: (match) => match.replace('-', '') },
-    { pattern: /\bdata-set\b/gi, suggestion: (match) => match.replace('-', '') },
-    { pattern: /\btime-frame\b/gi, suggestion: (match) => match.replace('-', '') },
-    { pattern: /\broad-map\b/gi, suggestion: (match) => match.replace('-', '') },
+    { pattern: /\bcode-base\b/g, suggestion: (match) => match.replace('-', '') },
+    { pattern: /\bdata-set\b/g, suggestion: (match) => match.replace('-', '') },
+    { pattern: /\btime-frame\b/g, suggestion: (match) => match.replace('-', '') },
+    { pattern: /\broad-map\b/g, suggestion: (match) => match.replace('-', '') },
 
     // Attributive-only forms used adverbially or as nouns. The boundary after
     // real-time / long-term is intentionally narrow: "real-time analytics"
     // and "long-term plan" must not fire.
     {
-      pattern: /\bin\s+real-time(?=\s*(?:[,.!?;:]|$)|\s+(?:(?:across|and|as|automatically|because|but|continuously|during|dynamically|every|for|from|immediately|instantly|on|or|simultaneously|through|throughout|until|via|when|while|with|without)\b))/gi,
+      pattern: /\bin\s+real-time(?=\s*(?:[,.!?;:]|$)|\s+(?:(?:across|as|automatically|because|but|continuously|during|dynamically|every|for|from|immediately|instantly|on|simultaneously|through|throughout|until|via|when|while|with|without)\b))/gi,
       suggestion: 'in real time',
     },
     {
-      pattern: /\b(?:for|over)\s+the\s+long-term(?=\s*(?:[,.!?;:]|$)|\s+(?:across|and|because|but|by|during|for|from|on|or|through|throughout|until|via|when|while|with|without)\b)/gi,
+      pattern: /\b(?:for|over)\s+the\s+long-term(?=\s*(?:[,.!?;:]|$)|\s+(?:across|because|but|by|during|for|from|on|through|throughout|until|via|when|while|with|without)\b)/gi,
       suggestion: (match) => match.replace(/long-term/i, 'long term'),
     },
     {

--- a/detector/patterns.js
+++ b/detector/patterns.js
@@ -867,7 +867,7 @@ const AIDetector = (() => {
     // superlinear backtracking on long kebab blobs, the explicit prefix and
     // trailing-slash forms cover single-component paths such as C:\\code-base,
     // ~/code-base, /code-base, and code-base/.
-    maskMatches(/(?:[a-z]:[\\/]|\.{1,2}[\\/]|~[\\/]|[\\/])[a-z0-9_.-]{1,64}/gi);
+    maskMatches(/(?:[a-z]:[\\/]|\.{1,2}[\\/]|~[\\/]|[\\/])[a-z0-9_.-]{1,255}/gi);
     maskMatches(/(?:[a-z]:[\\/]|(?:\.\.?[\\/])?)(?:[a-z0-9_.-]{1,64}[\\/]){1,128}[a-z0-9_.-]{1,64}/gi);
     maskMatches(/\b[a-z0-9_.]{0,63}-[a-z0-9_.-]{1,64}[\\/]/gi);
     maskMatches(/\b[a-z0-9_.-]{1,64}-[a-z0-9_.-]{1,64}\.[a-z0-9]{1,16}\b/gi);

--- a/detector/patterns.js
+++ b/detector/patterns.js
@@ -342,6 +342,10 @@ const AIDetector = (() => {
     'ai-placeholder': 10,
     'ai-citation-markup': 15,
     'ai-utm-source': 12,
+    // Curated copyedits, not authorship evidence. These contribute the same
+    // modest weight as other P2 language cleanups and never act as a trinary
+    // classifier corroborator.
+    'unnecessary-hyphenation': 2,
   };
 
   // ─── Transition phrases ────────────────────────────────────────────
@@ -700,6 +704,12 @@ const AIDetector = (() => {
     return typeof index === 'number' && ranges.some(([a, b]) => index >= a && index < b);
   }
 
+  function blankRange(chars, start, end) {
+    for (let i = start; i < end && i < chars.length; i += 1) {
+      if (chars[i] !== '\n') chars[i] = ' ';
+    }
+  }
+
   // Copy of the text with fenced blocks and inline code spans blanked out.
   // Index-preserving: each masked character becomes a space and newlines are
   // kept, so offsets into the result still address the same position in the
@@ -709,12 +719,7 @@ const AIDetector = (() => {
   // inline span and swallow the prose between them.
   function maskCode(text) {
     const chars = text.split('');
-    const blank = (a, b) => {
-      for (let i = a; i < b && i < chars.length; i += 1) {
-        if (chars[i] !== '\n') chars[i] = ' ';
-      }
-    };
-    for (const [a, b] of fenceRanges(text)) blank(a, b);
+    for (const [a, b] of fenceRanges(text)) blankRange(chars, a, b);
     // Indented code blocks are deliberately NOT masked. Four spaces is a code
     // block only at top level; under a list marker it is a paragraph
     // continuation, so blanking it silences real tag blocks. #90 reports
@@ -722,8 +727,71 @@ const AIDetector = (() => {
     const withoutFences = chars.join('');
     const inlineRe = /(`+)(?:(?!\1)[^\n])+\1/g;
     let m;
-    while ((m = inlineRe.exec(withoutFences)) !== null) blank(m.index, m.index + m[0].length);
+    while ((m = inlineRe.exec(withoutFences)) !== null) blankRange(chars, m.index, m.index + m[0].length);
     return chars.join('');
+  }
+
+  function maskTopLevelIndentedCode(chars) {
+    const lines = chars.join('').split('\n');
+    let offset = 0;
+    let inBlock = false;
+    for (let i = 0; i < lines.length; i += 1) {
+      const line = lines[i];
+      const indented = /^(?: {4}|\t)\S/.test(line);
+      const previousBlank = i === 0 || lines[i - 1].trim() === '';
+      if (indented && (inBlock || previousBlank)) {
+        blankRange(chars, offset, offset + line.length);
+        inBlock = true;
+      } else if (line.trim() !== '') {
+        inBlock = false;
+      }
+      offset += line.length + 1;
+    }
+  }
+
+  // Additional protected spans for the hyphenation copyedit. Unlike general
+  // AI-tell matching, this rule must not "correct" a literal spelling in a
+  // quote, URL, path, filename, command flag, or Markdown blockquote.
+  function maskHyphenationProtected(text) {
+    const chars = maskCode(text).split('');
+    maskTopLevelIndentedCode(chars);
+    const maskMatches = (regex) => {
+      const source = chars.join('');
+      let match;
+      while ((match = regex.exec(source)) !== null) {
+        blankRange(chars, match.index, match.index + match[0].length);
+      }
+    };
+
+    maskMatches(/^[ \t]*>[^\n]*$/gm);
+    maskMatches(/"[^"\n]+"|“[^”\n]+”|(?<![a-z0-9])'(?:[^'\n]|(?<=[a-z0-9])'(?=[a-z0-9]))+'(?![a-z0-9])|‘(?:[^’\n]|(?<=[a-z0-9])’(?=[a-z0-9]))+’/gi);
+    maskMatches(/\b(?:https?:\/\/|www\.)[^\s<>()]+/gi);
+    maskMatches(/(?<!\S)--?[a-z0-9][a-z0-9-]*/gi);
+    maskMatches(/(?:[a-z]:[\\/]|(?:\.\.?[\\/])?)(?:[a-z0-9_.-]+[\\/])+[a-z0-9_.-]+/gi);
+    maskMatches(/\b[a-z0-9_.-]+-[a-z0-9_.-]+\.[a-z0-9]{1,16}\b/gi);
+
+    return chars.join('');
+  }
+
+  function findUnnecessaryHyphenation(text) {
+    const scanText = maskHyphenationProtected(text);
+    const issues = [];
+    for (const entry of UNNECESSARY_HYPHENATION) {
+      const regex = new RegExp(entry.pattern.source, entry.pattern.flags);
+      let match;
+      while ((match = regex.exec(scanText)) !== null) {
+        issues.push({
+          type: 'unnecessary-hyphenation',
+          text: match[0],
+          index: match.index,
+          severity: 'medium',
+          suggestion: typeof entry.suggestion === 'function'
+            ? entry.suggestion(match[0])
+            : entry.suggestion,
+        });
+      }
+    }
+    return issues;
   }
 
   // ─── Forms that open with `#` but are not social tags ──────────────
@@ -821,6 +889,46 @@ const AIDetector = (() => {
     /\bbookmark\s+this(?:\s+(?:one|post|thread))?(?=\s*(?:[:.!\n]|$))/gi,
     /\bdo\s*n['’]?t\s+sleep\s+on\s+this\b/gi,
     /\btrust\s+me,?\s+(?:on\s+this|you['’]?ll)\b/gi,
+  ];
+
+  // ─── Unnecessary hyphenation (#107) ───────────────────────────────
+  // Precision-first subclasses only. The general question of whether a
+  // compound modifier is established English needs editorial judgment and
+  // remains in SKILL.md; the engine covers only curated open/closed forms and
+  // compounds whose surrounding syntax makes the unhyphenated form clear.
+  const UNNECESSARY_HYPHENATION = [
+    // Welded open noun phrases reported in #107. Match the complete phrase so
+    // a project-specific spelling of the pair in another role is not swept in.
+    { pattern: /\bresearch-impact\s+aggregat(?:or|ion)s?\b/gi, suggestion: (match) => match.replace(/research-impact/i, 'research impact') },
+    { pattern: /\bdata-source\s+strateg(?:y|ies)\b/gi, suggestion: (match) => match.replace(/data-source/i, 'data source') },
+    { pattern: /\bPython-package\s+usage\b/g, suggestion: (match) => match.replace('Python-package', 'Python package') },
+    { pattern: /\bRust-crate\s+usage\b/g, suggestion: (match) => match.replace('Rust-crate', 'Rust crate') },
+    { pattern: /\bsingle-Project\s+Manifest\b/g, suggestion: (match) => match.replace('single-Project', 'single Project') },
+    { pattern: /\btotal-downloads\s+figures?\b/gi, suggestion: (match) => match.replace(/total-downloads/i, 'total downloads') },
+    { pattern: /\blife-sciences-native\s+citation\s+count\b/gi, suggestion: 'citation count from a life sciences source' },
+
+    // Compounds whose standard spelling is closed. Kept as a small curated
+    // list rather than guessing that every noun-noun pair should close up.
+    { pattern: /\bcode-base\b/gi, suggestion: (match) => match.replace('-', '') },
+    { pattern: /\bdata-set\b/gi, suggestion: (match) => match.replace('-', '') },
+    { pattern: /\btime-frame\b/gi, suggestion: (match) => match.replace('-', '') },
+    { pattern: /\broad-map\b/gi, suggestion: (match) => match.replace('-', '') },
+
+    // Attributive-only forms used adverbially or as nouns. The boundary after
+    // real-time / long-term is intentionally narrow: "real-time analytics"
+    // and "long-term plan" must not fire.
+    {
+      pattern: /\bin\s+real-time(?=\s*(?:[,.!?;:]|$)|\s+(?:(?:across|and|as|automatically|because|but|continuously|during|dynamically|every|for|from|immediately|instantly|on|or|simultaneously|through|throughout|until|via|when|while|with|without)\b))/gi,
+      suggestion: 'in real time',
+    },
+    {
+      pattern: /\b(?:for|over)\s+the\s+long-term(?=\s*(?:[,.!?;:]|$)|\s+(?:across|and|because|but|by|during|for|from|on|or|through|throughout|until|via|when|while|with|without)\b)/gi,
+      suggestion: (match) => match.replace(/long-term/i, 'long term'),
+    },
+    {
+      pattern: /\b(?:functions?|functioned|functioning|operates?|operated|operating|runs?|ran|running|works?|worked|working)\s+out-of-the-box\b/gi,
+      suggestion: (match) => match.replace(/out-of-the-box/i, 'out of the box'),
+    },
   ];
 
   // ═══ Helpers ═══════════════════════════════════════════════════════
@@ -1068,6 +1176,7 @@ const AIDetector = (() => {
     issues.push(...matchPatterns(text, FUTURE_NARRATIVE, 'future-narrative', 'high'));
     issues.push(...matchPatterns(text, REAL_ACTUAL_INFLATION, 'real-actual-inflation', 'medium'));
     issues.push(...matchPatterns(text, SOCIAL_CTA_CLOSER, 'social-cta-closer', 'high'));
+    issues.push(...findUnnecessaryHyphenation(text));
 
     // ── Tier 1 v2: formulaic openers + parenthetical hedges ──────────
     issues.push(...matchPatterns(text, FORMULAIC_OPENERS, 'formulaic-opener', 'high'));
@@ -1930,6 +2039,7 @@ const AIDetector = (() => {
     'ai-placeholder': 'Unfilled placeholder',
     'ai-citation-markup': 'Chatbot citation markup leak',
     'ai-utm-source': 'AI-tool URL parameter',
+    'unnecessary-hyphenation': 'Unnecessary hyphenation',
   };
 
   return {

--- a/detector/patterns.js
+++ b/detector/patterns.js
@@ -1894,13 +1894,17 @@ const AIDetector = (() => {
     }
     if (sentences.length === 0) return [];
 
-    // Map issue.text back to sentence indexes via substring search. Issues
-    // without a meaningful text (e.g. summary signals like "Punctuation
-    // density uniform across paragraphs") have no sentence anchor — they
-    // contribute to the document-level signal but not to highlights.
+    // Map issue.text back to sentence indexes via substring search. Two
+    // kinds of issue stay out of the AI-highlight regions. Summary signals
+    // like "Punctuation density uniform across paragraphs" have no sentence
+    // anchor — they contribute to the document-level signal but not to
+    // highlights. Zero-weight style copyedits (unnecessary-hyphenation) do
+    // have an anchor, but they are P2 grammar cleanup rather than evidence
+    // of machine authorship, so they belong in issues[] and nowhere near a
+    // field reserved for AI sentence highlights.
     // Filter by issue TYPE not text-regex: text-based filtering used to
     // drop legitimate phrase issues containing "across" / "density".
-    const SUMMARY_ONLY_TYPES = new Set([
+    const NON_HIGHLIGHT_TYPES = new Set([
       'punct-distribution',
       'cross-para-burstiness',
       'fnword-trigram-entropy',
@@ -1914,13 +1918,14 @@ const AIDetector = (() => {
       'tier3-phrase-cluster',
       'hashtag-stuff',
       'bullet-np-list',
+      'unnecessary-hyphenation',
     ]);
     const hits = sentences.map(() => ({ count: 0, weight: 0 }));
     const lowerText = text.toLowerCase();
     let unmappedHighlights = 0;
     for (const issue of issues) {
       if (!issue.text || issue.text.length > 200) continue;
-      if (SUMMARY_ONLY_TYPES.has(issue.type)) continue;
+      if (NON_HIGHLIGHT_TYPES.has(issue.type)) continue;
       const needle = issue.text.toLowerCase();
       let idx = 0;
       let matched = false;

--- a/detector/patterns.test.js
+++ b/detector/patterns.test.js
@@ -500,6 +500,8 @@ test('#107: punctuation-adjacent flags and single-component paths stay protected
     'The generated output is copied into code-base/ during every local release build.',
     'The relative file lives at ./code-base for users of the legacy client.',
     'The parent-relative file lives at ../code-base for users of the legacy client.',
+    `The generated file lives at /${'a'.repeat(65)}-code-base for users of the legacy client.`,
+    `The generated Windows file lives at C:\\${'a'.repeat(65)}-code-base for legacy users.`,
   ];
 
   for (const text of protectedForms) {

--- a/detector/patterns.test.js
+++ b/detector/patterns.test.js
@@ -594,6 +594,11 @@ test('#107: copyedit-only findings do not affect score or trinary classification
   assert.equal(result.label, baseline.label, 'copyedit-only issues must not change the AI label');
   assert.equal(result.document_classification, baseline.document_classification);
   assert.deepEqual(result.class_probabilities, baseline.class_probabilities);
+  assert.deepEqual(
+    result.highlight_sentence_for_ai,
+    [],
+    'copyedit-only issues must not create AI-highlight regions'
+  );
 });
 
 test('"verbatim" is Tier 3: single use stays clean, overuse flags by density', () => {

--- a/detector/patterns.test.js
+++ b/detector/patterns.test.js
@@ -355,6 +355,92 @@ test('"load-bearing" (metaphor) flags tier1; construction nouns exempt', () => {
   }
 });
 
+test('#107: deterministic unnecessary hyphenation subclasses fire with fixes', () => {
+  const cases = [
+    ['The team built a research-impact aggregator for the annual reporting workflow.', 'research-impact aggregator', 'research impact aggregator'],
+    ['The report summarizes two research-impact aggregations from the external evaluation teams.', 'research-impact aggregations', 'research impact aggregations'],
+    ['We agreed on a data-source strategy before rebuilding the ingestion pipeline.', 'data-source strategy', 'data source strategy'],
+    ['The guide compares Python-package usage across the supported deployment environments.', 'Python-package usage', 'Python package usage'],
+    ['The guide also compares Rust-crate usage across the supported deployment environments.', 'Rust-crate usage', 'Rust crate usage'],
+    ['The repository keeps a single-Project Manifest for every supported deployment environment.', 'single-Project Manifest', 'single Project Manifest'],
+    ['The audit records a total-downloads figure for every published package each month.', 'total-downloads figure', 'total downloads figure'],
+    ['The dashboard reports a life-sciences-native citation count beside each indexed article.', 'life-sciences-native citation count', 'citation count from a life sciences source'],
+    ['The old code-base still powers the internal dashboard used by the support team.', 'code-base', 'codebase'],
+    ['- Migration note\n    The old code-base remains available while customers finish moving their applications.', 'code-base', 'codebase'],
+    ['The old data-set still feeds the internal dashboard used by the support team.', 'data-set', 'dataset'],
+    ['The published time-frame leaves enough room for another review before launch.', 'time-frame', 'timeframe'],
+    ['The product road-map lists every migration milestone planned for the next quarter.', 'road-map', 'roadmap'],
+    ['The service refreshes the dashboard in real-time, even during the nightly import.', 'in real-time', 'in real time'],
+    ['The service refreshes the dashboard in real-time every day during the nightly import.', 'in real-time', 'in real time'],
+    ['The service refreshes the dashboard in real-time continuously during the nightly import.', 'in real-time', 'in real time'],
+    ['The service refreshes the dashboard in real-time as new records arrive for processing.', 'in real-time', 'in real time'],
+    ['The service refreshes the dashboard in real-time via the existing event stream.', 'in real-time', 'in real time'],
+    ['The current release works out-of-the-box on every operating system we support.', 'works out-of-the-box', 'works out of the box'],
+    ['That shortcut creates maintenance problems over the long-term, despite its early convenience.', 'over the long-term', 'over the long term'],
+    ['That shortcut creates maintenance problems over the long-term across every department.', 'over the long-term', 'over the long term'],
+    ['That shortcut creates maintenance problems over the long-term through deferred upgrades.', 'over the long-term', 'over the long term'],
+    ['The team plans to keep this compatibility layer for the long-term by design.', 'for the long-term', 'for the long term'],
+  ];
+
+  for (const [text, matched, suggestion] of cases) {
+    const result = AIDetector.analyzeText(text);
+    const hits = result.issues.filter((issue) => issue.type === 'unnecessary-hyphenation');
+    assert.equal(hits.length, 1, `expected one unnecessary-hyphenation hit: ${text}`);
+    assert.equal(hits[0].text, matched, `unexpected matched text: ${text}`);
+    assert.equal(hits[0].suggestion, suggestion, `unexpected suggestion: ${text}`);
+    assert.equal(hits[0].severity, 'medium', `hyphenation cleanup should be P2: ${text}`);
+  }
+});
+
+test('#107: standard compound modifiers and open forms do not fire', () => {
+  const clean = [
+    'The team ships high-quality reports through a well-tested release process every week.',
+    'The highly-skilled editor reviewed the draft before the scheduled publication date.',
+    'A family-owned consultancy maintains the third-party integration for our regional offices.',
+    'The real-time dashboard shows a field-normalized score from the open-access dataset.',
+    'The service publishes changes in real-time monthly reports for each customer account.',
+    'The service publishes changes in real-time supply chain analytics for each customer.',
+    'The long-term plan includes out-of-the-box support for server-side rendering.',
+    'The system improved over the long-term planning horizon measured by the research team.',
+    'The codebase stores each dataset and roadmap in the same project workspace.',
+    'We agreed on a data source strategy before rebuilding the ingestion pipeline.',
+  ];
+
+  for (const text of clean) {
+    const result = AIDetector.analyzeText(text);
+    const hits = result.issues.filter((issue) => issue.type === 'unnecessary-hyphenation');
+    assert.equal(hits.length, 0, `legitimate compound should stay clean: ${text}`);
+  }
+});
+
+test('#107: protected spans are excluded from unnecessary-hyphenation detection', () => {
+  const text = [
+    'The docs mention `data-source strategy` only as a literal compatibility key.',
+    'The file lives at docs/code-base/notes.md beside the archived code-base.md document.',
+    'The Windows copy lives at C:\\docs\\code-base\\notes.md for legacy users.',
+    'The Windows fixture directory is C:\\fixtures\\code-base for legacy users.',
+    'Run the command with --code-base before starting the local service.',
+    'Run the command with -code-base before starting the local service.',
+    'The migration guide says "the old code-base remains available" for legacy users.',
+    "The migration guide calls this 'the old code-base' for legacy users.",
+    "The migration guide calls this 'the user's old code-base remains available' for legacy users.",
+    'The migration guide calls this ‘the old code-base’ for legacy users.',
+    `The migration guide says "${'word '.repeat(120)}the old code-base remains available" for legacy users.`,
+    'See https://example.com/guides/code-base for the archived implementation notes.',
+    'The archived exports are named code-base.csv and code-base.go for legacy users.',
+    '> The old code-base remains available to teams migrating legacy applications.',
+    '```text',
+    'Python-package usage and works out-of-the-box are fixture strings here.',
+    '```',
+    '',
+    '    The old code-base remains in this top-level indented code block.',
+  ].join('\n');
+
+  const result = AIDetector.analyzeText(text);
+  const hits = result.issues.filter((issue) => issue.type === 'unnecessary-hyphenation');
+  assert.equal(hits.length, 0, `protected text should not fire: ${JSON.stringify(hits)}`);
+});
+
 test('"verbatim" is Tier 3: single use stays clean, overuse flags by density', () => {
   // Tier 3 words fire only at density (max(3, 3% of words)), so a lone
   // "verbatim" — including the legal/QA term-of-art use — never flags, and the

--- a/detector/patterns.test.js
+++ b/detector/patterns.test.js
@@ -402,6 +402,8 @@ test('#107: standard compound modifiers and open forms do not fire', () => {
     'The service publishes changes in real-time supply chain analytics for each customer.',
     'The long-term plan includes out-of-the-box support for server-side rendering.',
     'The system improved over the long-term planning horizon measured by the research team.',
+    'The report compares results in real-time and historical dashboards for each customer.',
+    'The report compares performance over the long-term and short-term planning horizons.',
     'The codebase stores each dataset and roadmap in the same project workspace.',
     'We agreed on a data source strategy before rebuilding the ingestion pipeline.',
   ];
@@ -439,6 +441,157 @@ test('#107: protected spans are excluded from unnecessary-hyphenation detection'
   const result = AIDetector.analyzeText(text);
   const hits = result.issues.filter((issue) => issue.type === 'unnecessary-hyphenation');
   assert.equal(hits.length, 0, `protected text should not fire: ${JSON.stringify(hits)}`);
+});
+
+test('#107: proper nouns, identifiers, and version strings stay protected', () => {
+  const protectedForms = [
+    'Code-Base Enterprise publishes its quarterly release notes for customers today.',
+    'Road-Map Analytics shared its annual report with the engineering group today.',
+    'Research-Impact Aggregator Enterprise shared its annual report with customers today.',
+    'Data-Source Strategy Analytics shared its annual report with customers today.',
+    'The CODE-BASE heading is a product label used by the documentation team.',
+    'Install the code-base package before running the local development server today.',
+    'Use the .code-base selector when styling the legacy navigation component today.',
+    'The code-base config key remains supported for older deployment manifests today.',
+    'The current package release is code-base@2.4.1 for supported production systems.',
+    'The migration still targets code-base-v2 across all supported production systems.',
+    'The deployment identifier code-base remains supported across production systems today.',
+    'The filename is code-base, which the migration script still recognizes for compatibility.',
+    'The folder named road-map remains available to older deployment scripts today.',
+    'The release notes quote "the old\ncode-base remains available" for compatibility.',
+    "The release notes quote 'the old\ncode-base remains available' for compatibility.",
+    'See https://example.com/guides/(code-base) for the archived implementation notes today.',
+  ];
+
+  for (const text of protectedForms) {
+    const hits = AIDetector.analyzeText(text).issues.filter((issue) => issue.type === 'unnecessary-hyphenation');
+    assert.equal(hits.length, 0, `proper noun or identifier should stay protected: ${text}`);
+  }
+
+  const prose = AIDetector.analyzeText(
+    'The old code-base still powers the internal dashboard used by the support team.'
+  );
+  assert.equal(
+    prose.issues.filter((issue) => issue.type === 'unnecessary-hyphenation').length,
+    1,
+    'ordinary lowercase prose must still fire'
+  );
+
+  const keyAsAdjective = AIDetector.analyzeText(
+    'The key code-base migration remains unfinished while the support team reviews it.'
+  );
+  assert.equal(
+    keyAsAdjective.issues.filter((issue) => issue.type === 'unnecessary-hyphenation').length,
+    1,
+    'an adjectival "key" must not be mistaken for an identifier cue'
+  );
+});
+
+test('#107: punctuation-adjacent flags and single-component paths stay protected', () => {
+  const protectedForms = [
+    'Use (--code-base) when starting the local compatibility service for older clients.',
+    'Pass ,--code-base when starting the local compatibility service for older clients.',
+    'Use [--code-base] when documenting the local compatibility service for older clients.',
+    'Set mode=--code-base when starting the local compatibility service for older clients.',
+    'The Windows file lives at C:\\code-base for users of the legacy client.',
+    'The portable file lives at C:/code-base for users of the legacy client.',
+    'The home-directory file lives at ~/code-base for users of the legacy client.',
+    'The root-level file lives at /code-base for users of the legacy client.',
+    'The generated output is copied into code-base/ during every local release build.',
+    'The relative file lives at ./code-base for users of the legacy client.',
+    'The parent-relative file lives at ../code-base for users of the legacy client.',
+  ];
+
+  for (const text of protectedForms) {
+    const hits = AIDetector.analyzeText(text).issues.filter((issue) => issue.type === 'unnecessary-hyphenation');
+    assert.equal(hits.length, 0, `flag or path should stay protected: ${text}`);
+  }
+
+  const prose = AIDetector.analyzeText(
+    'Outside those literal paths, the old code-base remains ordinary prose and needs editing.'
+  );
+  assert.equal(
+    prose.issues.filter((issue) => issue.type === 'unnecessary-hyphenation').length,
+    1,
+    'nearby prose must still fire'
+  );
+});
+
+test('#107: frontmatter, YAML, Markdown tables, and HTML attributes stay protected', () => {
+  const text = [
+    '---',
+    'title: Code-base migration notes',
+    'tags:',
+    '  - code-base',
+    '---',
+    '',
+    'release-name: code-base',
+    'legacy-tags:',
+    '  - road-map',
+    '',
+    '| Setting | Legacy value |',
+    '| --- | --- |',
+    '| package | code-base |',
+    '',
+    '<div data-package=code-base class=road-map>Rendered content remains ordinary prose here.</div>',
+  ].join('\n');
+
+  const hits = AIDetector.analyzeText(text).issues.filter((issue) => issue.type === 'unnecessary-hyphenation');
+  assert.equal(hits.length, 0, `metadata should stay protected: ${JSON.stringify(hits)}`);
+
+  const prose = AIDetector.analyzeText(
+    'After the metadata, the old code-base remains ordinary prose and needs editing today.'
+  );
+  assert.equal(
+    prose.issues.filter((issue) => issue.type === 'unnecessary-hyphenation').length,
+    1,
+    'ordinary prose outside metadata must still fire'
+  );
+
+  const labelledProse = AIDetector.analyzeText(
+    'Note: the old code-base remains ordinary prose and still needs editing before publication.'
+  );
+  assert.equal(
+    labelledProse.issues.filter((issue) => issue.type === 'unnecessary-hyphenation').length,
+    1,
+    'a capitalized prose label must not be mistaken for unfenced YAML'
+  );
+});
+
+test('#107: adversarial filename masking remains within a linear-time budget', () => {
+  const attacks = [
+    `${'a-'.repeat(3000)}a`,
+    `${'segment/'.repeat(1000)}`,
+  ];
+  for (const attack of attacks) {
+    const text = `The generated identifier below has no filename extension and must remain safe to scan. ${attack}`;
+    const started = performance.now();
+    AIDetector.analyzeText(text);
+    const elapsedMs = performance.now() - started;
+    assert.ok(elapsedMs < 1000, `adversarial mask scan took ${elapsedMs.toFixed(1)}ms`);
+  }
+});
+
+test('#107: long closed quotations are masked without a length cutoff', () => {
+  const text = `The release notes quote "${'word '.repeat(3600)}the old code-base remains available" for compatibility.`;
+  const hits = AIDetector.analyzeText(text).issues.filter((issue) => issue.type === 'unnecessary-hyphenation');
+  assert.equal(hits.length, 0, 'quoted material must stay protected below the analyzer word limit');
+});
+
+test('#107: copyedit-only findings do not affect score or trinary classification', () => {
+  const clean = 'The team reviewed the release notes before publishing them to customers. Everyone checked the examples, links, headings, and migration steps before the final approval meeting.';
+  const copyedits = 'The code-base and data-set updates follow the time-frame in the road-map. The service runs in real-time, works out-of-the-box, and remains supported over the long-term for every customer.';
+  const baseline = AIDetector.analyzeText(clean);
+  const result = AIDetector.analyzeText(copyedits);
+
+  assert.ok(
+    result.issues.filter((issue) => issue.type === 'unnecessary-hyphenation').length >= 7,
+    'fixture must contain enough distinct copyedits to exercise the short-document threshold'
+  );
+  assert.equal(result.score, baseline.score, 'copyedit-only issues must not change the AI score');
+  assert.equal(result.label, baseline.label, 'copyedit-only issues must not change the AI label');
+  assert.equal(result.document_classification, baseline.document_classification);
+  assert.deepEqual(result.class_probabilities, baseline.class_probabilities);
 });
 
 test('"verbatim" is Tier 3: single use stays clean, overuse flags by density', () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avoid-ai-writing-detector",
-  "version": "3.23.1",
+  "version": "3.24.0",
   "description": "Deterministic detection engine for the Avoid AI Writing skill — pattern + stylometric analysis of AI-generated text.",
   "license": "MIT",
   "repository": {

--- a/plugins/avoid-ai-writing/.claude-plugin/plugin.json
+++ b/plugins/avoid-ai-writing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "avoid-ai-writing",
   "description": "Audit & rewrite content to remove AI writing patterns (\"AI-isms\"). Supports detect-only and edit-in-place modes, voice profiles, and iterate-to-convergence.",
-  "version": "3.23.1",
+  "version": "3.24.0",
   "author": {
     "name": "Conor Bronsdon"
   },

--- a/plugins/avoid-ai-writing/skills/avoid-ai-writing/SKILL.md
+++ b/plugins/avoid-ai-writing/skills/avoid-ai-writing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: avoid-ai-writing
 description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Use this skill when asked to "remove AI-isms," "clean up AI writing," "edit writing for AI patterns," "audit writing for AI tells," or "make this sound less like AI." Supports a detect-only mode, an edit-in-place mode for files, an optional voice profile (casual / professional / technical / warm / blunt), and an iterate-to-convergence pass.
-version: 3.23.1
+version: 3.24.0
 license: MIT
 compatibility: Any AI coding assistant that supports agentskills.io SKILL.md format (Claude Code, Cursor, VS Code Copilot, Hermes Agent, OpenHands, etc.) or OpenClaw. No external tools or APIs required.
 metadata:
@@ -401,8 +401,15 @@ These slot-fill constructions signal that a sentence was generated, not written.
 ### Title case headings
 - AI over-capitalizes headings: "Strategic Negotiations And Key Partnerships" instead of "Strategic negotiations and key partnerships." Use sentence case for subheadings. Title case only for the piece's main title, if at all.
 
-### Hyphenated-pair overuse
-- AI stacks compound modifiers: "a high-quality, well-architected, future-proof solution." Two distinct problems. First, density — strings of hyphenated adjectives piled on one noun; cut to the modifier that actually matters. Second, the attributive/predicate error: a compound is hyphenated *before* the noun ("a high-quality report") but not *after* a linking verb ("the report is high quality," no hyphen). AI frequently hyphenates the predicate form; fix it to two words. Adapted from `blader/humanizer` P26.
+### Hyphenated modifier stacking
+- AI stacks compound modifiers: "a high-quality, well-architected, future-proof solution." The individual hyphens may be correct; the tell is the density. Cut to the modifier that matters. Adapted from `blader/humanizer` P26.
+
+### Unnecessary hyphenation
+- Check welded open noun phrases: "research-impact aggregator" becomes "research impact aggregator," "data-source strategy" becomes "data source strategy," and "Python-package usage" becomes "Python package usage."
+- Close compounds whose standard form is one word: "code-base," "data-set," "time-frame," and "road-map" become "codebase," "dataset," "timeframe," and "roadmap."
+- Remove attributive hyphens when the phrase is used adverbially or as a noun: "in real-time" becomes "in real time" and "works out-of-the-box" becomes "works out of the box." Keep the same compounds before a noun: "real-time analytics," "long-term plan," and "out-of-the-box support."
+- Preserve established and technical compounds such as "high-quality," "open-access," "third-party," "machine-readable," "server-side," "field-normalized," and "family-owned." Spelling varies by dialect and house style, so ambiguous pairs are judgment calls rather than automatic rewrites.
+- Treat a clear hit as P2 copyediting, not evidence of machine authorship. The deterministic detector uses a curated list and excludes code, quoted material, URLs, paths, filenames, and command flags. General attributive-versus-predicate cases stay judgment-only.
 
 ### Cutoff disclaimers
 - "While specific details are limited based on available information," "As of my last update," "I don't have access to real-time data." These are model limitations leaking into prose. Either find the information or remove the hedge. Never publish a sentence that admits the writer didn't look something up.
@@ -609,6 +616,7 @@ Not all AI-isms are equal. When doing a quick pass or triaging a large document,
 - Transition phrases (Moreover, Furthermore, Additionally)
 - Hashtag stuffing (`blog`/`technical-blog` profiles)
 - Tier 3 phrase repetition (single phrase ≥2× — fine in isolation, suspect in stacks)
+- Unnecessary hyphenation (curated open, closed, and position-dependent compounds)
 
 Use P0+P1 for quick passes. Full audit covers all three tiers.
 


### PR DESCRIPTION
## Summary

- add a P2 `unnecessary-hyphenation` detector for the bounded subclasses agreed in #107: welded open noun phrases, curated closed compounds, and position-sensitive compounds
- preserve established compound modifiers and mask code, quotes, blockquotes, URLs, paths, filenames, and command flags before scanning
- split the existing modifier-stacking guidance from grammatical cleanup, bump the catalog to 62 categories and the engine to 48 types, and synchronize the plugin and Cursor copies

The optional `-ly` adverb cleanup is intentionally left out. The issue discussion allows that to arrive later as opt-out style cleanup rather than as an AI tell.

Closes #107.

## User impact

Detect and rewrite suggestions now cover forms such as:

- `research-impact aggregator` → `research impact aggregator`
- `code-base` → `codebase`
- `in real-time` → `in real time`
- `works out-of-the-box` → `works out of the box`

Legitimate uses such as `real-time analytics`, `long-term plan`, `out-of-the-box support`, `high-quality`, and `family-owned` remain unchanged.

## Validation

- `npm test`
- `npm run self-scan:check`
- `bash scripts/check-pattern-count.sh`
- generated plugin and Cursor synchronization checks
- `git diff --check`

## Checklist

- [x] `npm test` passes
- [x] New detector type is documented in `detector/CATEGORIES.md`
- [x] True-positive and must-not-fire fixtures are included
- [x] False positives and protected spans have explicit carve-outs
- [x] `CHANGELOG.md` and version metadata are updated
- [x] Added prose passes the repository self-scan budget
