### PR TITLE
fix: require blank closing code fences

### DIFF
--- a/detector/patterns.js
+++ b/detector/patterns.js
@@ -693,7 +693,7 @@ const AIDetector = (() => {
       } else if (
         marker[0] === open.char &&
         marker.length >= open.len &&
-        m[2].trim() === ''
+        /^[ \t]*\r?$/.test(m[2])
       ) {
         ranges.push([open.start, m.index + m[0].length]);
         open = null;

--- a/detector/patterns.js
+++ b/detector/patterns.js
@@ -682,7 +682,7 @@ const AIDetector = (() => {
    * sliced the whole document for every candidate, which is quadratic on a
    * heading-dense file. */
   function fenceRanges(text) {
-    const re = /^[ \t]{0,3}(`{3,}|~{3,})[^\n]*$/gm;
+    const re = /^[ \t]{0,3}(`{3,}|~{3,})([^\n]*)$/gm;
     const ranges = [];
     let open = null;
     let m;
@@ -690,7 +690,11 @@ const AIDetector = (() => {
       const marker = m[1];
       if (!open) {
         open = { char: marker[0], len: marker.length, start: m.index };
-      } else if (marker[0] === open.char && marker.length >= open.len) {
+      } else if (
+        marker[0] === open.char &&
+        marker.length >= open.len &&
+        m[2].trim() === ''
+      ) {
         ranges.push([open.start, m.index + m[0].length]);
         open = null;
       }

--- a/detector/patterns.test.js
+++ b/detector/patterns.test.js
@@ -1282,6 +1282,18 @@ test('#62: fences that a parity count gets wrong', () => {
   );
 });
 
+test('#77: a fence with an info string cannot close an outer fence', () => {
+  const f3 = '```';
+  const intro = 'Documentation about writing Markdown, long enough to clear the word gate.';
+  const title = '## Benefits And Strategic Considerations';
+
+  assert.equal(
+    titleCaseHits([intro, f3, f3 + 'js', title, f3, f3].join('\n') + HEADING_BODY).length,
+    0,
+    'an info string belongs to an opening fence, so the heading remains code',
+  );
+});
+
 test('#62: MD_HEADING_PREFIX accepts what the pattern accepts', () => {
   // The two must stay coupled: TITLE_CASE_HEADER matches `#{1,6}[ \t]+`, so if
   // the prefix strip stops accepting a tab, `##` survives into the token list

--- a/detector/patterns.test.js
+++ b/detector/patterns.test.js
@@ -1282,16 +1282,32 @@ test('#62: fences that a parity count gets wrong', () => {
   );
 });
 
-test('#77: a fence with an info string cannot close an outer fence', () => {
-  const f3 = '```';
+test('#77: only spaces and tabs may follow a closing fence', () => {
   const intro = 'Documentation about writing Markdown, long enough to clear the word gate.';
   const title = '## Benefits And Strategic Considerations';
 
-  assert.equal(
-    titleCaseHits([intro, f3, f3 + 'js', title, f3, f3].join('\n') + HEADING_BODY).length,
-    0,
-    'an info string belongs to an opening fence, so the heading remains code',
-  );
+  for (const fence of ['```', '~~~']) {
+    assert.equal(
+      titleCaseHits([intro, fence, fence + 'js', title, fence].join('\n') + HEADING_BODY).length,
+      0,
+      'trailing text cannot close the outer fence',
+    );
+    assert.equal(
+      titleCaseHits([intro, fence, 'code', fence + ' \t', title].join('\n') + HEADING_BODY).length,
+      1,
+      'spaces and tabs may follow a closing fence',
+    );
+    assert.equal(
+      titleCaseHits([intro, fence, 'code', fence + '\u00a0', title].join('\n') + HEADING_BODY).length,
+      0,
+      'non-breaking space is fence content, not an allowed closing-fence suffix',
+    );
+    assert.equal(
+      titleCaseHits([intro, fence, 'code', fence, title].join('\r\n') + HEADING_BODY).length,
+      1,
+      'CRLF line endings still allow a closing fence',
+    );
+  }
 });
 
 test('#62: MD_HEADING_PREFIX accepts what the pattern accepts', () => {


### PR DESCRIPTION
## Summary

- capture the text after a fenced-code delimiter
- only allow a matching delimiter with whitespace-only trailing text to close an open fence
- cover an info-string fence nested inside an outer fenced block

## Root cause

`fenceRanges()` accepted every fence-like line as a possible closer, including lines such as `````js``. CommonMark allows an info string on an opening fence, but a closing fence may only be followed by spaces or tabs. The premature close exposed headings inside the outer code block to prose detectors.

## Tests

- `npm test`
- `npm run self-scan:check`
- `bash scripts/check-pattern-count.sh`

Fixes #77