### PR TITLE
feat: add rendered Markdown source mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,11 @@ All notable changes to this project are documented here.
 - **`analyzeText()` can score rendered Markdown instead of source-only
   metadata (#123).** Pass `sourceMode: "rendered-markdown"` to mask initial
   YAML frontmatter and HTML comments before pattern and document analysis.
-  Masks preserve source offsets, and `stats` reports the selected mode and
-  masked-span counts. Plain mode remains the default.
+  Code-span comment examples remain visible, frontmatter recognition accepts
+  LF, CRLF, and CR without hiding thematic-break sections, and masks preserve
+  issue and sentence-highlight offsets. `stats` reports the selected mode,
+  explicit fallbacks, and masked-span counts. Plain mode remains compatible
+  with its existing scoring behavior.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project are documented here.
 
 ---
 
+## [3.27.0] — 2026-08-26
+
+### Added
+
+- **`analyzeText()` can score rendered Markdown instead of source-only
+  metadata (#123).** Pass `sourceMode: "rendered-markdown"` to mask initial
+  YAML frontmatter and HTML comments before pattern and document analysis.
+  Masks preserve source offsets, and `stats` reports the selected mode and
+  masked-span counts. Plain mode remains the default.
+
+---
+
 ## [3.26.0] — 2026-08-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -368,6 +368,11 @@ const AIDetector = require("./detector/patterns.js");
 const { score, label, issues } = AIDetector.analyzeText("Your text here…");
 ```
 
+When the input is a Markdown source file, pass
+`{ sourceMode: "rendered-markdown" }` to exclude initial YAML frontmatter and
+HTML comments from the score while keeping issue offsets aligned with the
+original file. Plain-text behavior remains the default.
+
 See [`detector/README.md`](./detector/README.md) for the full `analyzeText` API
 and [`detector/CATEGORIES.md`](./detector/CATEGORIES.md) for the rule ↔ category
 map that keeps `SKILL.md` and the engine in sync.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: avoid-ai-writing
 description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Use this skill when asked to "remove AI-isms," "clean up AI writing," "edit writing for AI patterns," "audit writing for AI tells," or "make this sound less like AI." Supports a detect-only mode, an edit-in-place mode for files, an optional voice profile (casual / professional / technical / warm / blunt), and an iterate-to-convergence pass.
-version: 3.26.0
+version: 3.27.0
 license: MIT
 compatibility: Any AI coding assistant that supports agentskills.io SKILL.md format (Claude Code, Cursor, VS Code Copilot, Hermes Agent, OpenHands, etc.) or OpenClaw. No external tools or APIs required.
 metadata:

--- a/cursor-rules/avoid-ai-writing.mdc
+++ b/cursor-rules/avoid-ai-writing.mdc
@@ -1,5 +1,5 @@
 ---
-description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Activate whenever editing prose-heavy files (Markdown, documentation, blog posts, READMEs, release notes, emails). Cursor port of the avoid-ai-writing skill v3.26.0. See https://github.com/conorbronsdon/avoid-ai-writing.
+description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Activate whenever editing prose-heavy files (Markdown, documentation, blog posts, READMEs, release notes, emails). Cursor port of the avoid-ai-writing skill v3.27.0. See https://github.com/conorbronsdon/avoid-ai-writing.
 globs: ["**/*.md", "**/*.mdx", "**/*.txt", "**/*.rst", "**/*.adoc"]
 alwaysApply: false
 ---

--- a/detector/README.md
+++ b/detector/README.md
@@ -39,19 +39,26 @@ CommonJS).
 | `document_classification` | string | trinary `HUMAN_ONLY` / `MIXED` / `AI_ONLY` (shape mirrors GPTZero for swap-in) |
 | `class_probabilities` | `{human, mixed, ai}` | sums to exactly 1.0 |
 | `confidence_category` | `low` / `medium` / `high` | |
-| `highlight_sentence_for_ai` | region[] | sentence spans with byte offsets + per-region score, for UI highlighting |
+| `highlight_sentence_for_ai` | region[] | sentence spans with source offsets + per-region score, for UI highlighting |
 
 `options.contextMode` accepts `general` (default) or `technical`; technical mode
 suppresses flags that are legitimate in code-adjacent prose (e.g. Title Case
 headers). Invalid modes fall back to `general` and set `stats.contextModeFallback`.
 
 `options.sourceMode` accepts `plain` (default) or `rendered-markdown`. Rendered
-Markdown mode masks initial YAML frontmatter and HTML comments, including an
-unclosed comment through end of file, before pattern matching and document
-metrics run. Masking preserves the input length and line endings so issue and
+Markdown mode masks initial YAML frontmatter and HTML comments before pattern
+matching and document metrics run. Frontmatter may use LF, CRLF, or CR line
+endings and must begin with a YAML mapping entry after any leading blank or
+comment lines; this keeps ordinary prose between thematic breaks visible.
+Comment markers inside fenced or inline code remain visible code, while an
+actual unclosed comment is masked through end of file.
+
+Masking preserves the input length and line endings so issue and
 sentence-highlight offsets still address the original source. The result
 reports `sourceMode`, `sourceModeFallback`, `maskedFrontmatter`, and
-`maskedHtmlComments` in `stats`.
+`maskedHtmlComments` in `stats`. When an explicit invalid source mode falls
+back to `plain`, `sourceModeFallback` retains the requested value, including
+falsy values; without a fallback it is `undefined`.
 
 Comment contents are fully excluded in rendered mode. Use plain mode or a
 source-hygiene linter when TODO placeholders inside comments should still be

--- a/detector/README.md
+++ b/detector/README.md
@@ -35,7 +35,7 @@ CommonJS).
 | `score` | `0–100` | 0 = clean, 100 = heavy AI |
 | `label` | string | `Minimal` / `Some` / `Strong` / `Heavy` (or `Empty` / `Too short` / `Text too long`) |
 | `issues[]` | `{type, text, severity, …}` | one entry per detected pattern; `type` keys map to [`CATEGORIES.md`](./CATEGORIES.md) |
-| `stats` | object | `wordCount`, per-tier counts, `contextMode`, `denseAIVocab`, normalization flags, etc. |
+| `stats` | object | `wordCount`, per-tier counts, `contextMode`, `sourceMode`, masked-span counts, `denseAIVocab`, normalization flags, etc. |
 | `document_classification` | string | trinary `HUMAN_ONLY` / `MIXED` / `AI_ONLY` (shape mirrors GPTZero for swap-in) |
 | `class_probabilities` | `{human, mixed, ai}` | sums to exactly 1.0 |
 | `confidence_category` | `low` / `medium` / `high` | |
@@ -44,6 +44,18 @@ CommonJS).
 `options.contextMode` accepts `general` (default) or `technical`; technical mode
 suppresses flags that are legitimate in code-adjacent prose (e.g. Title Case
 headers). Invalid modes fall back to `general` and set `stats.contextModeFallback`.
+
+`options.sourceMode` accepts `plain` (default) or `rendered-markdown`. Rendered
+Markdown mode masks initial YAML frontmatter and HTML comments, including an
+unclosed comment through end of file, before pattern matching and document
+metrics run. Masking preserves the input length and line endings so issue and
+sentence-highlight offsets still address the original source. The result
+reports `sourceMode`, `sourceModeFallback`, `maskedFrontmatter`, and
+`maskedHtmlComments` in `stats`.
+
+Comment contents are fully excluded in rendered mode. Use plain mode or a
+source-hygiene linter when TODO placeholders inside comments should still be
+reported.
 
 ## `validate(original, rewritten, options?)` → result
 

--- a/detector/patterns.js
+++ b/detector/patterns.js
@@ -735,29 +735,60 @@ const AIDetector = (() => {
     return chars.join('');
   }
 
+  function initialFrontmatterRange(text) {
+    const lines = [];
+    const lineRe = /[^\r\n]*(?:\r\n|\n|\r|$)/g;
+    let match;
+    while ((match = lineRe.exec(text)) !== null && match[0]) {
+      const body = match[0].replace(/(?:\r\n|\n|\r)$/, '');
+      lines.push({ body, start: match.index, end: match.index + body.length });
+    }
+
+    if (lines.length < 3 || !/^---[ \t]*$/.test(lines[0].body.replace(/^\uFEFF/, ''))) return null;
+
+    let closingLine = -1;
+    for (let i = 1; i < lines.length; i += 1) {
+      if (/^---[ \t]*$/.test(lines[i].body)) {
+        closingLine = i;
+        break;
+      }
+    }
+    if (closingLine === -1) return null;
+
+    // A pair of thematic breaks can also surround ordinary Markdown prose.
+    // Require the first substantive line to begin like a YAML mapping entry
+    // before treating the delimited block as frontmatter. Leading blank lines
+    // and YAML comments are valid, and the line parser accepts LF, CRLF, or CR.
+    const yamlKey = /^[ \t]*(?:[A-Za-z0-9_.-]+|"[^"\r\n]+"|'[^'\r\n]+')[ \t]*:/;
+    const firstContent = lines
+      .slice(1, closingLine)
+      .find((line) => line.body.trim() && !/^[ \t]*#/.test(line.body));
+    if (!firstContent || !yamlKey.test(firstContent.body)) return null;
+
+    return { start: 0, end: lines[closingLine].end };
+  }
+
   // Mask source-only Markdown spans while preserving source offsets. The
   // detector can then score what a reader sees without making later issue
   // indexes or sentence highlights point at the wrong source location.
   function maskRenderedMarkdown(text) {
     const chars = text.split('');
-    const blank = (start, end) => {
-      for (let i = start; i < end && i < chars.length; i += 1) {
-        if (chars[i] !== '\n' && chars[i] !== '\r') chars[i] = ' ';
-      }
-    };
 
     let maskedFrontmatter = 0;
-    const frontmatter = /^(?:\uFEFF)?---[ \t]*\r?\n(?=[^\r\n]*\S)[\s\S]*?\r?\n---[ \t]*(?=\r?\n|$)/.exec(text);
+    const frontmatter = initialFrontmatterRange(text);
     if (frontmatter) {
-      blank(frontmatter.index, frontmatter.index + frontmatter[0].length);
+      blankRange(chars, frontmatter.start, frontmatter.end);
       maskedFrontmatter = 1;
     }
 
+    // Discover comments in a code-masked copy so comment-shaped examples in
+    // fenced or inline code cannot open or close a source-only HTML comment.
     let maskedHtmlComments = 0;
+    const commentSource = maskCode(chars.join(''));
     const commentRe = /<!--[\s\S]*?(?:-->|$)/g;
     let match;
-    while ((match = commentRe.exec(text)) !== null) {
-      blank(match.index, match.index + match[0].length);
+    while ((match = commentRe.exec(commentSource)) !== null) {
+      blankRange(chars, match.index, match.index + match[0].length);
       maskedHtmlComments += 1;
     }
 
@@ -784,6 +815,22 @@ const AIDetector = (() => {
     }
 
     return { text: chars.join(''), quotedLines };
+  }
+
+  // Keep the historical deletion behavior for default plain mode. Paragraph-
+  // scoped rules depend on the surrounding lines being rejoined exactly this
+  // way, so changing this prepass would change scores for existing callers.
+  function stripMultilineBlockquotes(text) {
+    const rawLines = text.split(/\r?\n/);
+    const isQuote = rawLines.map((line) => /^\s*>\s/.test(line));
+    const stripIndexes = new Set();
+    for (let i = 0; i < rawLines.length; i += 1) {
+      if (isQuote[i] && ((isQuote[i - 1] && i > 0) || isQuote[i + 1])) stripIndexes.add(i);
+    }
+    return {
+      text: rawLines.filter((_, i) => !stripIndexes.has(i)).join('\n'),
+      quotedLines: stripIndexes.size,
+    };
   }
 
   function maskTopLevelIndentedCode(chars) {
@@ -1191,9 +1238,9 @@ const AIDetector = (() => {
     // initial YAML frontmatter and HTML comments; source-hygiene checks for
     // hidden TODO/placeholder comments remain available through plain mode.
     const VALID_SOURCE_MODES = new Set(['plain', 'rendered-markdown']);
-    const requestedSourceMode = options.sourceMode || 'plain';
+    const requestedSourceMode = options.sourceMode === undefined ? 'plain' : options.sourceMode;
     const sourceMode = VALID_SOURCE_MODES.has(requestedSourceMode) ? requestedSourceMode : 'plain';
-    const sourceModeFallback = requestedSourceMode !== sourceMode ? requestedSourceMode : null;
+    const sourceModeFallback = requestedSourceMode !== sourceMode ? requestedSourceMode : undefined;
     let maskedFrontmatter = 0;
     let maskedHtmlComments = 0;
     if (sourceMode === 'rendered-markdown') {
@@ -1209,7 +1256,9 @@ const AIDetector = (() => {
     // lines to count as a blockquote — single-line `> ls -la` shell
     // prompts in technical docs stay in the text. Masking instead of deleting
     // keeps later issue and highlight offsets aligned with the source file.
-    const blockquotes = maskMultilineBlockquotes(text);
+    const blockquotes = sourceMode === 'rendered-markdown'
+      ? maskMultilineBlockquotes(text)
+      : stripMultilineBlockquotes(text);
     text = blockquotes.text;
     const { quotedLines } = blockquotes;
 
@@ -1884,7 +1933,7 @@ const AIDetector = (() => {
     // merge adjacent flagged sentences into contiguous regions for UI
     // highlighting. Borrowed from GPTZero's sentence-highlighting model
     // — gives users "this paragraph is AI" rather than scattered hits.
-    const regions = buildSentenceRegions(text, deduped);
+    const regions = buildSentenceRegions(text, deduped, sourceMode === 'rendered-markdown');
 
     // Stats derived from the same deduped list so tier counts + patternCount
     // sum to `deduped.length`. Previously patternCount subtracted
@@ -1956,17 +2005,23 @@ const AIDetector = (() => {
 
   // ═══ Sentence regions + trinary classifier ═════════════════════════
 
-  function buildSentenceRegions(text, issues) {
-    // Split text into sentences with byte offsets preserved so the UI
+  function buildSentenceRegions(text, issues, trimBoundaryWhitespace = false) {
+    // Split text into sentences with source offsets preserved so the UI
     // can highlight spans accurately. Sentence boundaries are coarse
     // (.!?) — fine for highlighting, not for linguistic correctness.
     const sentences = [];
     const sentenceRe = /[^.!?]+[.!?]+|\S[^.!?]*$/g;
     let m;
     while ((m = sentenceRe.exec(text)) !== null) {
-      const trimmed = m[0].trim();
-      if (trimmed.length < 4) continue;
-      sentences.push({ start: m.index, end: m.index + m[0].length, text: trimmed });
+      const sentenceText = m[0].trim();
+      if (sentenceText.length < 4) continue;
+      let start = m.index;
+      let end = m.index + m[0].length;
+      if (trimBoundaryWhitespace) {
+        start += m[0].search(/\S/);
+        end -= m[0].match(/\s*$/)[0].length;
+      }
+      sentences.push({ start, end, text: sentenceText });
     }
     if (sentences.length === 0) return [];
 

--- a/detector/patterns.js
+++ b/detector/patterns.js
@@ -735,6 +735,57 @@ const AIDetector = (() => {
     return chars.join('');
   }
 
+  // Mask source-only Markdown spans while preserving source offsets. The
+  // detector can then score what a reader sees without making later issue
+  // indexes or sentence highlights point at the wrong source location.
+  function maskRenderedMarkdown(text) {
+    const chars = text.split('');
+    const blank = (start, end) => {
+      for (let i = start; i < end && i < chars.length; i += 1) {
+        if (chars[i] !== '\n' && chars[i] !== '\r') chars[i] = ' ';
+      }
+    };
+
+    let maskedFrontmatter = 0;
+    const frontmatter = /^(?:\uFEFF)?---[ \t]*\r?\n(?=[^\r\n]*\S)[\s\S]*?\r?\n---[ \t]*(?=\r?\n|$)/.exec(text);
+    if (frontmatter) {
+      blank(frontmatter.index, frontmatter.index + frontmatter[0].length);
+      maskedFrontmatter = 1;
+    }
+
+    let maskedHtmlComments = 0;
+    const commentRe = /<!--[\s\S]*?(?:-->|$)/g;
+    let match;
+    while ((match = commentRe.exec(text)) !== null) {
+      blank(match.index, match.index + match[0].length);
+      maskedHtmlComments += 1;
+    }
+
+    return { text: chars.join(''), maskedFrontmatter, maskedHtmlComments };
+  }
+
+  function maskMultilineBlockquotes(text) {
+    const chars = text.split('');
+    const lines = [];
+    const lineRe = /[^\r\n]*(?:\r\n|\n|\r|$)/g;
+    let match;
+    while ((match = lineRe.exec(text)) !== null && match[0]) {
+      const body = match[0].replace(/[\r\n]+$/, '');
+      lines.push({ text: body, start: match.index, end: match.index + body.length });
+    }
+
+    let quotedLines = 0;
+    const isQuote = lines.map((line) => /^\s*>\s/.test(line.text));
+    for (let i = 0; i < lines.length; i += 1) {
+      if (isQuote[i] && ((isQuote[i - 1] && i > 0) || isQuote[i + 1])) {
+        blankRange(chars, lines[i].start, lines[i].end);
+        quotedLines += 1;
+      }
+    }
+
+    return { text: chars.join(''), quotedLines };
+  }
+
   function maskTopLevelIndentedCode(chars) {
     const lines = chars.join('').split('\n');
     let offset = 0;
@@ -1135,22 +1186,32 @@ const AIDetector = (() => {
     const contextMode = VALID_CONTEXT_MODES.has(requestedMode) ? requestedMode : 'general';
     const contextModeFallback = requestedMode !== contextMode ? requestedMode : null;
 
-    // Pre-pass: strip Markdown blockquotes before scoring. A human
+    // Source mode controls which parts of a Markdown file count as prose.
+    // Plain remains the compatibility default. Rendered Markdown masks only
+    // initial YAML frontmatter and HTML comments; source-hygiene checks for
+    // hidden TODO/placeholder comments remain available through plain mode.
+    const VALID_SOURCE_MODES = new Set(['plain', 'rendered-markdown']);
+    const requestedSourceMode = options.sourceMode || 'plain';
+    const sourceMode = VALID_SOURCE_MODES.has(requestedSourceMode) ? requestedSourceMode : 'plain';
+    const sourceModeFallback = requestedSourceMode !== sourceMode ? requestedSourceMode : null;
+    let maskedFrontmatter = 0;
+    let maskedHtmlComments = 0;
+    if (sourceMode === 'rendered-markdown') {
+      const rendered = maskRenderedMarkdown(text);
+      text = rendered.text;
+      maskedFrontmatter = rendered.maskedFrontmatter;
+      maskedHtmlComments = rendered.maskedHtmlComments;
+    }
+
+    // Pre-pass: mask Markdown blockquotes before scoring. A human
     // reacting to AI text by quoting it shouldn't have the quoted block
     // counted against their own writing. Requires ≥2 consecutive `> `
     // lines to count as a blockquote — single-line `> ls -la` shell
-    // prompts in technical docs stay in the text.
-    let quotedLines = 0;
-    const rawLines = text.split(/\r?\n/);
-    const isQuote = rawLines.map((l) => /^\s*>\s/.test(l));
-    const stripIdx = new Set();
-    for (let i = 0; i < rawLines.length; i++) {
-      if (isQuote[i] && ((isQuote[i - 1] && i > 0) || isQuote[i + 1])) {
-        stripIdx.add(i);
-        quotedLines++;
-      }
-    }
-    text = rawLines.filter((_, i) => !stripIdx.has(i)).join('\n');
+    // prompts in technical docs stay in the text. Masking instead of deleting
+    // keeps later issue and highlight offsets aligned with the source file.
+    const blockquotes = maskMultilineBlockquotes(text);
+    text = blockquotes.text;
+    const { quotedLines } = blockquotes;
 
     // Pre-pass: strip bypass-trick chars before pattern matching so
     // "delve" with a Cyrillic 'е' still hits Tier 1. Original text is
@@ -1160,7 +1221,14 @@ const AIDetector = (() => {
 
     const wordCount = countWords(text);
     if (wordCount < 10) {
-      return { ...buildV2Defaults('UNSCORED', 'low'), score: 0, label: 'Too short', issues: [], stats: { wordCount, contextMode, contextModeFallback }, tooShort: true };
+      return {
+        ...buildV2Defaults('UNSCORED', 'low'),
+        score: 0,
+        label: 'Too short',
+        issues: [],
+        stats: { wordCount, contextMode, contextModeFallback, sourceMode, sourceModeFallback, maskedFrontmatter, maskedHtmlComments },
+        tooShort: true,
+      };
     }
     if (wordCount > MAX_WORDS) {
       return {
@@ -1168,7 +1236,7 @@ const AIDetector = (() => {
         score: 0,
         label: 'Text too long',
         issues: [],
-        stats: { wordCount, contextMode, contextModeFallback },
+        stats: { wordCount, contextMode, contextModeFallback, sourceMode, sourceModeFallback, maskedFrontmatter, maskedHtmlComments },
         tooLong: true,
       };
     }
@@ -1868,6 +1936,10 @@ const AIDetector = (() => {
         patternCount: deduped.length - tier1Count - tier2Count - tier3Count,
         contextMode,
         contextModeFallback,
+        sourceMode,
+        sourceModeFallback,
+        maskedFrontmatter,
+        maskedHtmlComments,
         normalization: norm.flags,
         quotedLines,
         unmappedHighlights: regions._unmapped ?? 0,

--- a/detector/patterns.js
+++ b/detector/patterns.js
@@ -781,15 +781,21 @@ const AIDetector = (() => {
       maskedFrontmatter = 1;
     }
 
-    // Discover comments in a code-masked copy so comment-shaped examples in
-    // fenced or inline code cannot open or close a source-only HTML comment.
+    const maskCommentCode = () => {
+      const codeChars = maskCode(chars.join('')).split('');
+      maskTopLevelIndentedCode(codeChars, { listAware: true });
+      return codeChars.join('');
+    };
     let maskedHtmlComments = 0;
-    const commentSource = maskCode(chars.join(''));
-    const commentRe = /<!--[\s\S]*?(?:-->|$)/g;
-    let match;
-    while ((match = commentRe.exec(commentSource)) !== null) {
-      blankRange(chars, match.index, match.index + match[0].length);
+    let searchIndex = 0;
+    while (searchIndex < text.length) {
+      const openingIndex = maskCommentCode().indexOf('<!--', searchIndex);
+      if (openingIndex === -1) break;
+      const closingIndex = text.indexOf('-->', openingIndex + 2);
+      const end = closingIndex === -1 ? text.length : closingIndex + 3;
+      blankRange(chars, openingIndex, end);
       maskedHtmlComments += 1;
+      searchIndex = end;
     }
 
     return { text: chars.join(''), maskedFrontmatter, maskedHtmlComments };
@@ -833,20 +839,28 @@ const AIDetector = (() => {
     };
   }
 
-  function maskTopLevelIndentedCode(chars) {
+  function maskTopLevelIndentedCode(chars, { listAware = false } = {}) {
     const lines = chars.join('').split('\n');
     let offset = 0;
     let inBlock = false;
+    let previousBlank = true;
+    let listContext = false;
     for (let i = 0; i < lines.length; i += 1) {
       const line = lines[i];
       const indented = /^(?: {4}|\t)\S/.test(line);
-      const previousBlank = i === 0 || lines[i - 1].trim() === '';
-      if (indented && (inBlock || previousBlank)) {
+      const blank = line.trim() === '';
+      const isCode = indented && (inBlock || (previousBlank && (!listAware || !listContext)));
+      if (isCode) {
         blankRange(chars, offset, offset + line.length);
         inBlock = true;
-      } else if (line.trim() !== '') {
+      } else if (!blank) {
         inBlock = false;
       }
+      if (listAware && !blank && !isCode) {
+        if (/^ {0,3}(?:[-*+]|\d{1,9}[.)])(?:\s|$)/.test(line)) listContext = true;
+        else if (/^\S/.test(line)) listContext = false;
+      }
+      previousBlank = blank;
       offset += line.length + 1;
     }
   }

--- a/detector/patterns.test.js
+++ b/detector/patterns.test.js
@@ -142,6 +142,37 @@ test('#123: same-line and unclosed HTML comments are source-only', () => {
   }
 });
 
+test('#123: comment markers inside fenced and inline code remain visible', () => {
+  const prose = 'Moreover, the editor checked the original document before changing the published account for the morning edition.';
+  const cases = [
+    ['fenced-unclosed', ['```html', '<!-- example marker stays open', '```', prose].join('\n')],
+    ['inline-unclosed', `The guide shows \`<!-- example marker\` in code before the sample. ${prose}`],
+    ['inline-closed', `The guide shows \`<!-- example -->\` in code before the sample. ${prose}`],
+  ];
+
+  for (const [name, text] of cases) {
+    const result = AIDetector.analyzeText(text, { sourceMode: 'rendered-markdown' });
+    assert.notEqual(result.label, 'Too short', `${name}: code must not hide later prose`);
+    assert.equal(result.stats.maskedHtmlComments, 0, `${name}: code markers are not comments`);
+    assert.ok(result.issues.some((issue) => issue.type === 'transition'), `${name}: later prose must be analyzed`);
+  }
+});
+
+test('#123: a comment delimiter inside inline code cannot close a comment', () => {
+  const prose = 'Moreover, the editor checked the original document before changing the published account for the morning edition.';
+  const sourceOnly = '<!-- plan `-->` Furthermore, seamless robust and pivotal notes stay hidden -->\n';
+  const baseline = AIDetector.analyzeText(prose);
+  const result = AIDetector.analyzeText(sourceOnly + prose, { sourceMode: 'rendered-markdown' });
+
+  assert.equal(result.stats.maskedHtmlComments, 1);
+  assert.equal(result.score, baseline.score);
+  assert.deepEqual(
+    result.issues.map((issue) => [issue.type, issue.text]),
+    baseline.issues.map((issue) => [issue.type, issue.text]),
+  );
+  assert.equal(result.issues.find((issue) => issue.type === 'transition').index, sourceOnly.length);
+});
+
 test('#123: rendered Markdown preserves issue offsets after masked source', () => {
   const sourceOnly = '<!-- This seamless, robust paradigm should stay hidden. -->\r\n';
   const prose = 'Moreover, the editor checked the original document before changing the published account for the morning edition.';
@@ -150,6 +181,8 @@ test('#123: rendered Markdown preserves issue offsets after masked source', () =
 
   assert.ok(transition, 'reader-facing prose should still be analyzed');
   assert.equal(transition.index, sourceOnly.length);
+  assert.equal(result.highlight_sentence_for_ai[0].start, sourceOnly.length);
+  assert.equal(result.highlight_sentence_for_ai[0].end, sourceOnly.length + prose.length);
 });
 
 test('#123: multiline blockquote masking preserves later source offsets', () => {
@@ -160,21 +193,63 @@ test('#123: multiline blockquote masking preserves later source offsets', () => 
 
   assert.ok(transition, 'reader-facing prose after the quote should still be analyzed');
   assert.equal(transition.index, quote.length);
+  assert.equal(result.highlight_sentence_for_ai[0].start, quote.length);
+  assert.equal(result.highlight_sentence_for_ai[0].end, quote.length + prose.length);
   assert.equal(result.stats.quotedLines, 2);
 });
 
-test('#123: rendered Markdown does not mistake a thematic break for frontmatter', () => {
+test('#123: plain mode preserves legacy blockquote paragraph scoring', () => {
   const text = [
-    '---',
-    '',
-    'Moreover, the team described a seamless and robust landscape in the final report.',
-    '',
-    '---',
+    'We harness practical tools for ordinary work each morning.',
+    '> This quoted material should not count against the author.',
+    '> It contains another quoted line for the detector.',
+    'We navigate routine problems with care before the daily review.',
   ].join('\n');
-  const result = AIDetector.analyzeText(text, { sourceMode: 'rendered-markdown' });
+  const result = AIDetector.analyzeText(text);
 
-  assert.equal(result.stats.maskedFrontmatter, 0);
-  assert.ok(result.issues.length > 0, 'prose between thematic breaks should remain visible');
+  assert.equal(result.score, 6);
+  assert.deepEqual(
+    result.issues.filter((issue) => issue.type === 'tier2').map((issue) => issue.text),
+    ['harness', 'navigate'],
+  );
+  assert.equal(result.stats.quotedLines, 2);
+
+  const leadingWhitespace = '\n\nMoreover, the editor checked the original document before changing the published account for the morning edition.';
+  assert.equal(
+    AIDetector.analyzeText(leadingWhitespace).highlight_sentence_for_ai[0].start,
+    0,
+    'plain-mode highlight boundaries must retain their legacy shape',
+  );
+});
+
+test('#123: rendered Markdown recognizes blank-first-line and CR-only frontmatter', () => {
+  const prose = 'Moreover, the editor checked the original document before changing the published account for the morning edition.';
+  const baseline = AIDetector.analyzeText(prose);
+  const cases = [
+    ['blank-first-line', ['---', '', 'title: Draft', 'description: A comprehensive and pivotal exploration', '---', ''].join('\n')],
+    ['CR-only', ['---', '', 'title: Draft', 'description: A comprehensive and pivotal exploration', '---', ''].join('\r')],
+  ];
+
+  for (const [name, sourceOnly] of cases) {
+    const result = AIDetector.analyzeText(sourceOnly + prose, { sourceMode: 'rendered-markdown' });
+    assert.equal(result.stats.maskedFrontmatter, 1, `${name}: frontmatter must be masked`);
+    assert.equal(result.score, baseline.score, `${name}: metadata must not affect the score`);
+    const transition = result.issues.find((issue) => issue.type === 'transition');
+    assert.ok(transition, `${name}: visible prose must still be analyzed`);
+    assert.equal(transition.index, sourceOnly.length);
+    assert.equal(result.highlight_sentence_for_ai[0].start, sourceOnly.length);
+  }
+});
+
+test('#123: rendered Markdown does not mistake a thematic break for frontmatter', () => {
+  for (const text of [
+    ['---', '', 'Moreover, the team described a seamless and robust landscape in the final report.', '', '---'].join('\n'),
+    ['---', 'Moreover, the team described a seamless and robust landscape in the final report.', '---'].join('\n'),
+  ]) {
+    const result = AIDetector.analyzeText(text, { sourceMode: 'rendered-markdown' });
+    assert.equal(result.stats.maskedFrontmatter, 0);
+    assert.ok(result.issues.length > 0, 'prose between thematic breaks should remain visible');
+  }
 });
 
 test('#123: unknown source modes fall back visibly to plain', () => {
@@ -185,6 +260,15 @@ test('#123: unknown source modes fall back visibly to plain', () => {
   assert.equal(result.stats.sourceModeFallback, 'rendered-markdonw');
   assert.equal(result.stats.maskedHtmlComments, 0);
   assert.ok(result.issues.length > 0, 'fallback must retain plain-mode behavior');
+
+  for (const requested of ['', false, 0, null]) {
+    const fallback = AIDetector.analyzeText(text, { sourceMode: requested });
+    assert.equal(fallback.stats.sourceMode, 'plain');
+    assert.equal(fallback.stats.sourceModeFallback, requested);
+  }
+
+  const omitted = AIDetector.analyzeText(text);
+  assert.equal(omitted.stats.sourceModeFallback, undefined);
 });
 
 test('repeated Tier 1 phrase does not inflate score linearly', () => {

--- a/detector/patterns.test.js
+++ b/detector/patterns.test.js
@@ -158,19 +158,109 @@ test('#123: comment markers inside fenced and inline code remain visible', () =>
   }
 });
 
-test('#123: a comment delimiter inside inline code cannot close a comment', () => {
-  const prose = 'Moreover, the editor checked the original document before changing the published account for the morning edition.';
-  const sourceOnly = '<!-- plan `-->` Furthermore, seamless robust and pivotal notes stay hidden -->\n';
-  const baseline = AIDetector.analyzeText(prose);
-  const result = AIDetector.analyzeText(sourceOnly + prose, { sourceMode: 'rendered-markdown' });
+test('#123: comment markers in top-level indented code remain visible', () => {
+  const text = [
+    '    <!-- seamless robust pivotal -->',
+    '',
+    'Moreover, the editor checked the original document before changing the published account for the morning edition.',
+  ].join('\n');
+  const result = AIDetector.analyzeText(text, { sourceMode: 'rendered-markdown' });
+
+  assert.equal(result.stats.maskedHtmlComments, 0, 'an indented code marker is not an HTML comment');
+  assert.deepEqual(
+    result.issues.filter((issue) => issue.type === 'tier1').map((issue) => issue.text),
+    ['seamless', 'robust', 'pivotal'],
+    'reader-visible indented code must still be analyzed',
+  );
+  assert.ok(result.issues.some((issue) => issue.type === 'transition' && issue.text === 'Moreover'));
+});
+
+test('#123: an indented HTML comment under a list item stays hidden', () => {
+  const text = [
+    '- Keep this item.',
+    '',
+    '    <!-- seamless robust pivotal -->',
+    '',
+    'Moreover, the editor checked the original document before changing the published account for the morning edition.',
+  ].join('\n');
+  const result = AIDetector.analyzeText(text, { sourceMode: 'rendered-markdown' });
 
   assert.equal(result.stats.maskedHtmlComments, 1);
-  assert.equal(result.score, baseline.score);
+  assert.equal(result.issues.some((issue) => /seamless|robust|pivotal/i.test(issue.text || '')), false);
+  assert.ok(result.issues.some((issue) => issue.type === 'transition' && issue.text === 'Moreover'));
+});
+
+test('#123: list syntax inside a comment cannot hide later indented code', () => {
+  const text = [
+    '<!--',
+    '- hidden list item',
+    '  hidden continuation -->',
+    '',
+    '    <!-- seamless robust pivotal -->',
+    '',
+    'Moreover, the editor checked the original document before changing the published account for the morning edition.',
+  ].join('\n');
+  const result = AIDetector.analyzeText(text, { sourceMode: 'rendered-markdown' });
+
+  assert.equal(result.stats.maskedHtmlComments, 1, 'the indented code marker is not a real comment');
+  assert.deepEqual(
+    result.issues.filter((issue) => issue.type === 'tier1').map((issue) => issue.text),
+    ['seamless', 'robust', 'pivotal'],
+  );
+  assert.ok(result.issues.some((issue) => issue.type === 'transition' && issue.text === 'Moreover'));
+});
+
+test('#123: backticks inside an HTML comment do not protect its closing delimiter', () => {
+  const commentPrefix = '<!-- plan `-->';
+  const prose = 'Moreover, the editor checked the original document before changing the published account for the morning edition.';
+  const visibleText = `\` Furthermore, seamless robust and pivotal notes stay hidden -->\n${prose}`;
+  const baseline = AIDetector.analyzeText(visibleText);
+  const source = commentPrefix + visibleText;
+  const result = AIDetector.analyzeText(source, { sourceMode: 'rendered-markdown' });
+
+  assert.equal(result.stats.maskedHtmlComments, 1);
+  assert.equal(result.score, 19, 'all reader-visible findings must contribute to the rendered score');
+  assert.equal(result.score, baseline.score, 'the first literal --> must close the comment');
+  assert.ok(result.issues.some((issue) => issue.type === 'transition' && issue.text === 'Furthermore'));
+  assert.deepEqual(
+    result.issues.filter((issue) => issue.type === 'tier1').map((issue) => issue.text),
+    ['seamless', 'robust', 'pivotal'],
+  );
   assert.deepEqual(
     result.issues.map((issue) => [issue.type, issue.text]),
     baseline.issues.map((issue) => [issue.type, issue.text]),
   );
-  assert.equal(result.issues.find((issue) => issue.type === 'transition').index, sourceOnly.length);
+  assert.deepEqual(
+    result.issues.filter((issue) => Number.isInteger(issue.index)).map((issue) => issue.index),
+    baseline.issues
+      .filter((issue) => Number.isInteger(issue.index))
+      .map((issue) => issue.index + commentPrefix.length),
+  );
+  for (const issue of result.issues.filter((candidate) => Number.isInteger(candidate.index))) {
+    assert.equal(issue.index, source.indexOf(issue.text), `${issue.text}: source offset must survive masking`);
+  }
+});
+
+test('#123: code delimiters in one comment cannot hide a later comment', () => {
+  const prose = 'Moreover, the editor checked the original document before changing the published account for the morning edition.';
+  const hidden = 'Furthermore, this seamless robust paradigm is a testament to progress.';
+  const text = ['<!--', '```', '-->', prose, `<!-- ${hidden} -->`].join('\n');
+  const result = AIDetector.analyzeText(text, { sourceMode: 'rendered-markdown' });
+
+  assert.equal(result.stats.maskedHtmlComments, 2);
+  assert.equal(result.issues.some((issue) => /seamless|robust|paradigm|testament/i.test(issue.text || '')), false);
+  assert.ok(result.issues.some((issue) => issue.type === 'transition'), 'visible prose must still fire');
+});
+
+test('#123: short HTML comments close at an overlapping delimiter', () => {
+  const prose = 'Moreover, the editor checked the original document before changing the published account for the morning edition.';
+
+  for (const comment of ['<!-->', '<!--->']) {
+    const result = AIDetector.analyzeText(`${comment}\n${prose}`, { sourceMode: 'rendered-markdown' });
+    assert.equal(result.stats.maskedHtmlComments, 1);
+    assert.notEqual(result.label, 'Too short', `${comment}: later prose must remain visible`);
+    assert.equal(result.issues.find((issue) => issue.type === 'transition').index, comment.length + 1);
+  }
 });
 
 test('#123: rendered Markdown preserves issue offsets after masked source', () => {

--- a/detector/patterns.test.js
+++ b/detector/patterns.test.js
@@ -83,6 +83,110 @@ test('stats fields sum to issues length', () => {
   assert.equal(sum, r.issues.length, `stats sum (${sum}) != issues (${r.issues.length})`);
 });
 
+test('#123: rendered Markdown ignores frontmatter and multiline HTML comments', () => {
+  const prose = [
+    'A clerk opened the file before sunrise. The names filled three pages.',
+    'He read them twice, signed the order, and passed it down the corridor.',
+  ].join(' ');
+  const comment = [
+    '<!-- ARCHITECTURE',
+    'Furthermore, this is a load-bearing transition. Add comprehensive and pivotal context here.',
+    '-->',
+    prose,
+  ].join('\n');
+  const frontmatter = [
+    '---',
+    'title: Draft',
+    'description: A comprehensive and pivotal exploration of a robust ecosystem',
+    '---',
+    prose,
+  ].join('\n');
+  const baseline = AIDetector.analyzeText(prose);
+
+  for (const [name, text, expected] of [
+    ['comment', comment, { maskedFrontmatter: 0, maskedHtmlComments: 1 }],
+    ['frontmatter', frontmatter, { maskedFrontmatter: 1, maskedHtmlComments: 0 }],
+  ]) {
+    const plain = AIDetector.analyzeText(text);
+    const rendered = AIDetector.analyzeText(text, { sourceMode: 'rendered-markdown' });
+
+    assert.ok(plain.score > baseline.score, `${name}: plain mode must keep inspecting source text`);
+    assert.equal(rendered.score, baseline.score, `${name}: rendered score must match visible prose`);
+    assert.deepEqual(
+      rendered.issues.map((issue) => [issue.type, issue.text]),
+      baseline.issues.map((issue) => [issue.type, issue.text]),
+      `${name}: rendered findings must match visible prose`,
+    );
+    assert.equal(rendered.stats.sourceMode, 'rendered-markdown');
+    assert.equal(rendered.stats.maskedFrontmatter, expected.maskedFrontmatter);
+    assert.equal(rendered.stats.maskedHtmlComments, expected.maskedHtmlComments);
+  }
+});
+
+test('#123: same-line and unclosed HTML comments are source-only', () => {
+  const prose = [
+    'The carpenter measured the door twice before cutting the oak board.',
+    'He shaved one edge, reset the hinges, and checked the latch again.',
+  ].join(' ');
+  const hidden = 'Moreover, this seamless and robust paradigm is a testament to progress.';
+  const baseline = AIDetector.analyzeText(prose);
+
+  for (const [name, text] of [
+    ['same-line', `${prose}\n<!-- ${hidden} -->`],
+    ['unclosed', `${prose}\n<!-- ${hidden}`],
+  ]) {
+    const rendered = AIDetector.analyzeText(text, { sourceMode: 'rendered-markdown' });
+    assert.equal(rendered.score, baseline.score, `${name}: hidden text must not affect the score`);
+    assert.equal(rendered.stats.maskedHtmlComments, 1);
+    assert.equal(rendered.issues.some((issue) => /seamless|robust|testament/i.test(issue.text || '')), false);
+  }
+});
+
+test('#123: rendered Markdown preserves issue offsets after masked source', () => {
+  const sourceOnly = '<!-- This seamless, robust paradigm should stay hidden. -->\r\n';
+  const prose = 'Moreover, the editor checked the original document before changing the published account for the morning edition.';
+  const result = AIDetector.analyzeText(sourceOnly + prose, { sourceMode: 'rendered-markdown' });
+  const transition = result.issues.find((issue) => issue.type === 'transition');
+
+  assert.ok(transition, 'reader-facing prose should still be analyzed');
+  assert.equal(transition.index, sourceOnly.length);
+});
+
+test('#123: multiline blockquote masking preserves later source offsets', () => {
+  const quote = '> This seamless landscape is a testament to progress.\r\n> Moreover, it is a robust paradigm.\r\n';
+  const prose = 'Moreover, the editor checked the original document before changing the published account for the morning edition.';
+  const result = AIDetector.analyzeText(quote + prose, { sourceMode: 'rendered-markdown' });
+  const transition = result.issues.find((issue) => issue.type === 'transition');
+
+  assert.ok(transition, 'reader-facing prose after the quote should still be analyzed');
+  assert.equal(transition.index, quote.length);
+  assert.equal(result.stats.quotedLines, 2);
+});
+
+test('#123: rendered Markdown does not mistake a thematic break for frontmatter', () => {
+  const text = [
+    '---',
+    '',
+    'Moreover, the team described a seamless and robust landscape in the final report.',
+    '',
+    '---',
+  ].join('\n');
+  const result = AIDetector.analyzeText(text, { sourceMode: 'rendered-markdown' });
+
+  assert.equal(result.stats.maskedFrontmatter, 0);
+  assert.ok(result.issues.length > 0, 'prose between thematic breaks should remain visible');
+});
+
+test('#123: unknown source modes fall back visibly to plain', () => {
+  const text = '<!-- Moreover, this seamless and robust paradigm is hidden. -->\nVisible prose has enough words for the detector to score this input normally.';
+  const result = AIDetector.analyzeText(text, { sourceMode: 'rendered-markdonw' });
+
+  assert.equal(result.stats.sourceMode, 'plain');
+  assert.equal(result.stats.sourceModeFallback, 'rendered-markdonw');
+  assert.equal(result.stats.maskedHtmlComments, 0);
+  assert.ok(result.issues.length > 0, 'fallback must retain plain-mode behavior');
+});
+
 test('repeated Tier 1 phrase does not inflate score linearly', () => {
   const single = AIDetector.analyzeText('We delve into the landscape of many things today.');
   const fivefold = AIDetector.analyzeText(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avoid-ai-writing-detector",
-  "version": "3.26.0",
+  "version": "3.27.0",
   "description": "Deterministic detection engine for the Avoid AI Writing skill — pattern + stylometric analysis of AI-generated text.",
   "license": "MIT",
   "repository": {

--- a/plugins/avoid-ai-writing/.claude-plugin/plugin.json
+++ b/plugins/avoid-ai-writing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "avoid-ai-writing",
   "description": "Audit & rewrite content to remove AI writing patterns (\"AI-isms\"). Supports detect-only and edit-in-place modes, voice profiles, and iterate-to-convergence.",
-  "version": "3.26.0",
+  "version": "3.27.0",
   "author": {
     "name": "Conor Bronsdon"
   },

--- a/plugins/avoid-ai-writing/skills/avoid-ai-writing/SKILL.md
+++ b/plugins/avoid-ai-writing/skills/avoid-ai-writing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: avoid-ai-writing
 description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Use this skill when asked to "remove AI-isms," "clean up AI writing," "edit writing for AI patterns," "audit writing for AI tells," or "make this sound less like AI." Supports a detect-only mode, an edit-in-place mode for files, an optional voice profile (casual / professional / technical / warm / blunt), and an iterate-to-convergence pass.
-version: 3.26.0
+version: 3.27.0
 license: MIT
 compatibility: Any AI coding assistant that supports agentskills.io SKILL.md format (Claude Code, Cursor, VS Code Copilot, Hermes Agent, OpenHands, etc.) or OpenClaw. No external tools or APIs required.
 metadata:


### PR DESCRIPTION
Fixes #123.

## What changed

- Adds `sourceMode: "rendered-markdown"` to mask initial YAML frontmatter and HTML comments before scoring.
- Preserves original source offsets, including through the existing multiline-blockquote prepass.
- Reports the selected or fallback source mode and masked-span counts in `stats`.
- Documents that comment TODO hygiene remains available through plain mode or a source linter.
- Adds regression coverage for multiline, same-line, and unclosed comments; frontmatter; thematic breaks; invalid modes; and CRLF offsets.

Plain mode remains the default.

## Verification

- `npm test`
- `npm run self-scan:check`
- `bash scripts/check-pattern-count.sh`