### PR TITLE
docs: add a restrained More from me block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project are documented here.
 
 ---
 
+## [Unreleased]
+
+### Changed
+
+- **README adds a restrained related-work block.** Links to Conor's public
+  builds, Chain of Thought, and `repo-audit` now sit after the core product and
+  usage documentation.
+
+---
+
 ## [3.27.0] — 2026-08-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -443,6 +443,15 @@ nothing here to check it against. The
 [license audit](https://github.com/conorbronsdon/avoid-ai-writing/issues/88)
 behind that line is public.
 
+## More from me
+
+I run agents against my own email, money, and publishing, so I build the
+guardrails first.
+
+- [What I'm building](https://conorbronsdon.com/builds/?utm_source=github&utm_medium=referral&utm_campaign=repo-readme&utm_content=avoid-ai-writing) — public projects across agent skills, MCP servers, creator tools, and Mojo.
+- [Chain of Thought](https://chainofthought.show/?utm_source=github&utm_medium=referral&utm_campaign=repo-readme&utm_content=avoid-ai-writing) — conversations with the people shipping AI systems.
+- [repo-audit](https://github.com/conorbronsdon/repo-audit) — checks whether repository claims are enforced, advisory, or guidance.
+
 ## Credits
 
 Pattern research informed by:


### PR DESCRIPTION
## Summary\n- add a restrained related-work block after the core product and usage documentation\n- link the public builds catalog, Chain of Thought, and the related epo-audit guardrail project\n- keep volatile project and episode counts out of the copy\n- add an Unreleased changelog entry\n\nProgresses conorbronsdon/personal-context#323 (workstream 1).\n\n## Verification\n- 
pm test\n- 
pm run self-scan:check\n- git diff --check\n- all three destinations verified live on 2026-08-28\n\n## Review status\nExact-SHA Claude + free-Hermes reviews pending.