### PR TITLE
docs: add seed coverage for missing corpus registers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 
 ---
 
-## [Unreleased]
+## [Unreleased] — 2026-08-29
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ All notable changes to this project are documented here.
 - **README adds a restrained related-work block.** Links to Conor's public
   builds, Chain of Thought, and `repo-audit` now sit after the core product and
   usage documentation.
+- **Corpus manifest documents the register gap with two auditable seed entries.**
+  RFC 8259 provides a pre-LLM `docs` source and a 1995 W3C mailing-list message
+  provides a pre-LLM `conversational` source. The corpus README records that
+  both registers remain under-sampled and that `social` and `email` still have
+  no entries; the additions do not authorize publishing a rate.
 
 ---
 

--- a/corpus/README.md
+++ b/corpus/README.md
@@ -44,7 +44,9 @@ buckets are what let that assertion be checked instead of assumed.
 
 ## Current contents
 
-Two sources, chosen for different reasons.
+Four source groups, chosen for different reasons. The last two are deliberately
+small seed entries: they make the missing-register state visible in the manifest
+without pretending that one document is enough to support a rate.
 
 **Nine public-domain works, 1788 to 1907**, sliced to 6,000 words each. Their
 provenance is beyond argument: nothing written in 1859 was machine-generated.
@@ -63,6 +65,26 @@ site has been rebuilt and its posts edited since; the median archived capture is
 only **0.92 similar** to its currently published counterpart, and five of the
 twenty-five fall below 0.90. Measuring "his pre-2023 writing" against pages
 edited in 2025 would have measured the wrong thing.
+
+**One documentation source**, [RFC 8259](https://www.rfc-editor.org/rfc/rfc8259),
+is included as a first `docs` seed. It is a pre-LLM, human-authored
+standards-track document with a named editor and a stable IETF publication
+record. It is useful for checking that the fetch-and-hash path handles a
+technical document, but one source is nowhere near a register-level sample.
+
+**One conversational source**, a 1995 message from the public
+[W3C `www-talk` archive](https://lists.w3.org/Archives/Public/www-talk/1995MayJun/0026.html),
+is included as a first `conversational` seed. It is a pre-LLM mailing-list
+exchange with preserved author, date, and thread context. The archive's page
+chrome is excluded by the HTML extractor; only the message page's main content
+is hashed. This seed is still far short of the `n >= 100` units needed for a
+claim.
+
+The manifest therefore has non-zero coverage for `docs` and `conversational`,
+but both remain under-sampled. `social` and `email` remain at zero: social posts
+need an export or an attested author source, and private correspondence must
+not enter the corpus. The register gap is still an explicit limitation, not a
+number the project can publish.
 
 Resolving them was not a matter of swapping a domain. The old site used
 compressed slugs (`beveragetax`, `challengerfunnel`, `emailmarketing`) that do

--- a/corpus/manifest.json
+++ b/corpus/manifest.json
@@ -957,14 +957,14 @@
         "license": "IETF Trust Legal Provisions (TLP) 5.0"
       },
       "slice": {
-        "after": "Abstract",
+        "after": "1.  Introduction",
         "maxWords": 6000
       },
-      "note": "A standards-track technical document with a named editor and a stable, permissive IETF publication policy.",
+      "note": "A standards-track technical document with a named editor and a stable, permissive IETF publication policy. The RFC header, title, and Abstract are front matter; measurement starts at §1 so only the body is hashed.",
       "added": "2026-08-29",
       "class": "human",
-      "sha256": "070f55972b19bb93fa6f517e53f6efc334a75adaf7dbdd7e5bc45431524cce8f",
-      "words": 3967
+      "sha256": "b593bd1763d8f3e506356b1d4c83ec0faf57a133e1a31684a4c693ec27694573",
+      "words": 3601
     },
     {
       "id": "w3c-www-talk-session-tracking-1995",
@@ -977,7 +977,7 @@
       "source": {
         "type": "url",
         "url": "https://lists.w3.org/Archives/Public/www-talk/1995MayJun/0026.html",
-        "license": "W3C public mailing-list archive",
+        "license": "Unverified rights status; author retained; not redistributed",
         "html": {
           "selector": "main"
         }

--- a/corpus/manifest.json
+++ b/corpus/manifest.json
@@ -943,6 +943,50 @@
           "single model family (ChatGPT, Dec 2022) — a TPR here is an upper bound, not an estimate for current models"
         ]
       }
+    },
+    {
+      "id": "rfc-8259-json-2017",
+      "title": "The JavaScript Object Notation (JSON) Data Interchange Format",
+      "author": "Tim Bray (editor)",
+      "year": 2017,
+      "register": "docs",
+      "authorship": "human-pre-llm",
+      "source": {
+        "type": "url",
+        "url": "https://www.rfc-editor.org/rfc/rfc8259.txt",
+        "license": "IETF Trust Legal Provisions (TLP) 5.0"
+      },
+      "slice": {
+        "after": "Abstract",
+        "maxWords": 6000
+      },
+      "note": "A standards-track technical document with a named editor and a stable, permissive IETF publication policy.",
+      "added": "2026-08-29",
+      "class": "human",
+      "sha256": "070f55972b19bb93fa6f517e53f6efc334a75adaf7dbdd7e5bc45431524cce8f",
+      "words": 3967
+    },
+    {
+      "id": "w3c-www-talk-session-tracking-1995",
+      "title": "Re: Session tracking",
+      "author": "Nathaniel Borenstein",
+      "year": 1995,
+      "date": "1995-05-03",
+      "register": "conversational",
+      "authorship": "human-pre-llm",
+      "source": {
+        "type": "url",
+        "url": "https://lists.w3.org/Archives/Public/www-talk/1995MayJun/0026.html",
+        "license": "W3C public mailing-list archive",
+        "html": {
+          "selector": "main"
+        }
+      },
+      "note": "A pre-LLM public mailing-list exchange; the archive preserves the author, date, thread context, and message body.",
+      "added": "2026-08-29",
+      "class": "human",
+      "sha256": "f1cad402e01e77b3e570dd9b6a44828e339d9808f59b20182ca12842e4b53286",
+      "words": 346
     }
   ]
 }

--- a/scripts/corpus.js
+++ b/scripts/corpus.js
@@ -125,7 +125,7 @@ function htmlToText(html, opts = {}) {
   }
 
   return source
-    .replace(/<(script|style)[\s\S]*?<\/\1>/gi, '')
+    .replace(/<(script|style|header|footer|nav)[\s\S]*?<\/\1>/gi, '')
     .replace(/<\/(p|div|h[1-6]|li|blockquote|section|tr)>/gi, '\n\n')
     .replace(/<br\s*\/?>/gi, '\n')
     .replace(/<[^>]+>/g, '')

--- a/scripts/corpus.js
+++ b/scripts/corpus.js
@@ -98,9 +98,12 @@ function stripGutenberg(raw) {
  * Deliberately crude: take the named container, drop scripts and styles, turn
  * block-level closers into paragraph breaks, strip the rest of the tags, and
  * decode the handful of entities that actually appear. No parser, no
- * dependency. Navigation, titles, and datelines survive as short lines, and
- * the measurement's 50-word paragraph floor discards them, so they never reach
- * a score.
+ * dependency. The container selector is what excludes page chrome: a source
+ * that wants its header, nav, or footer dropped chooses a selector that wraps
+ * only the body (the W3C seed uses `main` for exactly that). Semantic elements
+ * that are part of the authored content survive extraction, and the
+ * measurement's 50-word paragraph floor discards short lines like navigation
+ * and datelines, so they never reach a score.
  */
 function htmlToText(html, opts = {}) {
   const config = typeof opts === 'string' ? { selector: opts } : opts;
@@ -125,7 +128,7 @@ function htmlToText(html, opts = {}) {
   }
 
   return source
-    .replace(/<(script|style|header|footer|nav)[\s\S]*?<\/\1>/gi, '')
+    .replace(/<(script|style)[\s\S]*?<\/\1>/gi, '')
     .replace(/<\/(p|div|h[1-6]|li|blockquote|section|tr)>/gi, '\n\n')
     .replace(/<br\s*\/?>/gi, '\n')
     .replace(/<[^>]+>/g, '')

--- a/scripts/corpus.test.js
+++ b/scripts/corpus.test.js
@@ -104,14 +104,31 @@ test('em dashes survive extraction', () => {
   assert.equal((out.match(/—/g) || []).length, 2);
 });
 
-test('script, style, and page chrome never reach the text', () => {
-  const html = '<article><header>Site title</header><nav>Home</nav><script>var delve = 1;</script><style>.a{color:red}</style><p>Body.</p><footer>Copyright</footer></article>';
+test('script and style never reach the text', () => {
+  const html = '<article><script>var delve = 1;</script><style>.a{color:red}</style><p>Body.</p></article>';
   const out = htmlToText(html, { selector: 'article' });
-  assert.ok(!out.includes('Site title'));
-  assert.ok(!out.includes('Home'));
   assert.ok(!out.includes('delve'));
   assert.ok(!out.includes('color:red'));
-  assert.ok(!out.includes('Copyright'));
+  assert.equal(out, 'Body.');
+});
+
+test('authored header, nav, and footer inside the container survive', () => {
+  // Semantic elements that are part of the writing must not be stripped by a
+  // global chrome rule; only the selector decides what is in scope.
+  const html = '<article><header>Site title</header><nav>Home</nav><p>Body.</p><footer>Copyright</footer></article>';
+  const out = htmlToText(html, { selector: 'article' });
+  assert.ok(out.includes('Site title'), 'authored header survived');
+  assert.ok(out.includes('Home'), 'authored nav survived');
+  assert.ok(out.includes('Body.'));
+  assert.ok(out.includes('Copyright'), 'authored footer survived');
+});
+
+test('page chrome outside the container is excluded by the selector', () => {
+  const html = '<header>Site title</header><nav>Home</nav><main><p>Body.</p></main><footer>Copyright</footer>';
+  const out = htmlToText(html, { selector: 'main' });
+  assert.ok(!out.includes('Site title'), 'outer header leaked');
+  assert.ok(!out.includes('Home'), 'outer nav leaked');
+  assert.ok(!out.includes('Copyright'), 'outer footer leaked');
   assert.equal(out, 'Body.');
 });
 

--- a/scripts/corpus.test.js
+++ b/scripts/corpus.test.js
@@ -104,11 +104,15 @@ test('em dashes survive extraction', () => {
   assert.equal((out.match(/—/g) || []).length, 2);
 });
 
-test('script and style contents never reach the text', () => {
-  const html = '<article><script>var delve = 1;</script><style>.a{color:red}</style><p>Body.</p></article>';
+test('script, style, and page chrome never reach the text', () => {
+  const html = '<article><header>Site title</header><nav>Home</nav><script>var delve = 1;</script><style>.a{color:red}</style><p>Body.</p><footer>Copyright</footer></article>';
   const out = htmlToText(html, { selector: 'article' });
+  assert.ok(!out.includes('Site title'));
+  assert.ok(!out.includes('Home'));
   assert.ok(!out.includes('delve'));
   assert.ok(!out.includes('color:red'));
+  assert.ok(!out.includes('Copyright'));
+  assert.equal(out, 'Body.');
 });
 
 // ── Slicing ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds auditable hash-only seed entries for the two corpus registers that the maintainer marked open to contributors:

- RFC 8259 as a pre-LLM `docs` source
- A 1995 W3C `www-talk` message as a pre-LLM `conversational` source

The corpus README now records that both registers remain under-sampled and that `social` and `email` remain empty because they require maintainer-provided or otherwise appropriate sources. This deliberately does not claim that either seed is sufficient to publish a false-positive rate.

The HTML extractor keeps authored semantic elements intact; the W3C archive entry uses its `main` container to exclude outer page chrome, while scripts and styles remain excluded. Focused regression fixtures cover both behaviors.

## Validation

- `node scripts/corpus.js verify` (new entries verify; pre-existing unavailable caches are reported as missing)
- `node scripts/corpus.test.js`
- `npm test`

Contributes to #85


