### PR TITLE
Harden OpenAI plugin validation for deferred port gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 
 ---
 
-## [Unreleased] — 2026-08-29
+## [Unreleased] — 2026-09-04
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project are documented here.
 
 ### Changed
 
+- **Plugin validation now fails closed on deferred port-integrity gaps.** `agents/openai.yaml` rejects scalar policies and malformed mapping/list lines, SVG assets must have an actual `<svg>` root, and the bundled routing matrix carries a checked graph digest plus generated edge inventory so it cannot silently drift from `skill-graph.json`.
+
 - **README adds a restrained related-work block.** Links to Conor's public
   builds, Chain of Thought, and `repo-audit` now sit after the core product and
   usage documentation.

--- a/scripts/validate-openai-plugin.py
+++ b/scripts/validate-openai-plugin.py
@@ -226,12 +226,16 @@ def validate_yaml_shape(path: Path, text: str, errors):
                 current_section = None
                 current_nested = None
                 continue
-            key = match.group(1)
+            key, value = match.groups()
+            value = value or ""
             if key in top_keys:
                 errors.append(f"{path}: duplicate top-level key: {key}")
             top_keys.add(key)
             if key not in AGENT_METADATA_KEYS:
                 errors.append(f"{path}: unknown top-level key: {key}")
+                current_section = None
+            elif value.strip() and not value.strip().startswith("#"):
+                errors.append(f"{path}: malformed YAML line {number}: {key} must be a mapping")
                 current_section = None
             else:
                 current_section = key

--- a/scripts/validate-openai-plugin.py
+++ b/scripts/validate-openai-plugin.py
@@ -129,11 +129,12 @@ def validate_agent_metadata(path: Path, errors):
                 stripped = line.strip()
                 if not stripped or stripped.startswith("#"):
                     continue
-                match = re.fullmatch(r"-\s*([^#]+?)(?:\s+#.*)?", stripped)
-                if not match:
+                match = re.fullmatch(r"-\s+(.+)", stripped)
+                value = parse_supported_yaml_scalar(match.group(1)) if match else None
+                if value is None:
                     malformed = True
                     continue
-                values.append(match.group(1).strip().strip('"').strip("'"))
+                values.append(value)
             if malformed:
                 errors.append(f"{path}: policy.products must be a YAML list")
         else:
@@ -145,11 +146,11 @@ def validate_agent_metadata(path: Path, errors):
             errors.append(f"{path}: policy.products must contain unique CHAT and/or CODEX values")
 
 
-def supported_yaml_scalar(value: str) -> bool:
-    """Return whether value uses the scalar subset supported by this validator."""
+def parse_supported_yaml_scalar(value: str):
+    """Decode the deliberately small scalar subset supported by this validator."""
     value = value.strip()
     if not value:
-        return False
+        return None
     if value.startswith('"'):
         escaped = False
         for index, char in enumerate(value[1:], 1):
@@ -160,12 +161,13 @@ def supported_yaml_scalar(value: str) -> bool:
             elif char == '"':
                 remainder = value[index + 1:].strip()
                 if remainder and not remainder.startswith("#"):
-                    return False
+                    return None
                 try:
-                    return isinstance(json.loads(value[:index + 1]), str)
+                    decoded = json.loads(value[:index + 1])
+                    return decoded if isinstance(decoded, str) else None
                 except json.JSONDecodeError:
-                    return False
-        return False
+                    return None
+        return None
     if value.startswith("'"):
         index = 1
         while index < len(value):
@@ -176,16 +178,23 @@ def supported_yaml_scalar(value: str) -> bool:
                 index += 2
                 continue
             remainder = value[index + 1:].strip()
-            return not remainder or remainder.startswith("#")
-        return False
+            if remainder and not remainder.startswith("#"):
+                return None
+            return value[1:index].replace("''", "'")
+        return None
 
     comment = re.search(r"(?:^|\s)#", value)
     scalar = value[:comment.start()].rstrip() if comment else value
     if not scalar or any(ord(char) < 32 for char in scalar):
-        return False
+        return None
     if scalar[0] in "-?:,[]{}#&*!|>'\"%@`":
-        return False
-    return not re.search(r":(?:\s|$)|[\[\]{}]", scalar)
+        return None
+    return None if re.search(r":(?:\s|$)|[\[\]{}]", scalar) else scalar
+
+
+def supported_yaml_scalar(value: str) -> bool:
+    """Return whether value uses the scalar subset supported by this validator."""
+    return parse_supported_yaml_scalar(value) is not None
 
 
 def valid_products_value(value: str) -> bool:

--- a/scripts/validate-openai-plugin.py
+++ b/scripts/validate-openai-plugin.py
@@ -195,7 +195,7 @@ def valid_products_value(value: str) -> bool:
         return True
     return bool(
         re.fullmatch(
-            r"\[\s*(?:CHAT|CODEX)(?:\s*,\s*(?:CHAT|CODEX))*\s*\](?:\s+#.*)?",
+            r"\[\s*(['\"]?)(?:CHAT|CODEX)\1(?:\s*,\s*(['\"]?)(?:CHAT|CODEX)\2)*\s*\](?:\s+#.*)?",
             value,
         )
     )

--- a/scripts/validate-openai-plugin.py
+++ b/scripts/validate-openai-plugin.py
@@ -2,6 +2,7 @@
 """Validate the public ChatGPT and Codex plugin surface with stdlib only."""
 from __future__ import annotations
 import argparse
+import hashlib
 import json
 from pathlib import Path, PurePosixPath
 import re
@@ -56,12 +57,17 @@ def typed_member(mapping, key, expected_type, errors, label):
 
 def validate_agent_metadata(path: Path, errors):
     text = path.read_text(encoding="utf-8")
+    validate_yaml_shape(path, text, errors)
     for token in ("interface:", "display_name:", "short_description:", "policy:", "allow_implicit_invocation:"):
         if token not in text:
             errors.append(f"{path}: missing {token}")
 
     lines = text.splitlines()
+    policy_match = next((re.match(r"policy:\s*(.*?)(?:\s+#.*)?$", line) for line in lines if re.match(r"policy:\s*", line)), None)
     policy_start = next((i for i, line in enumerate(lines) if re.fullmatch(r"policy:\s*(?:#.*)?", line)), None)
+    if policy_match and policy_match.group(1).strip():
+        errors.append(f"{path}: policy must be a non-empty mapping")
+        return
     if policy_start is None:
         return
     block = []
@@ -123,6 +129,79 @@ def validate_agent_metadata(path: Path, errors):
         if not values or len(values) != len(set(values)) or not set(values).issubset({"CHAT", "CODEX"}):
             errors.append(f"{path}: policy.products must contain unique CHAT and/or CODEX values")
 
+
+def validate_yaml_shape(path: Path, text: str, errors):
+    """Reject lines that cannot belong to the deliberately small openai.yaml schema."""
+    current_section = None
+    current_nested = None
+    top_keys = set()
+    for number, raw in enumerate(text.splitlines(), 1):
+        if not raw.strip() or raw.lstrip().startswith("#"):
+            continue
+        indent = len(raw) - len(raw.lstrip(" "))
+        stripped = raw.strip()
+        if "\t" in raw[:indent]:
+            errors.append(f"{path}: malformed YAML line {number}: tabs are not valid indentation")
+            continue
+        if indent == 0:
+            match = re.match(r"^([A-Za-z_][A-Za-z0-9_-]*):(?:\s|$)", raw)
+            if not match:
+                errors.append(f"{path}: malformed YAML line {number}: expected key/value mapping")
+                current_section = None
+                current_nested = None
+                continue
+            key = match.group(1)
+            if key in top_keys:
+                errors.append(f"{path}: duplicate top-level key: {key}")
+            top_keys.add(key)
+            current_section = key
+            current_nested = None
+            continue
+        if current_section is None:
+            errors.append(f"{path}: malformed YAML line {number}: indented value has no parent mapping")
+            continue
+        if stripped.startswith("-"):
+            if current_section != "policy" or current_nested != "products":
+                errors.append(f"{path}: malformed YAML line {number}: unexpected list item")
+            continue
+        match = re.match(r"^[A-Za-z_][A-Za-z0-9_-]*:", stripped)
+        if not match:
+            errors.append(f"{path}: malformed YAML line {number}: expected key/value mapping")
+            continue
+        current_nested = match.group(0)[:-1]
+
+
+def graph_sha256(graph: dict) -> str:
+    payload = json.dumps(graph, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def validate_routing_matrix(graph: dict, path: Path, errors):
+    """Check the generated route inventory so prose cannot silently drift from the graph."""
+    text = path.read_text(encoding="utf-8")
+    begin = "<!-- BEGIN GENERATED GRAPH ROUTES -->"
+    end = "<!-- END GENERATED GRAPH ROUTES -->"
+    if begin not in text or end not in text:
+        errors.append(f"{path}: missing generated graph route inventory")
+        return
+    generated = text.split(begin, 1)[1].split(end, 1)[0].strip()
+    expected_lines = [
+        f"<!-- skill-graph-sha256: {graph_sha256(graph)} -->",
+        "| Type | From | To | When | Max reentries |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for edge in graph.get("edges", []):
+        if not isinstance(edge, dict):
+            continue
+        limit = edge.get("max_reentries", "")
+        expected_lines.append(
+            f"| {edge.get('type', '')} | `{edge.get('from', '')}` | `{edge.get('to', '')}` | "
+            f"`{edge.get('when', '')}` | {limit} |"
+        )
+    expected = "\n".join(expected_lines)
+    if generated != expected:
+        errors.append(f"{path}: generated graph route inventory drifted from skill-graph.json")
+
 def check_square_svg(path: Path, errors):
     try:
         if path.stat().st_size > MAX_SVG_BYTES:
@@ -137,7 +216,7 @@ def check_square_svg(path: Path, errors):
     except Exception as exc:
         errors.append(f"{path}: invalid SVG: {exc}")
         return
-    if not root.tag.endswith("svg"):
+    if root.tag.split("}")[-1] != "svg":
         errors.append(f"{path}: root element is not svg")
         return
     def number(value):
@@ -288,6 +367,11 @@ def validate(root: Path):
             errors.append("router graph canonical_authority drifted")
         if graph.get("entrypoint") != "avoid-ai-writing-router":
             errors.append("router graph entrypoint drifted")
+    routing_path = skills_root / "avoid-ai-writing-router" / "references" / "routing-matrix.md"
+    if not routing_path.is_file():
+        errors.append("missing router routing matrix")
+    elif isinstance(graph, dict) and graph:
+        validate_routing_matrix(graph, routing_path, errors)
     # The preservation validator imports ./patterns.js for residual checks.
     # Both resources must be present in the public archive so that behavior
     # does not silently degrade after packaging.

--- a/scripts/validate-openai-plugin.py
+++ b/scripts/validate-openai-plugin.py
@@ -14,6 +14,7 @@ FRONTMATTER = re.compile(r"\A---\s*\n(.*?)\n---\s*\n(.*)\Z", re.S)
 TOP_LEVEL_INCLUDE_FILES = ("OPENAI_PLUGIN.md", "NOTICE.md", "PRIVACY.md", "TERMS.md", "SUPPORT.md", "LICENSE")
 CANONICAL_PROJECT_URL = "https://github.com/conorbronsdon/avoid-ai-writing"
 MAX_SVG_BYTES = 256 * 1024
+YAML_MAPPING = re.compile(r"([A-Za-z_][A-Za-z0-9_-]*):(?:[ 	]+(.*)|$)")
 AGENT_METADATA_KEYS = {
     "interface": {"display_name", "short_description", "default_prompt"},
     "policy": {"allow_implicit_invocation", "products"},
@@ -61,19 +62,28 @@ def typed_member(mapping, key, expected_type, errors, label):
 
 def validate_agent_metadata(path: Path, errors):
     text = path.read_text(encoding="utf-8")
-    validate_yaml_shape(path, text, errors)
-    for token in ("interface:", "display_name:", "short_description:", "policy:", "allow_implicit_invocation:"):
-        if token not in text:
-            errors.append(f"{path}: missing {token}")
+    top_keys, nested_keys = validate_yaml_shape(path, text, errors)
+    for key in ("interface", "policy"):
+        if key not in top_keys:
+            errors.append(f"{path}: missing {key}:")
+    for section, keys in (("interface", ("display_name", "short_description")), ("policy", ("allow_implicit_invocation",))):
+        for key in keys:
+            if key not in nested_keys.get(section, set()):
+                errors.append(f"{path}: missing {key}:")
 
     lines = text.splitlines()
-    policy_match = next((re.match(r"policy:\s*(.*?)(?:\s+#.*)?$", line) for line in lines if re.match(r"policy:\s*", line)), None)
-    policy_start = next((i for i, line in enumerate(lines) if re.fullmatch(r"policy:\s*(?:#.*)?", line)), None)
-    if policy_match and policy_match.group(1).strip():
+    policy_entry = next(
+        ((i, (match.group(2) or "").split("#", 1)[0].strip())
+         for i, line in enumerate(lines)
+         if (match := YAML_MAPPING.fullmatch(line.rstrip())) and match.group(1) == "policy"),
+        None,
+    )
+    if policy_entry and policy_entry[1]:
         errors.append(f"{path}: policy must be a non-empty mapping")
         return
-    if policy_start is None:
+    if policy_entry is None:
         return
+    policy_start = policy_entry[0]
     block = []
     for line in lines[policy_start + 1:]:
         if line and not line[0].isspace() and not line.lstrip().startswith("#"):
@@ -81,9 +91,10 @@ def validate_agent_metadata(path: Path, errors):
         block.append(line)
     candidates = []
     for i, line in enumerate(block):
-        match = re.match(r"^( +)([A-Za-z_][A-Za-z0-9_-]*):\s*(.*?)\s*$", line)
-        if match:
-            candidates.append((i, len(match.group(1)), match.group(2), match.group(3)))
+        leading = re.match(r"^( +)", line)
+        match = YAML_MAPPING.fullmatch(line[len(leading.group(1)):].rstrip()) if leading else None
+        if leading and match:
+            candidates.append((i, len(leading.group(1)), match.group(1), match.group(2) or ""))
     if not candidates:
         errors.append(f"{path}: policy must be a non-empty mapping")
         return
@@ -209,7 +220,7 @@ def validate_yaml_shape(path: Path, text: str, errors):
         indent = len(leading)
         stripped = raw.strip()
         if indent == 0:
-            match = re.fullmatch(r"([A-Za-z_][A-Za-z0-9_-]*):\s*(?:#.*)?", raw)
+            match = YAML_MAPPING.fullmatch(raw.rstrip())
             if not match:
                 errors.append(f"{path}: malformed YAML line {number}: expected top-level mapping")
                 current_section = None
@@ -231,11 +242,12 @@ def validate_yaml_shape(path: Path, text: str, errors):
             if current_section is None:
                 errors.append(f"{path}: malformed YAML line {number}: indented value has no parent mapping")
                 continue
-            match = re.fullmatch(r"([A-Za-z_][A-Za-z0-9_-]*):\s*(.*)", stripped)
+            match = YAML_MAPPING.fullmatch(stripped)
             if not match:
                 errors.append(f"{path}: malformed YAML line {number}: expected key/value mapping")
                 continue
             key, value = match.groups()
+            value = value or ""
             if key not in AGENT_METADATA_KEYS[current_section]:
                 errors.append(f"{path}: unknown {current_section} key: {key}")
                 continue
@@ -265,6 +277,7 @@ def validate_yaml_shape(path: Path, text: str, errors):
             errors.append(f"{path}: malformed YAML line {number}: indented value has no parent mapping")
         else:
             errors.append(f"{path}: malformed YAML line {number}: invalid indentation")
+    return top_keys, nested_keys
 
 
 def graph_sha256(graph: dict) -> str:

--- a/scripts/validate-openai-plugin.py
+++ b/scripts/validate-openai-plugin.py
@@ -14,6 +14,10 @@ FRONTMATTER = re.compile(r"\A---\s*\n(.*?)\n---\s*\n(.*)\Z", re.S)
 TOP_LEVEL_INCLUDE_FILES = ("OPENAI_PLUGIN.md", "NOTICE.md", "PRIVACY.md", "TERMS.md", "SUPPORT.md", "LICENSE")
 CANONICAL_PROJECT_URL = "https://github.com/conorbronsdon/avoid-ai-writing"
 MAX_SVG_BYTES = 256 * 1024
+AGENT_METADATA_KEYS = {
+    "interface": {"display_name", "short_description", "default_prompt"},
+    "policy": {"allow_implicit_invocation", "products"},
+}
 
 def parse_frontmatter(path: Path):
     text = path.read_text(encoding="utf-8")
@@ -130,23 +134,84 @@ def validate_agent_metadata(path: Path, errors):
             errors.append(f"{path}: policy.products must contain unique CHAT and/or CODEX values")
 
 
+def supported_yaml_scalar(value: str) -> bool:
+    """Return whether value uses the scalar subset supported by this validator."""
+    value = value.strip()
+    if not value:
+        return False
+    if value.startswith('"'):
+        escaped = False
+        for index, char in enumerate(value[1:], 1):
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                remainder = value[index + 1:].strip()
+                if remainder and not remainder.startswith("#"):
+                    return False
+                try:
+                    return isinstance(json.loads(value[:index + 1]), str)
+                except json.JSONDecodeError:
+                    return False
+        return False
+    if value.startswith("'"):
+        index = 1
+        while index < len(value):
+            if value[index] != "'":
+                index += 1
+                continue
+            if index + 1 < len(value) and value[index + 1] == "'":
+                index += 2
+                continue
+            remainder = value[index + 1:].strip()
+            return not remainder or remainder.startswith("#")
+        return False
+
+    comment = re.search(r"(?:^|\s)#", value)
+    scalar = value[:comment.start()].rstrip() if comment else value
+    if not scalar or any(ord(char) < 32 for char in scalar):
+        return False
+    if scalar[0] in "-?:,[]{}#&*!|>'\"%@`":
+        return False
+    return not re.search(r":(?:\s|$)|[\[\]{}]", scalar)
+
+
+def valid_products_value(value: str) -> bool:
+    """Accept an empty block value or the supported inline products sequence."""
+    value = value.strip()
+    if not value or value.startswith("#"):
+        return True
+    return bool(
+        re.fullmatch(
+            r"\[\s*(?:CHAT|CODEX)(?:\s*,\s*(?:CHAT|CODEX))*\s*\](?:\s+#.*)?",
+            value,
+        )
+    )
+
+
 def validate_yaml_shape(path: Path, text: str, errors):
-    """Reject lines that cannot belong to the deliberately small openai.yaml schema."""
+    """Reject lines outside the deliberately small openai.yaml schema."""
     current_section = None
     current_nested = None
     top_keys = set()
+    nested_keys = {section: set() for section in AGENT_METADATA_KEYS}
     for number, raw in enumerate(text.splitlines(), 1):
-        if not raw.strip() or raw.lstrip().startswith("#"):
+        if not raw.strip():
             continue
-        indent = len(raw) - len(raw.lstrip(" "))
-        stripped = raw.strip()
-        if "\t" in raw[:indent]:
+        leading = re.match(r"^[ \t]*", raw).group(0)
+        if "\t" in leading:
             errors.append(f"{path}: malformed YAML line {number}: tabs are not valid indentation")
+            current_nested = None
             continue
+        if raw.lstrip().startswith("#"):
+            continue
+        indent = len(leading)
+        stripped = raw.strip()
         if indent == 0:
-            match = re.match(r"^([A-Za-z_][A-Za-z0-9_-]*):(?:\s|$)", raw)
+            match = re.fullmatch(r"([A-Za-z_][A-Za-z0-9_-]*):\s*(?:#.*)?", raw)
             if not match:
-                errors.append(f"{path}: malformed YAML line {number}: expected key/value mapping")
+                errors.append(f"{path}: malformed YAML line {number}: expected top-level mapping")
                 current_section = None
                 current_nested = None
                 continue
@@ -154,21 +219,52 @@ def validate_yaml_shape(path: Path, text: str, errors):
             if key in top_keys:
                 errors.append(f"{path}: duplicate top-level key: {key}")
             top_keys.add(key)
-            current_section = key
+            if key not in AGENT_METADATA_KEYS:
+                errors.append(f"{path}: unknown top-level key: {key}")
+                current_section = None
+            else:
+                current_section = key
             current_nested = None
+            continue
+        if indent == 2:
+            current_nested = None
+            if current_section is None:
+                errors.append(f"{path}: malformed YAML line {number}: indented value has no parent mapping")
+                continue
+            match = re.fullmatch(r"([A-Za-z_][A-Za-z0-9_-]*):\s*(.*)", stripped)
+            if not match:
+                errors.append(f"{path}: malformed YAML line {number}: expected key/value mapping")
+                continue
+            key, value = match.groups()
+            if key not in AGENT_METADATA_KEYS[current_section]:
+                errors.append(f"{path}: unknown {current_section} key: {key}")
+                continue
+            if key in nested_keys[current_section]:
+                errors.append(f"{path}: duplicate {current_section} key: {key}")
+            nested_keys[current_section].add(key)
+            if current_section == "policy" and key == "products":
+                if not valid_products_value(value):
+                    errors.append(f"{path}: malformed YAML line {number}: unsupported products value")
+                elif not value.strip() or value.strip().startswith("#"):
+                    current_nested = key
+            elif current_section == "policy" and key == "allow_implicit_invocation":
+                if not re.fullmatch(r"(?:true|false)(?:\s+#.*)?", value.strip()):
+                    errors.append(f"{path}: malformed YAML line {number}: unsupported boolean value")
+            elif not supported_yaml_scalar(value):
+                errors.append(f"{path}: malformed YAML line {number}: unsupported scalar value")
+            continue
+        if indent == 4:
+            if current_section != "policy" or current_nested != "products":
+                errors.append(f"{path}: malformed YAML line {number}: unexpected nested value")
+                continue
+            match = re.fullmatch(r"-\s+(.+)", stripped)
+            if not match or not supported_yaml_scalar(match.group(1)):
+                errors.append(f"{path}: malformed YAML line {number}: invalid products list item")
             continue
         if current_section is None:
             errors.append(f"{path}: malformed YAML line {number}: indented value has no parent mapping")
-            continue
-        if stripped.startswith("-"):
-            if current_section != "policy" or current_nested != "products":
-                errors.append(f"{path}: malformed YAML line {number}: unexpected list item")
-            continue
-        match = re.match(r"^[A-Za-z_][A-Za-z0-9_-]*:", stripped)
-        if not match:
-            errors.append(f"{path}: malformed YAML line {number}: expected key/value mapping")
-            continue
-        current_nested = match.group(0)[:-1]
+        else:
+            errors.append(f"{path}: malformed YAML line {number}: invalid indentation")
 
 
 def graph_sha256(graph: dict) -> str:
@@ -190,10 +286,25 @@ def validate_routing_matrix(graph: dict, path: Path, errors):
         "| Type | From | To | When | Max reentries |",
         "| --- | --- | --- | --- | --- |",
     ]
-    for edge in graph.get("edges", []):
+    edges = graph.get("edges", [])
+    if not isinstance(edges, list):
+        errors.append("router skill graph edges must be an array")
+        return
+    for index, edge in enumerate(edges):
         if not isinstance(edge, dict):
+            errors.append(f"router skill graph edge {index} must be an object")
             continue
+        malformed = False
+        for key in ("type", "from", "to", "when"):
+            if not isinstance(edge.get(key), str) or not edge[key].strip():
+                errors.append(f"router skill graph edge {index} {key} must be a non-empty string")
+                malformed = True
         limit = edge.get("max_reentries", "")
+        if limit != "" and (not isinstance(limit, int) or isinstance(limit, bool)):
+            errors.append(f"router skill graph edge {index} max_reentries must be an integer")
+            malformed = True
+        if malformed:
+            continue
         expected_lines.append(
             f"| {edge.get('type', '')} | `{edge.get('from', '')}` | `{edge.get('to', '')}` | "
             f"`{edge.get('when', '')}` | {limit} |"

--- a/scripts/validate-openai-plugin.test.py
+++ b/scripts/validate-openai-plugin.test.py
@@ -95,6 +95,8 @@ def validation_errors_for(*, manifest=None, tests=None, listing=None, pack=None)
 
 
 assert errors_for("  products: [CHAT, CODEX]\n") == []
+assert errors_for('  products: ["CHAT", "CODEX"]\n') == []
+assert errors_for("  products: ['CHAT', 'CODEX']\n") == []
 assert errors_for("  products:\n    - CHAT\n") == []
 assert any("CHAT and/or CODEX" in error for error in errors_for("  products: [API]\n"))
 assert any("unknown policy key" in error for error in errors_for("  surprise: true\n"))

--- a/scripts/validate-openai-plugin.test.py
+++ b/scripts/validate-openai-plugin.test.py
@@ -98,6 +98,11 @@ assert errors_for("  products: [CHAT, CODEX]\n") == []
 assert errors_for('  products: ["CHAT", "CODEX"]\n') == []
 assert errors_for("  products: ['CHAT', 'CODEX']\n") == []
 assert errors_for("  products:\n    - CHAT\n") == []
+assert errors_for('  products:\n    - "CHAT" # comment\n') == []
+assert any(
+    "CHAT and/or CODEX" in error
+    for error in errors_for('  products:\n    - "CHAT # comment"\n')
+)
 assert any("CHAT and/or CODEX" in error for error in errors_for("  products: [API]\n"))
 assert any("unknown policy key" in error for error in errors_for("  surprise: true\n"))
 assert any(

--- a/scripts/validate-openai-plugin.test.py
+++ b/scripts/validate-openai-plugin.test.py
@@ -41,6 +41,15 @@ def errors_for(policy_tail: str):
         return errors
 
 
+def metadata_errors(text: str):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        path = Path(temp_dir) / "openai.yaml"
+        path.write_text(text, encoding="utf-8")
+        errors = []
+        MODULE.validate_agent_metadata(path, errors)
+        return errors
+
+
 def make_packager_root(root: Path):
     for rel in PACKAGER.INCLUDE_DIRS:
         (root / rel).mkdir()
@@ -89,6 +98,33 @@ assert errors_for("  products: [CHAT, CODEX]\n") == []
 assert errors_for("  products:\n    - CHAT\n") == []
 assert any("CHAT and/or CODEX" in error for error in errors_for("  products: [API]\n"))
 assert any("unknown policy key" in error for error in errors_for("  surprise: true\n"))
+assert any("policy must be a non-empty mapping" in error for error in metadata_errors(PREFIX.replace("policy:\n", "policy: true\n")))
+assert any("malformed YAML line" in error for error in errors_for("  products:\n    this is not a list item\n"))
+
+with tempfile.TemporaryDirectory() as temp_dir:
+    svg_path = Path(temp_dir) / "wrong-root.svg"
+    svg_path.write_text(
+        '<not-svg xmlns="http://www.w3.org/2000/svg" width="1" height="1" />',
+        encoding="utf-8",
+    )
+    errors = []
+    MODULE.check_square_svg(svg_path, errors)
+    assert errors == [f"{svg_path}: root element is not svg"]
+
+with tempfile.TemporaryDirectory() as temp_dir:
+    matrix = Path(temp_dir) / "routing-matrix.md"
+    matrix.write_text("<!-- BEGIN GENERATED GRAPH ROUTES -->\n<!-- END GENERATED GRAPH ROUTES -->\n", encoding="utf-8")
+    errors = []
+    MODULE.validate_routing_matrix({"edges": []}, matrix, errors)
+    assert errors == [f"{matrix}: generated graph route inventory drifted from skill-graph.json"]
+
+with tempfile.TemporaryDirectory() as temp_dir:
+    root = Path(temp_dir)
+    make_valid_plugin_root(root)
+    matrix = root / "skills/avoid-ai-writing-router/references/routing-matrix.md"
+    matrix.write_text(matrix.read_text(encoding="utf-8").replace("detect_or_audit_only", "changed_route"), encoding="utf-8")
+    errors, _, _ = MODULE.validate(root)
+    assert any("routing-matrix.md: generated graph route inventory drifted" in error for error in errors)
 
 with tempfile.TemporaryDirectory() as temp_dir:
     svg_path = Path(temp_dir) / "entity-expansion.svg"

--- a/scripts/validate-openai-plugin.test.py
+++ b/scripts/validate-openai-plugin.test.py
@@ -124,6 +124,18 @@ assert any(
     "unsupported scalar value" in error
     for error in metadata_errors(PREFIX.replace("display_name: Test", "display_name: [unterminated"))
 )
+assert any("expected top-level mapping" in error or "expected key/value mapping" in error for error in errors_for("  products:[CHAT]" + chr(92) + "n"))
+commented_key_errors = metadata_errors(PREFIX.replace("  short_description: Test metadata", "  # short_description: missing"))
+assert any("missing short_description:" in error for error in commented_key_errors)
+quoted_tokens_errors = metadata_errors(
+    """interface:
+  display_name: Test
+  short_description: Test metadata
+  default_prompt: \"policy: allow_implicit_invocation:\"
+"""
+)
+assert any("missing policy:" in error for error in quoted_tokens_errors)
+assert any("missing allow_implicit_invocation:" in error for error in quoted_tokens_errors)
 
 with tempfile.TemporaryDirectory() as temp_dir:
     svg_path = Path(temp_dir) / "wrong-root.svg"

--- a/scripts/validate-openai-plugin.test.py
+++ b/scripts/validate-openai-plugin.test.py
@@ -98,8 +98,32 @@ assert errors_for("  products: [CHAT, CODEX]\n") == []
 assert errors_for("  products:\n    - CHAT\n") == []
 assert any("CHAT and/or CODEX" in error for error in errors_for("  products: [API]\n"))
 assert any("unknown policy key" in error for error in errors_for("  surprise: true\n"))
-assert any("policy must be a non-empty mapping" in error for error in metadata_errors(PREFIX.replace("policy:\n", "policy: true\n")))
-assert any("malformed YAML line" in error for error in errors_for("  products:\n    this is not a list item\n"))
+assert any(
+    "policy must be a non-empty mapping" in error
+    for error in metadata_errors(PREFIX.replace("policy:\n", "policy: true\n"))
+)
+assert any(
+    "malformed YAML line" in error
+    for error in errors_for("  products:\n    this is not a list item\n")
+)
+assert any("tabs are not valid indentation" in error for error in errors_for(" \tproducts: [CHAT]\n"))
+assert any("invalid indentation" in error for error in errors_for("  products:\n - CHAT\n"))
+assert any(
+    "unknown interface key: policy" in error
+    for error in metadata_errors(PREFIX.replace("policy:\n", "  policy:\n"))
+)
+assert any(
+    "unknown interface key: surprise" in error
+    for error in metadata_errors(PREFIX.replace("  short_description: Test metadata\n", "  short_description: Test metadata\n  surprise: value\n"))
+)
+assert any(
+    "unknown top-level key: surprise" in error
+    for error in metadata_errors(PREFIX + "surprise:\n")
+)
+assert any(
+    "unsupported scalar value" in error
+    for error in metadata_errors(PREFIX.replace("display_name: Test", "display_name: [unterminated"))
+)
 
 with tempfile.TemporaryDirectory() as temp_dir:
     svg_path = Path(temp_dir) / "wrong-root.svg"
@@ -118,6 +142,19 @@ with tempfile.TemporaryDirectory() as temp_dir:
     MODULE.validate_routing_matrix({"edges": []}, matrix, errors)
     assert errors == [f"{matrix}: generated graph route inventory drifted from skill-graph.json"]
 
+for invalid_edges, expected_error in (
+    (None, "router skill graph edges must be an array"),
+    (7, "router skill graph edges must be an array"),
+    ([None], "router skill graph edge 0 must be an object"),
+    ([{"type": "ROUTE"}], "router skill graph edge 0 from must be a non-empty string"),
+):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        matrix = Path(temp_dir) / "routing-matrix.md"
+        matrix.write_text("<!-- BEGIN GENERATED GRAPH ROUTES -->\n<!-- END GENERATED GRAPH ROUTES -->\n", encoding="utf-8")
+        errors = []
+        MODULE.validate_routing_matrix({"edges": invalid_edges}, matrix, errors)
+        assert expected_error in errors
+
 with tempfile.TemporaryDirectory() as temp_dir:
     root = Path(temp_dir)
     make_valid_plugin_root(root)
@@ -125,6 +162,21 @@ with tempfile.TemporaryDirectory() as temp_dir:
     matrix.write_text(matrix.read_text(encoding="utf-8").replace("detect_or_audit_only", "changed_route"), encoding="utf-8")
     errors, _, _ = MODULE.validate(root)
     assert any("routing-matrix.md: generated graph route inventory drifted" in error for error in errors)
+
+for invalid_edges, expected_error in (
+    (None, "router skill graph edges must be an array"),
+    ([None], "router skill graph edge 0 must be an object"),
+):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        root = Path(temp_dir)
+        make_valid_plugin_root(root)
+        graph_path = root / "skills/avoid-ai-writing-router/references/skill-graph.json"
+        graph = json.loads(graph_path.read_text(encoding="utf-8"))
+        graph["edges"] = invalid_edges
+        graph_path.write_text(json.dumps(graph), encoding="utf-8")
+        errors, _, summary = MODULE.validate(root)
+        assert expected_error in errors
+        assert summary["ok"] is False
 
 with tempfile.TemporaryDirectory() as temp_dir:
     svg_path = Path(temp_dir) / "entity-expansion.svg"

--- a/scripts/validate-openai-plugin.test.py
+++ b/scripts/validate-openai-plugin.test.py
@@ -124,7 +124,17 @@ assert any(
     "unsupported scalar value" in error
     for error in metadata_errors(PREFIX.replace("display_name: Test", "display_name: [unterminated"))
 )
-assert any("expected top-level mapping" in error or "expected key/value mapping" in error for error in errors_for("  products:[CHAT]" + chr(92) + "n"))
+assert any("expected top-level mapping" in error or "expected key/value mapping" in error for error in errors_for("  products:[CHAT]\n"))
+scalar_interface_errors = metadata_errors(
+    """interface: true
+  display_name: Test
+  short_description: Test metadata
+policy:
+  allow_implicit_invocation: true
+  products: [CHAT]
+"""
+)
+assert any("interface must be a mapping" in error for error in scalar_interface_errors)
 commented_key_errors = metadata_errors(PREFIX.replace("  short_description: Test metadata", "  # short_description: missing"))
 assert any("missing short_description:" in error for error in commented_key_errors)
 quoted_tokens_errors = metadata_errors(

--- a/skills/avoid-ai-writing-router/references/routing-matrix.md
+++ b/skills/avoid-ai-writing-router/references/routing-matrix.md
@@ -2,6 +2,25 @@
 
 `skill-graph.json` is the machine-readable source of truth. This table explains the same routes for human review. Cross-stage state follows `handoff-contract.md`.
 
+<!-- BEGIN GENERATED GRAPH ROUTES -->
+<!-- skill-graph-sha256: 66a3beb7883a580e56810fab5e8e2fc01147ef8f8ee21fb37d66cbd1c7e2ed0b -->
+| Type | From | To | When | Max reentries |
+| --- | --- | --- | --- | --- |
+| ROUTE | `avoid-ai-writing-router` | `ai-writing-detector` | `detect_or_audit_only` |  |
+| ROUTE | `avoid-ai-writing-router` | `voice-preserving-rewriter` | `rewrite_returned_text` |  |
+| ROUTE | `avoid-ai-writing-router` | `file-edit-in-place` | `mutate_named_file` |  |
+| ROUTE | `avoid-ai-writing-router` | `preservation-verifier` | `compare_before_after` |  |
+| ROUTE | `avoid-ai-writing-router` | `false-positive-reviewer` | `consequential_authorship_interpretation` |  |
+| FEED | `ai-writing-detector` | `voice-preserving-rewriter` | `user_requests_rewrite_after_audit` |  |
+| FEED | `ai-writing-detector` | `file-edit-in-place` | `user_requests_named_file_fix_after_audit` |  |
+| ESCALATE | `ai-writing-detector` | `false-positive-reviewer` | `user_asks_what_flags_prove` |  |
+| VERIFY | `voice-preserving-rewriter` | `preservation-verifier` | `original_and_rewrite_available` |  |
+| VERIFY | `file-edit-in-place` | `preservation-verifier` | `before_snapshot_available` |  |
+| REPAIR | `preservation-verifier` | `voice-preserving-rewriter` | `returned_text_failed_preservation` | 1 |
+| REPAIR | `preservation-verifier` | `file-edit-in-place` | `named_file_failed_preservation` | 1 |
+| RECHECK | `preservation-verifier` | `ai-writing-detector` | `convergence_or_residual_audit_requested` | 1 |
+<!-- END GENERATED GRAPH ROUTES -->
+
 | Intent | Primary owner | Allowed follow-up | Stop condition |
 | --- | --- | --- | --- |
 | detect, scan, audit, score, flag only | `ai-writing-detector` | feed findings into a requested rewrite/edit stage, or escalate interpretation when needed | findings returned |


### PR DESCRIPTION
## Summary

Addresses the implementation-owned follow-ups in #143 from the ChatGPT/Codex port review:

- Reject scalar `policy:` values and malformed `agents/openai.yaml` mapping/list lines instead of allowing invalid metadata through.
- Require SVG assets to have an actual `<svg>` root element.
- Make the human-readable routing matrix generated-and-verified against `skill-graph.json` with a SHA-256 graph digest and exact edge inventory, preventing silent drift.

## Validation

- `python scripts/validate-openai-plugin.test.py`
- `python -m py_compile scripts/validate-openai-plugin.py`
- `python skills/avoid-ai-writing-router/scripts/validate_connections.py .`
- `python scripts/validate-openai-plugin.py .`
- `npm test`
- `git diff --check`

Closes #143.