### PR TITLE
Drop frontmatter metadata from the OpenAI copy of the canonical skill

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -2,7 +2,7 @@
 
 The canonical Avoid AI Writing skill, detector, validator, documentation, and underlying project are Copyright (c) 2026 Conor Bronsdon and distributed under the MIT License in this repository.
 
-The ChatGPT and Codex package added in this repository preserves the original canonical skill as an exact generated copy. Its router and focused workflow skills are packaging and orchestration additions. They do not replace the original rulebook or claim authorship of it.
+The ChatGPT and Codex package added in this repository preserves the original canonical skill as a generated copy that is identical except for the omitted frontmatter `metadata` block, which the OpenAI portal rejects. Its router and focused workflow skills are packaging and orchestration additions. They do not replace the original rulebook or claim authorship of it.
 
 The public OpenAI package intentionally excludes the separate `avoid-ai-writing-mcp` project. That project is optional and independently distributed.
 

--- a/OPENAI_PLUGIN.md
+++ b/OPENAI_PLUGIN.md
@@ -8,7 +8,7 @@ The public package is skills-only. The separate `avoid-ai-writing-mcp` project r
 
 The canonical root `SKILL.md` remains the editorial authority. The OpenAI package adds focused workflow Skills around it:
 
-- `avoid-ai-writing`: exact copy of the original Skill
+- `avoid-ai-writing`: generated copy of the original Skill, identical except that the frontmatter `metadata` block (agentskills.io/OpenClaw fields) is omitted because the OpenAI portal rejects it
 - `avoid-ai-writing-router`: orchestration for mixed and multi-stage requests
 - `ai-writing-detector`: detect-only workflow with the bundled deterministic detector
 - `voice-preserving-rewriter`: returned-text rewrite owner

--- a/scripts/sync-plugin-skill.sh
+++ b/scripts/sync-plugin-skill.sh
@@ -42,7 +42,18 @@ mkdir -p \
   "$(dirname "$verifier_validate_dest")"
 
 cp "$src" "$claude_dest"
-cp "$src" "$openai_dest"
+# The OpenAI plugin portal rejects a `metadata` key in SKILL.md frontmatter
+# ("Skill interface settings must use agents/openai.yaml"); that block carries
+# agentskills.io/OpenClaw fields, so the OpenAI copy omits it and everything
+# else stays byte-identical. validate-openai-plugin.py applies the same
+# transform before its drift check.
+awk '
+  NR == 1 && $0 == "---" { fm = 1; print; next }
+  fm && $0 == "---" { fm = 0; print; next }
+  fm && /^metadata:/ { skip = 1; next }
+  fm && skip && /^[[:blank:]]/ { next }
+  { skip = 0; print }
+' "$src" > "$openai_dest"
 cp "$patterns_src" "$canonical_detector_dest/patterns.js"
 cp "$validate_src" "$canonical_detector_dest/validate.js"
 cp "$categories_src" "$canonical_detector_dest/CATEGORIES.md"

--- a/scripts/sync-plugin-skill.sh
+++ b/scripts/sync-plugin-skill.sh
@@ -44,16 +44,11 @@ mkdir -p \
 cp "$src" "$claude_dest"
 # The OpenAI plugin portal rejects a `metadata` key in SKILL.md frontmatter
 # ("Skill interface settings must use agents/openai.yaml"); that block carries
-# agentskills.io/OpenClaw fields, so the OpenAI copy omits it and everything
-# else stays byte-identical. validate-openai-plugin.py applies the same
-# transform before its drift check.
-awk '
-  NR == 1 && $0 == "---" { fm = 1; print; next }
-  fm && $0 == "---" { fm = 0; print; next }
-  fm && /^metadata:/ { skip = 1; next }
-  fm && skip && /^[[:blank:]]/ { next }
-  { skip = 0; print }
-' "$src" > "$openai_dest"
+# agentskills.io/OpenClaw fields, so the OpenAI copy omits it and every other
+# byte stays identical. The transform lives in validate-openai-plugin.py so the
+# sync and the drift check cannot diverge.
+python_bin="$(command -v python3 || command -v python)"
+"$python_bin" "$repo_root/scripts/validate-openai-plugin.py" --strip-frontmatter-metadata "$src" > "$openai_dest"
 cp "$patterns_src" "$canonical_detector_dest/patterns.js"
 cp "$validate_src" "$canonical_detector_dest/validate.js"
 cp "$categories_src" "$canonical_detector_dest/CATEGORIES.md"

--- a/scripts/validate-openai-plugin.py
+++ b/scripts/validate-openai-plugin.py
@@ -33,6 +33,34 @@ def parse_frontmatter(path: Path):
         meta[key.strip()] = value.strip().strip('"').strip("'")
     return meta, match.group(2).strip()
 
+def strip_frontmatter_metadata(text: str) -> str:
+    """Drop the top-level `metadata` block from SKILL.md frontmatter.
+
+    Mirrors scripts/sync-plugin-skill.sh: the OpenAI plugin portal rejects
+    `metadata` in SKILL.md ("Skill interface settings must use
+    agents/openai.yaml"), so the OpenAI copy of the canonical skill omits it.
+    """
+    match = FRONTMATTER.match(text)
+    if not match:
+        return text
+    kept, skip = [], False
+    for line in match.group(1).split("\n"):
+        if line.startswith("metadata:"):
+            skip = True
+            continue
+        if skip and line[:1] in (" ", "\t"):
+            continue
+        skip = False
+        kept.append(line)
+    start, end = match.start(1), match.end(1)
+    return text[:start] + "\n".join(kept) + text[end:]
+
+
+def frontmatter_has_metadata(path: Path) -> bool:
+    match = FRONTMATTER.match(path.read_text(encoding="utf-8"))
+    return bool(match) and any(line.startswith("metadata:") for line in match.group(1).split("\n"))
+
+
 def safe_rel(value: str) -> bool:
     if not value or value != value.strip() or any(ord(ch) < 32 for ch in value):
         return False
@@ -462,6 +490,11 @@ def validate(root: Path):
         name, desc = meta.get("name", ""), meta.get("description", "")
         if not name or not desc or not body:
             errors.append(f"{skill_path}: name, description, and body are required")
+        if frontmatter_has_metadata(skill_path):
+            errors.append(
+                f"{skill_path}: `metadata` in SKILL.md frontmatter is rejected by the OpenAI plugin portal; "
+                "put interface settings under `interface` in agents/openai.yaml"
+            )
         if name:
             if name in names:
                 errors.append(f"duplicate skill name {name!r}: {names[name]} and {skill_dir.name}")
@@ -476,8 +509,8 @@ def validate(root: Path):
     if canonical.is_file():
         if not openai_copy.is_file():
             errors.append("skills/avoid-ai-writing/SKILL.md missing; cannot check drift from root SKILL.md")
-        elif canonical.read_bytes() != openai_copy.read_bytes():
-            errors.append("skills/avoid-ai-writing/SKILL.md drifted from root SKILL.md")
+        elif strip_frontmatter_metadata(canonical.read_text(encoding="utf-8")) != openai_copy.read_text(encoding="utf-8"):
+            errors.append("skills/avoid-ai-writing/SKILL.md drifted from root SKILL.md (expected: root minus the frontmatter `metadata` block)")
         meta, _ = parse_frontmatter(canonical)
         if meta.get("version") != version:
             errors.append(f"canonical SKILL.md version {meta.get('version')!r} does not match manifest {version!r}")

--- a/scripts/validate-openai-plugin.py
+++ b/scripts/validate-openai-plugin.py
@@ -12,6 +12,9 @@ import xml.etree.ElementTree as ET
 
 SEMVER = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
 FRONTMATTER = re.compile(r"\A---\s*\n(.*?)\n---\s*\n(.*)\Z", re.S)
+# The top-level `metadata` key only: `metadata:` at column 0 followed by
+# whitespace or end of line, so `metadata:extra:` (a different plain key) is kept.
+METADATA_KEY = re.compile(r"metadata:(?:\s|$)")
 TOP_LEVEL_INCLUDE_FILES = ("OPENAI_PLUGIN.md", "NOTICE.md", "PRIVACY.md", "TERMS.md", "SUPPORT.md", "LICENSE")
 CANONICAL_PROJECT_URL = "https://github.com/conorbronsdon/avoid-ai-writing"
 MAX_SVG_BYTES = 256 * 1024
@@ -49,10 +52,10 @@ def strip_frontmatter_metadata(text: str) -> str:
     inner = match.group(1)
     kept, skip = [], False
     for line in inner.splitlines(keepends=True):
-        if line.startswith("metadata:"):
+        if METADATA_KEY.match(line):
             skip = True
             continue
-        if skip and (line[:1] in (" ", "\t") or line.strip() == ""):
+        if skip and (line[:1] in (" ", "\t", "#") or line.strip() == ""):
             continue
         skip = False
         kept.append(line)
@@ -71,7 +74,7 @@ def strip_frontmatter_metadata(text: str) -> str:
 
 def frontmatter_has_metadata(path: Path) -> bool:
     match = FRONTMATTER.match(path.read_text(encoding="utf-8"))
-    return bool(match) and any(line.startswith("metadata:") for line in match.group(1).split("\n"))
+    return bool(match) and any(METADATA_KEY.match(line) for line in match.group(1).split("\n"))
 
 
 def safe_rel(value: str) -> bool:

--- a/scripts/validate-openai-plugin.py
+++ b/scripts/validate-openai-plugin.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import sys
 from pathlib import Path, PurePosixPath
 import re
 import subprocess
@@ -34,26 +35,38 @@ def parse_frontmatter(path: Path):
     return meta, match.group(2).strip()
 
 def strip_frontmatter_metadata(text: str) -> str:
-    """Drop the top-level `metadata` block from SKILL.md frontmatter.
+    """Drop the top-level `metadata` block from SKILL.md frontmatter, byte-exact otherwise.
 
-    Mirrors scripts/sync-plugin-skill.sh: the OpenAI plugin portal rejects
-    `metadata` in SKILL.md ("Skill interface settings must use
-    agents/openai.yaml"), so the OpenAI copy of the canonical skill omits it.
+    Mirrors the OpenAI copy written by scripts/sync-plugin-skill.sh (which calls
+    this function): the OpenAI plugin portal rejects `metadata` in SKILL.md
+    ("Skill interface settings must use agents/openai.yaml"). Line endings are
+    preserved; a blank line inside the metadata block does not end it; text
+    without a well-formed frontmatter is returned unchanged.
     """
     match = FRONTMATTER.match(text)
     if not match:
         return text
+    inner = match.group(1)
     kept, skip = [], False
-    for line in match.group(1).split("\n"):
+    for line in inner.splitlines(keepends=True):
         if line.startswith("metadata:"):
             skip = True
             continue
-        if skip and line[:1] in (" ", "\t"):
+        if skip and (line[:1] in (" ", "\t") or line.strip() == ""):
             continue
         skip = False
         kept.append(line)
+    joined = "".join(kept)
+    if skip and joined:
+        # The block ran to the end of the frontmatter, so the last kept line
+        # still carries the terminator that used to separate it from the block.
+        # Drop exactly that terminator and keep the delimiter's own line ending
+        # (the regex leaves a trailing "\r" inside the group for CRLF files).
+        joined = joined[:-2] if joined.endswith("\r\n") else joined[:-1]
+        if inner.endswith("\r"):
+            joined += "\r"
     start, end = match.start(1), match.end(1)
-    return text[:start] + "\n".join(kept) + text[end:]
+    return text[:start] + joined + text[end:]
 
 
 def frontmatter_has_metadata(path: Path) -> bool:
@@ -509,7 +522,7 @@ def validate(root: Path):
     if canonical.is_file():
         if not openai_copy.is_file():
             errors.append("skills/avoid-ai-writing/SKILL.md missing; cannot check drift from root SKILL.md")
-        elif strip_frontmatter_metadata(canonical.read_text(encoding="utf-8")) != openai_copy.read_text(encoding="utf-8"):
+        elif strip_frontmatter_metadata(canonical.read_bytes().decode("utf-8")).encode("utf-8") != openai_copy.read_bytes():
             errors.append("skills/avoid-ai-writing/SKILL.md drifted from root SKILL.md (expected: root minus the frontmatter `metadata` block)")
         meta, _ = parse_frontmatter(canonical)
         if meta.get("version") != version:
@@ -658,7 +671,16 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("root", nargs="?", default=".")
     parser.add_argument("--json", action="store_true")
+    parser.add_argument(
+        "--strip-frontmatter-metadata",
+        metavar="SKILL_MD",
+        help="print SKILL_MD with the frontmatter `metadata` block removed (used by sync-plugin-skill.sh) and exit",
+    )
     args = parser.parse_args()
+    if args.strip_frontmatter_metadata:
+        data = Path(args.strip_frontmatter_metadata).read_bytes().decode("utf-8")
+        sys.stdout.buffer.write(strip_frontmatter_metadata(data).encode("utf-8"))
+        return 0
     errors, warnings, summary = validate(Path(args.root).resolve())
     if args.json:
         print(json.dumps(summary, indent=2))

--- a/scripts/validate-openai-plugin.test.py
+++ b/scripts/validate-openai-plugin.test.py
@@ -376,6 +376,24 @@ assert "metadata:" not in STRIPPED_HEAD
 assert "\nversion:" in STRIPPED_HEAD and "\nlicense:" in STRIPPED_HEAD and "\ncompatibility:" in STRIPPED_HEAD
 assert STRIPPED_BODY == ROOT_BODY, "body must be untouched"
 assert MODULE.strip_frontmatter_metadata("no frontmatter\nmetadata:\n  x: y\n") == "no frontmatter\nmetadata:\n  x: y\n"
+STRIP = MODULE.strip_frontmatter_metadata
+# metadata not last; a blank line inside the block; CRLF preserved; no trailing newline preserved
+assert STRIP("---\nname: x\nmetadata:\n  author: y\n\n  repository: z\nlicense: MIT\n---\nBody\n") == "---\nname: x\nlicense: MIT\n---\nBody\n"
+assert STRIP("---\r\nname: x\r\nmetadata:\r\n  author: y\r\n---\r\nBody\r\n") == "---\r\nname: x\r\n---\r\nBody\r\n"
+assert STRIP("---\nname: x\nmetadata:\n  author: y\n---\nBody") == "---\nname: x\n---\nBody"
+assert STRIP("---\nname: x\nmetadata:\n  author: y\n---\nmetadata:\n  in: body\n") == "---\nname: x\n---\nmetadata:\n  in: body\n"
+# blank line before the closing delimiter survives; CRLF with metadata not last
+assert STRIP("---\nname: x\nmetadata:\n  a: b\nlicense: MIT\n\n---\nBody\n") == "---\nname: x\nlicense: MIT\n\n---\nBody\n"
+assert STRIP("---\r\nname: x\r\nmetadata:\r\n  a: b\r\nlicense: MIT\r\n---\r\nBody\r\n") == "---\r\nname: x\r\nlicense: MIT\r\n---\r\nBody\r\n"
+# missing closing delimiter: not a frontmatter, untouched
+assert STRIP("---\nname: x\nmetadata:\n  author: y\nBody\n") == "---\nname: x\nmetadata:\n  author: y\nBody\n"
+# the CLI path sync-plugin-skill.sh uses must be byte-exact with the function
+import subprocess
+cli = subprocess.run(
+    [sys.executable, str(MODULE_PATH), "--strip-frontmatter-metadata", str(REPO_ROOT / "SKILL.md")],
+    capture_output=True, check=True,
+)
+assert cli.stdout == STRIPPED.encode("utf-8"), "CLI output differs from strip_frontmatter_metadata"
 assert STRIPPED == (REPO_ROOT / "skills" / "avoid-ai-writing" / "SKILL.md").read_text(encoding="utf-8"), (
     "run bash scripts/sync-plugin-skill.sh; the OpenAI copy is out of date"
 )

--- a/scripts/validate-openai-plugin.test.py
+++ b/scripts/validate-openai-plugin.test.py
@@ -365,4 +365,42 @@ with tempfile.TemporaryDirectory() as temp_dir:
         errors, _, _ = MODULE.validate(root)
         assert any("symlink not allowed in plugin surface: LICENSE" in error for error in errors)
 
+# The OpenAI copy of the canonical skill must drop the frontmatter `metadata`
+# block (the portal rejects it) and otherwise match root SKILL.md exactly.
+ROOT_SKILL = (REPO_ROOT / "SKILL.md").read_text(encoding="utf-8")
+assert "\nmetadata:\n" in ROOT_SKILL, "fixture assumption: root SKILL.md carries a metadata block"
+STRIPPED = MODULE.strip_frontmatter_metadata(ROOT_SKILL)
+ROOT_HEAD, ROOT_BODY = ROOT_SKILL.split("\n---\n", 1)
+STRIPPED_HEAD, STRIPPED_BODY = STRIPPED.split("\n---\n", 1)
+assert "metadata:" not in STRIPPED_HEAD
+assert "\nversion:" in STRIPPED_HEAD and "\nlicense:" in STRIPPED_HEAD and "\ncompatibility:" in STRIPPED_HEAD
+assert STRIPPED_BODY == ROOT_BODY, "body must be untouched"
+assert MODULE.strip_frontmatter_metadata("no frontmatter\nmetadata:\n  x: y\n") == "no frontmatter\nmetadata:\n  x: y\n"
+assert STRIPPED == (REPO_ROOT / "skills" / "avoid-ai-writing" / "SKILL.md").read_text(encoding="utf-8"), (
+    "run bash scripts/sync-plugin-skill.sh; the OpenAI copy is out of date"
+)
+
+with tempfile.TemporaryDirectory() as temp_dir:
+    root = Path(temp_dir)
+    make_valid_plugin_root(root)
+    errors, _, _ = MODULE.validate(root)
+    assert errors == [], errors
+    # red control 1: a byte-identical copy (metadata kept) is rejected on both rules
+    shutil.copy2(root / "SKILL.md", root / "skills" / "avoid-ai-writing" / "SKILL.md")
+    errors, _, _ = MODULE.validate(root)
+    assert any("`metadata` in SKILL.md frontmatter is rejected" in error for error in errors), errors
+    assert any("drifted from root SKILL.md" in error for error in errors), errors
+    # red control 2: a body edit in the copy still counts as drift
+    copy = root / "skills" / "avoid-ai-writing" / "SKILL.md"
+    copy.write_text(STRIPPED.replace("\n---\n", "\n---\n\nextra line\n", 1), encoding="utf-8")
+    errors, _, _ = MODULE.validate(root)
+    assert any("drifted from root SKILL.md" in error for error in errors), errors
+    assert not any("`metadata` in SKILL.md" in error for error in errors), errors
+    # red control 3: metadata in any other skill is rejected too
+    copy.write_text(STRIPPED, encoding="utf-8")
+    other = root / "skills" / "ai-writing-detector" / "SKILL.md"
+    other.write_text(other.read_text(encoding="utf-8").replace("\n---\n", "\nmetadata:\n  author: x\n---\n", 1), encoding="utf-8")
+    errors, _, _ = MODULE.validate(root)
+    assert any("ai-writing-detector" in error and "`metadata` in SKILL.md" in error for error in errors), errors
+
 print("all OpenAI plugin validation tests passed")

--- a/scripts/validate-openai-plugin.test.py
+++ b/scripts/validate-openai-plugin.test.py
@@ -385,6 +385,9 @@ assert STRIP("---\nname: x\nmetadata:\n  author: y\n---\nmetadata:\n  in: body\n
 # blank line before the closing delimiter survives; CRLF with metadata not last
 assert STRIP("---\nname: x\nmetadata:\n  a: b\nlicense: MIT\n\n---\nBody\n") == "---\nname: x\nlicense: MIT\n\n---\nBody\n"
 assert STRIP("---\r\nname: x\r\nmetadata:\r\n  a: b\r\nlicense: MIT\r\n---\r\nBody\r\n") == "---\r\nname: x\r\nlicense: MIT\r\n---\r\nBody\r\n"
+# a column-zero comment inside the block belongs to it; `metadata:extra` is a different key and stays
+assert STRIP("---\nname: x\nmetadata:\n  author: y\n# note\n  repository: z\nlicense: MIT\n---\nBody\n") == "---\nname: x\nlicense: MIT\n---\nBody\n"
+assert STRIP("---\nname: x\nmetadata:extra: keep\n---\nBody\n") == "---\nname: x\nmetadata:extra: keep\n---\nBody\n"
 # missing closing delimiter: not a frontmatter, untouched
 assert STRIP("---\nname: x\nmetadata:\n  author: y\nBody\n") == "---\nname: x\nmetadata:\n  author: y\nBody\n"
 # the CLI path sync-plugin-skill.sh uses must be byte-exact with the function

--- a/skills/avoid-ai-writing/SKILL.md
+++ b/skills/avoid-ai-writing/SKILL.md
@@ -4,13 +4,6 @@ description: Audit and rewrite content to remove AI writing patterns ("AI-isms")
 version: 3.29.0
 license: MIT
 compatibility: Any AI coding assistant that supports agentskills.io SKILL.md format (Claude Code, Cursor, VS Code Copilot, Hermes Agent, OpenHands, etc.) or OpenClaw. No external tools or APIs required.
-metadata:
-  author: Conor Bronsdon
-  repository: https://github.com/conorbronsdon/avoid-ai-writing
-  tags: writing editing voice quality
-  agentskills_spec: "1.0"
-  openclaw:
-    emoji: "✍️"
 ---
 
 # Avoid AI Writing — Audit & Rewrite

--- a/submission/submission-pack.json
+++ b/submission/submission-pack.json
@@ -7,7 +7,7 @@
   },
   "architecture": "skills-only",
   "publicSkills": ["avoid-ai-writing","avoid-ai-writing-router","ai-writing-detector","voice-preserving-rewriter","file-edit-in-place","preservation-verifier","false-positive-reviewer"],
-  "canonicalSkill": {"path":"skills/avoid-ai-writing/SKILL.md","source":"SKILL.md","preservation":"exact generated copy"},
+  "canonicalSkill": {"path":"skills/avoid-ai-writing/SKILL.md","source":"SKILL.md","preservation":"generated copy, identical except the frontmatter metadata block is omitted (OpenAI portal rejects it)"},
   "bundledDeterministicResources": [
     {"path":"skills/ai-writing-detector/scripts/patterns.js","source":"detector/patterns.js","purpose":"detect-only local analysis"},
     {"path":"skills/preservation-verifier/scripts/validate.js","source":"detector/validate.js","purpose":"before/after preservation verification"},


### PR DESCRIPTION
The OpenAI plugin portal rejected our Skills-only ZIP with:

> Skill interface settings must use `agents/openai.yaml` — `skills/avoid-ai-writing/SKILL.md`: `metadata` in `SKILL.md` does not configure the skill interface. Put supported interface settings under `interface` in `agents/openai.yaml`.

The bundled copy was byte-identical to root `SKILL.md`, whose frontmatter carries an agentskills.io/OpenClaw `metadata` block. Those fields have no OpenAI meaning (the interface settings already live in `agents/openai.yaml`), so the OpenAI copy now omits the block and stays identical otherwise.

**Changes**
- `scripts/sync-plugin-skill.sh`: the OpenAI copy is root `SKILL.md` minus the frontmatter `metadata` block (awk over the frontmatter only). The Claude plugin copy is unchanged.
- `scripts/validate-openai-plugin.py`: drift check compares root-minus-metadata to the copy; a `metadata` key in any packaged skill's `SKILL.md` is an error with the portal's wording.
- `scripts/validate-openai-plugin.test.py`: transform tests (body untouched, `version`/`license`/`compatibility` kept, no-frontmatter passthrough, copy in sync) plus three red controls (byte-identical copy fails both rules; body edit still reads as drift; `metadata` in another skill fails).
- `skills/avoid-ai-writing/SKILL.md`: regenerated.

**Verification**
- `python scripts/validate-openai-plugin.test.py` passes; `python scripts/validate-openai-plugin.py .` is OK; `npm test` passes.
- Rebuilt archive (41 entries, sha256 `f1d40874…ad1440`) validates after extraction and was accepted by the portal's upload validation; the submission wizard prefilled the listing from it.

Written with Claude Code as reviewer/implementer; a Codex read-only review of the diff is running and any findings land as follow-up commits before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UaeXzpBoBZKa1dWxVS1bTE
