### PR TITLE
Record the published directory listing and scope the notices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented here.
 
 ### Changed
 
+- **Published in the OpenAI Plugins Directory** as [Avoid AI Writing](https://chatgpt.com/plugins/plugins_6a9b77b18b8881918efa9c1255868164) (version 3.29.0, approved 2026-09-04). The bundled canonical skill now omits the frontmatter `metadata` block, which the portal rejects (#146); TERMS.md and PRIVACY.md state the plugin's scope and data handling in the terms OpenAI's plugin guidelines ask for (#147).
 - **Plugin validation now fails closed on deferred port-integrity gaps.** `agents/openai.yaml` rejects scalar policies and malformed mapping/list lines, SVG assets must have an actual `<svg>` root, and the bundled routing matrix carries a checked graph digest plus generated edge inventory so it cannot silently drift from `skill-graph.json`.
 
 - **README adds a restrained related-work block.** Links to Conor's public

--- a/OPENAI_PLUGIN.md
+++ b/OPENAI_PLUGIN.md
@@ -2,6 +2,8 @@
 
 This repository contains a native ChatGPT and Codex plugin package while keeping the existing Claude plugin and the canonical root `SKILL.md`.
 
+The package is published as [Avoid AI Writing](https://chatgpt.com/plugins/plugins_6a9b77b18b8881918efa9c1255868164) in the OpenAI Plugins Directory (version 3.29.0, approved and published 2026-09-04).
+
 ## Architecture
 
 The public package is skills-only. The separate `avoid-ai-writing-mcp` project remains optional and is not bundled or required.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -6,6 +6,10 @@ The package does not include a developer-hosted server, analytics endpoint, tele
 
 Text supplied to ChatGPT or Codex is processed by the host product under the user's OpenAI account and applicable OpenAI terms and privacy controls. This repository does not add a separate network destination for that text.
 
+The developer receives no user text during plugin operation. Categories of personal data collected by the developer: none. Purposes of use: none. Recipients: none. Retention: none. There is no developer-side account, setting, or deletion request to make, because nothing is stored.
+
+The only data the developer sees is what a person chooses to post in the public GitHub repository, for example an issue or pull request. That content is public, is stored by GitHub under GitHub's terms and retention, and can be edited or deleted by its author through GitHub. Do not include confidential text or personal data in a public issue.
+
 The external `avoid-ai-writing-mcp` project mentioned in the repository documentation is a separate optional installation and is not part of this plugin package. Its behavior and privacy terms should be reviewed separately before use.
 
-Support and issue reports are handled through the public GitHub repository. Do not include confidential text or personal data in a public issue.
+Support and issue reports are handled through the public GitHub repository at https://github.com/conorbronsdon/avoid-ai-writing/issues.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -6,10 +6,8 @@ The package does not include a developer-hosted server, analytics endpoint, tele
 
 Text supplied to ChatGPT or Codex is processed by the host product under the user's OpenAI account and applicable OpenAI terms and privacy controls. This repository does not add a separate network destination for that text.
 
-The developer receives no user text during plugin operation. Categories of personal data collected by the developer: none. Purposes of use: none. Recipients: none. Retention: none. There is no developer-side account, setting, or deletion request to make, because nothing is stored.
+During plugin operation the developer receives no user text and holds no data about users. The developer collects no personal data through the plugin, uses none, shares none with anyone, and retains none, so there is no developer-side account, setting, or deletion request to make.
 
-The only data the developer sees is what a person chooses to post in the public GitHub repository, for example an issue or pull request. That content is public, is stored by GitHub under GitHub's terms and retention, and can be edited or deleted by its author through GitHub. Do not include confidential text or personal data in a public issue.
-
-The external `avoid-ai-writing-mcp` project mentioned in the repository documentation is a separate optional installation and is not part of this plugin package. Its behavior and privacy terms should be reviewed separately before use.
+The only data the developer sees is what a person chooses to post in the public GitHub repository, such as an issue or pull request. That shows the poster's GitHub username and whatever they wrote, it is public, and the developer uses it only to maintain the project. GitHub stores it under GitHub's own terms for as long as the repository exists; the developer keeps no separate copies. A poster can edit their own comments and can ask the maintainer to delete an issue or a comment.
 
 Support and issue reports are handled through the public GitHub repository at https://github.com/conorbronsdon/avoid-ai-writing/issues.

--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ curl -o .agents/skills/avoid-ai-writing/SKILL.md \
 
 ### Native ChatGPT and Codex plugin package
 
+Published in the [OpenAI Plugins Directory](https://chatgpt.com/plugins/plugins_6a9b77b18b8881918efa9c1255868164); install it there for ChatGPT or Codex.
+
 The [plugin package](./OPENAI_PLUGIN.md) keeps the canonical `SKILL.md` as its editorial authority and provides seven focused Skills:
 
 - `avoid-ai-writing` — uses the canonical audit and rewrite instructions

--- a/TERMS.md
+++ b/TERMS.md
@@ -4,7 +4,7 @@ This plugin package and the underlying Avoid AI Writing project are provided und
 
 The plugin identifies writing patterns and can help revise prose. Its scores and flags are not proof of AI authorship and must not be treated as the sole basis for academic, employment, publication, disciplinary, legal, or other consequential decisions.
 
-This is an editorial tool, not an authorship adjudication or eligibility-assessment service. Do not use its output about a person to make decisions with legal or similarly material effects on that person, including academic, employment, disciplinary, or credit decisions. Do not use it for academic dishonesty, and do not present AI-generated output as wholly human-written where that would be deceptive.
+The plugin edits prose. It does not judge who wrote a text or whether a person is eligible for anything. Do not use its output about a person for any purpose that could have a legal or material impact on that person, such as academic, employment, disciplinary, or credit decisions. Do not use it for academic dishonesty, and do not present AI-generated output as human-written.
 
 The plugin is not designed for or marketed to children under 13.
 

--- a/TERMS.md
+++ b/TERMS.md
@@ -4,6 +4,10 @@ This plugin package and the underlying Avoid AI Writing project are provided und
 
 The plugin identifies writing patterns and can help revise prose. Its scores and flags are not proof of AI authorship and must not be treated as the sole basis for academic, employment, publication, disciplinary, legal, or other consequential decisions.
 
+This is an editorial tool, not an authorship adjudication or eligibility-assessment service. Do not use its output about a person to make decisions with legal or similarly material effects on that person, including academic, employment, disciplinary, or credit decisions. Do not use it for academic dishonesty, and do not present AI-generated output as wholly human-written where that would be deceptive.
+
+The plugin is not designed for or marketed to children under 13.
+
 Users remain responsible for reviewing rewritten content, verifying factual accuracy, respecting third-party rights, and deciding whether an edit is appropriate for the destination.
 
 The software is provided without warranty, subject to the MIT License.

--- a/submission/listing.json
+++ b/submission/listing.json
@@ -39,7 +39,8 @@
     "packagePublisher": "Conor Bronsdon",
     "originalProjectAuthor": "Conor Bronsdon",
     "packagingContributor": "Mamdouh Aboammar",
-    "openAIVerifiedDeveloperStatus": "must be confirmed in the OpenAI submission portal"
+    "openAIVerifiedDeveloperStatus": "verified individual identity, confirmed in the portal 2026-09-04"
   },
-  "listingStatus": "listing_ready_except_platform_identity_confirmation"
+  "listingStatus": "published_2026-09-04",
+  "directoryUrl": "https://chatgpt.com/plugins/plugins_6a9b77b18b8881918efa9c1255868164"
 }

--- a/submission/submission-pack.json
+++ b/submission/submission-pack.json
@@ -33,10 +33,7 @@
     "Fresh-install smoke test in Codex",
     "Upload the exact final ZIP and rerun portal validation"
   ],
-  "state": "not_ready",
-  "blockers": [
-    "OpenAI verified developer identity is not available from repository metadata",
-    "Fresh ChatGPT and Codex install smoke tests are host-side checks",
-    "CI validation and deterministic archive hash must be observed for the exact PR commit"
-  ]
+  "state": "published",
+  "published": {"date":"2026-09-04","pluginId":"plugins_6a9b77b18b8881918efa9c1255868164","directoryUrl":"https://chatgpt.com/plugins/plugins_6a9b77b18b8881918efa9c1255868164","version":"3.29.0","archiveSha256":"f1d4087433d7270d0f94fdb3c592df0a0dc87c15cafa2cd747e12b750fad1440","note":"Archive built from PR #146 before its second commit; differs from main only in the exact-copy wording of NOTICE.md and OPENAI_PLUGIN.md. All seven skill scans passed."},
+  "blockers": []
 }


### PR DESCRIPTION
The plugin was approved and published in the OpenAI Plugins Directory on 2026-09-04: https://chatgpt.com/plugins/plugins_6a9b77b18b8881918efa9c1255868164 (version 3.29.0).

- **TERMS.md**: the plugin edits prose and does not judge authorship or eligibility; no use of person-related output for any purpose with legal or material impact (as broad as OpenAI's consumer Terms); no academic dishonesty or presenting AI output as human-written; not for under-13s.
- **PRIVACY.md**: the disclosures OpenAI's plugin guidelines list, in prose: no developer-side collection, use, sharing, or retention during plugin operation; public GitHub issues described honestly (username and content, used only to maintain the project, stored by GitHub, edit and deletion-request controls).
- **README / OPENAI_PLUGIN.md / CHANGELOG**: link the directory listing.
- **submission/listing.json, submission-pack.json**: state `published`, plugin id, uploaded archive hash, blockers cleared.

Docs and records only; `validate-openai-plugin.py` and `npm test` pass; both notices pass `check-style.js --config technical` (0 hard, 0 advisory). Two Codex read-only reviews of the wording, second pass applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UaeXzpBoBZKa1dWxVS1bTE