### PR TITLE
docs: add a maintainer follow invitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- 2026-09-05: Add a GitHub follow invitation to the README's maintainer section.
+
 All notable changes to this project are documented here.
 
 ---

--- a/README.md
+++ b/README.md
@@ -453,6 +453,8 @@ behind that line is public.
 I run agents against my own email, money, and publishing, so I build the
 guardrails first.
 
+[Follow me on GitHub](https://github.com/conorbronsdon) for new tools and practical examples from maintaining them.
+
 - [What I'm building](https://conorbronsdon.com/builds/?utm_source=github&utm_medium=referral&utm_campaign=repo-readme&utm_content=avoid-ai-writing) — public projects across agent skills, MCP servers, creator tools, and Mojo.
 - [Chain of Thought](https://chainofthought.show/?utm_source=github&utm_medium=referral&utm_campaign=repo-readme&utm_content=avoid-ai-writing) — conversations with the people shipping AI systems.
 - [repo-audit](https://github.com/conorbronsdon/repo-audit) — checks whether repository claims are enforced, advisory, or guidance.


### PR DESCRIPTION
Adds one GitHub profile link in the existing More from me section so readers can follow future tools and examples. Includes a dated changelog entry. Validation: npm test passed. Exact commit 962894479586fa6b993907bcbcc25591adf1bde9 received paid opencode-go/glm-5.3 and free opencode/muse-spark-1.3-contributor-free reviews, both PASS; paid Go substitutes for the confirmed Claude quota failure. Actual URL and placement verified locally.