### PR TITLE
Preserve paired prose quotes around bare URLs

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "avoid-ai-writing",
-  "version": "3.33.0",
+  "version": "3.33.1",
   "description": "Audit AI-writing patterns, rewrite text while preserving voice and facts, edit files carefully, and verify that protected content survives the rewrite.",
   "author": {
     "name": "Conor Bronsdon",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- 2026-09-06: Keep paired prose quotes around bare URLs visible to quote normalization even when the URL contains an unmatched opening parenthesis. Preserve internal URL apostrophes and explicit Markdown link destinations.
 - 2026-09-05: Add a GitHub follow invitation to the README's maintainer section.
 
 All notable changes to this project are documented here.

--- a/SKILL.full.md
+++ b/SKILL.full.md
@@ -1,7 +1,7 @@
 ---
 name: avoid-ai-writing
 description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Use this skill when asked to "remove AI-isms," "clean up AI writing," "edit writing for AI patterns," "audit writing for AI tells," or "make this sound less like AI." Supports a detect-only mode, an edit-in-place mode for files, an optional voice profile (casual / professional / technical / warm / blunt), and an iterate-to-convergence pass.
-version: 3.33.0
+version: 3.33.1
 license: MIT
 compatibility: Any AI coding assistant that supports agentskills.io SKILL.md format (Claude Code, Cursor, VS Code Copilot, Hermes Agent, OpenHands, etc.) or OpenClaw. No external tools or APIs required.
 metadata:

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: avoid-ai-writing
 description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Use this skill when asked to "remove AI-isms," "clean up AI writing," "edit writing for AI patterns," "audit writing for AI tells," or "make this sound less like AI." Supports a detect-only mode, an edit-in-place mode for files, an optional voice profile (casual / professional / technical / warm / blunt), and an iterate-to-convergence pass.
-version: 3.33.0
+version: 3.33.1
 license: MIT
 compatibility: Any AI coding assistant that supports agentskills.io SKILL.md format (Claude Code, Cursor, VS Code Copilot, Hermes Agent, OpenHands, etc.) or OpenClaw. No external tools or APIs required.
 metadata:

--- a/cursor-rules/avoid-ai-writing.mdc
+++ b/cursor-rules/avoid-ai-writing.mdc
@@ -1,5 +1,5 @@
 ---
-description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Activate whenever editing prose-heavy files (Markdown, documentation, blog posts, READMEs, release notes, emails). Cursor port of the avoid-ai-writing skill v3.33.0. See https://github.com/conorbronsdon/avoid-ai-writing.
+description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Activate whenever editing prose-heavy files (Markdown, documentation, blog posts, READMEs, release notes, emails). Cursor port of the avoid-ai-writing skill v3.33.1. See https://github.com/conorbronsdon/avoid-ai-writing.
 globs: ["**/*.md", "**/*.mdx", "**/*.txt", "**/*.rst", "**/*.adoc"]
 alwaysApply: false
 ---

--- a/dist/avoid-ai-writing.md
+++ b/dist/avoid-ai-writing.md
@@ -1,7 +1,7 @@
 ---
 name: avoid-ai-writing
 description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Use this skill when asked to "remove AI-isms," "clean up AI writing," "edit writing for AI patterns," "audit writing for AI tells," or "make this sound less like AI." Supports a detect-only mode, an edit-in-place mode for files, an optional voice profile (casual / professional / technical / warm / blunt), and an iterate-to-convergence pass.
-version: 3.33.0
+version: 3.33.1
 license: MIT
 compatibility: Any AI coding assistant that supports agentskills.io SKILL.md format (Claude Code, Cursor, VS Code Copilot, Hermes Agent, OpenHands, etc.) or OpenClaw. No external tools or APIs required.
 metadata:

--- a/examples/README.md
+++ b/examples/README.md
@@ -110,3 +110,9 @@ verbatim. Dashes and heading case stay as written. This pass does not claim guid
 compliance. Curly education
 uses neighboring characters, so leading elisions such as `'twas` and `rock 'n' roll` need
 review. Straight marks after digits follow the checker's feet/inch carve-out.
+
+For a bare URL immediately surrounded by single quotes, a closing quote followed
+only by terminal punctuation ends the URL even if its parentheses are unbalanced.
+Internal apostrophes such as `O'Reilly` remain part of the URL. If a URL literally
+ends in an apostrophe or has ambiguous punctuation, use an explicit Markdown link
+or `<https://example.com/...>` autolink to keep its destination unchanged.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avoid-ai-writing-detector",
-  "version": "3.33.0",
+  "version": "3.33.1",
   "description": "Deterministic detection engine for the Avoid AI Writing skill — pattern + stylometric analysis of AI-generated text.",
   "license": "MIT",
   "repository": {

--- a/plugins/avoid-ai-writing/.claude-plugin/plugin.json
+++ b/plugins/avoid-ai-writing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "avoid-ai-writing",
   "description": "Audit & rewrite content to remove AI writing patterns (\"AI-isms\"). Supports detect-only and edit-in-place modes, voice profiles, and iterate-to-convergence.",
-  "version": "3.33.0",
+  "version": "3.33.1",
   "author": {
     "name": "Conor Bronsdon"
   },

--- a/plugins/avoid-ai-writing/skills/avoid-ai-writing/SKILL.md
+++ b/plugins/avoid-ai-writing/skills/avoid-ai-writing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: avoid-ai-writing
 description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Use this skill when asked to "remove AI-isms," "clean up AI writing," "edit writing for AI patterns," "audit writing for AI tells," or "make this sound less like AI." Supports a detect-only mode, an edit-in-place mode for files, an optional voice profile (casual / professional / technical / warm / blunt), and an iterate-to-convergence pass.
-version: 3.33.0
+version: 3.33.1
 license: MIT
 compatibility: Any AI coding assistant that supports agentskills.io SKILL.md format (Claude Code, Cursor, VS Code Copilot, Hermes Agent, OpenHands, etc.) or OpenClaw. No external tools or APIs required.
 metadata:

--- a/plugins/avoid-ai-writing/skills/avoid-ai-writing/examples/README.md
+++ b/plugins/avoid-ai-writing/skills/avoid-ai-writing/examples/README.md
@@ -110,3 +110,9 @@ verbatim. Dashes and heading case stay as written. This pass does not claim guid
 compliance. Curly education
 uses neighboring characters, so leading elisions such as `'twas` and `rock 'n' roll` need
 review. Straight marks after digits follow the checker's feet/inch carve-out.
+
+For a bare URL immediately surrounded by single quotes, a closing quote followed
+only by terminal punctuation ends the URL even if its parentheses are unbalanced.
+Internal apostrophes such as `O'Reilly` remain part of the URL. If a URL literally
+ends in an apostrophe or has ambiguous punctuation, use an explicit Markdown link
+or `<https://example.com/...>` autolink to keep its destination unchanged.

--- a/plugins/avoid-ai-writing/skills/avoid-ai-writing/scripts/markdown-prose.js
+++ b/plugins/avoid-ai-writing/skills/avoid-ai-writing/scripts/markdown-prose.js
@@ -253,7 +253,13 @@ function markdownProse(text) {
     const url = m[0];
     let end = url.length;
     let surroundingQuote = /[‘']/.test(s[m.index - 1] || '');
-    let extra = (url.match(/\)/g) || []).length - (url.match(/\(/g) || []).length;
+    // An explicit prose quote wins over URL parenthesis balancing when its
+    // closing mark is followed only by terminal punctuation. Otherwise an
+    // unmatched URL '(' can consume the prose ')' and hide the closing quote.
+    const quotedEnd = surroundingQuote && /[’'][).,;:!?]*$/.exec(url);
+    if (quotedEnd) end = quotedEnd.index + 1;
+    const bounded = url.slice(0, end);
+    let extra = (bounded.match(/\)/g) || []).length - (bounded.match(/\(/g) || []).length;
     // Peel adjacent prose delimiters in any order. Each iteration removes one
     // character, retaining balanced URL parentheses and internal apostrophes.
     while (end > 0) {

--- a/scripts/markdown-prose.js
+++ b/scripts/markdown-prose.js
@@ -253,7 +253,13 @@ function markdownProse(text) {
     const url = m[0];
     let end = url.length;
     let surroundingQuote = /[‘']/.test(s[m.index - 1] || '');
-    let extra = (url.match(/\)/g) || []).length - (url.match(/\(/g) || []).length;
+    // An explicit prose quote wins over URL parenthesis balancing when its
+    // closing mark is followed only by terminal punctuation. Otherwise an
+    // unmatched URL '(' can consume the prose ')' and hide the closing quote.
+    const quotedEnd = surroundingQuote && /[’'][).,;:!?]*$/.exec(url);
+    if (quotedEnd) end = quotedEnd.index + 1;
+    const bounded = url.slice(0, end);
+    let extra = (bounded.match(/\)/g) || []).length - (bounded.match(/\(/g) || []).length;
     // Peel adjacent prose delimiters in any order. Each iteration removes one
     // character, retaining balanced URL parentheses and internal apostrophes.
     while (end > 0) {

--- a/scripts/normalize-quotes.test.js
+++ b/scripts/normalize-quotes.test.js
@@ -293,4 +293,26 @@ t('inline destinations require a matching unescaped link-text opener in the same
   }
 });
 
+t('explicit quotes bound bare URLs even when URL parentheses are unmatched', () => {
+  for (const suffix of ["').", "').,", "');", "'!", "'"] ) {
+    const source = "(see 'https://example.com/(unclosed" + suffix;
+    const expected = source.replace("'https", '\u2018https').replace(/'(?=[).,;!]*$)/, '\u2019');
+    assert.strictEqual(curly(source), expected);
+    assert.strictEqual(normalize(expected, 'straight'), source);
+    assert.strictEqual(curly(expected), expected);
+    assert.deepStrictEqual(check(expected, { quotes: 'curly' }).hard, []);
+    assert.ok(check(source, { quotes: 'curly' }).hard.length);
+  }
+  for (const url of ["https://example.com/O'Reilly", "https://example.com/(O'Reilly)", "https://example.com/(unclosed/O'Reilly"]) {
+    const source = "(see '" + url + "').";
+    const expected = '(see \u2018' + url + '\u2019).';
+    assert.strictEqual(curly(source), expected);
+    assert.strictEqual(normalize(expected, 'straight'), source);
+    assert.deepStrictEqual(check(expected, { quotes: 'curly' }).hard, []);
+  }
+  for (const source of ["https://example.com/(O'Reilly", "<https://example.com/(O'Reilly>", "[docs](<https://example.com/(O'Reilly> \"title\")"]) {
+    assert.strictEqual(curly(source + ' "live"'), source + ' \u201clive\u201d');
+  }
+});
+
 console.log(`\nnormalize-quotes: ${passed} passed.`);

--- a/skills/avoid-ai-writing/SKILL.md
+++ b/skills/avoid-ai-writing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: avoid-ai-writing
 description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Use this skill when asked to "remove AI-isms," "clean up AI writing," "edit writing for AI patterns," "audit writing for AI tells," or "make this sound less like AI." Supports a detect-only mode, an edit-in-place mode for files, an optional voice profile (casual / professional / technical / warm / blunt), and an iterate-to-convergence pass.
-version: 3.33.0
+version: 3.33.1
 license: MIT
 compatibility: Any AI coding assistant that supports agentskills.io SKILL.md format (Claude Code, Cursor, VS Code Copilot, Hermes Agent, OpenHands, etc.) or OpenClaw. No external tools or APIs required.
 ---

--- a/skills/avoid-ai-writing/examples/README.md
+++ b/skills/avoid-ai-writing/examples/README.md
@@ -110,3 +110,9 @@ verbatim. Dashes and heading case stay as written. This pass does not claim guid
 compliance. Curly education
 uses neighboring characters, so leading elisions such as `'twas` and `rock 'n' roll` need
 review. Straight marks after digits follow the checker's feet/inch carve-out.
+
+For a bare URL immediately surrounded by single quotes, a closing quote followed
+only by terminal punctuation ends the URL even if its parentheses are unbalanced.
+Internal apostrophes such as `O'Reilly` remain part of the URL. If a URL literally
+ends in an apostrophe or has ambiguous punctuation, use an explicit Markdown link
+or `<https://example.com/...>` autolink to keep its destination unchanged.

--- a/skills/avoid-ai-writing/scripts/markdown-prose.js
+++ b/skills/avoid-ai-writing/scripts/markdown-prose.js
@@ -253,7 +253,13 @@ function markdownProse(text) {
     const url = m[0];
     let end = url.length;
     let surroundingQuote = /[‘']/.test(s[m.index - 1] || '');
-    let extra = (url.match(/\)/g) || []).length - (url.match(/\(/g) || []).length;
+    // An explicit prose quote wins over URL parenthesis balancing when its
+    // closing mark is followed only by terminal punctuation. Otherwise an
+    // unmatched URL '(' can consume the prose ')' and hide the closing quote.
+    const quotedEnd = surroundingQuote && /[’'][).,;:!?]*$/.exec(url);
+    if (quotedEnd) end = quotedEnd.index + 1;
+    const bounded = url.slice(0, end);
+    let extra = (bounded.match(/\)/g) || []).length - (bounded.match(/\(/g) || []).length;
     // Peel adjacent prose delimiters in any order. Each iteration removes one
     // character, retaining balanced URL parentheses and internal apostrophes.
     while (end > 0) {

--- a/submission/listing.json
+++ b/submission/listing.json
@@ -2,7 +2,7 @@
   "source": {
     "repository": "https://github.com/conorbronsdon/avoid-ai-writing",
     "baseCommit": "d8c235186ff764ac20a0464ca8b1a13993ea37e4",
-    "version": "3.33.0",
+    "version": "3.33.1",
     "architecture": "skills-only"
   },
   "fields": {
@@ -15,7 +15,7 @@
     "supportURL": "https://github.com/conorbronsdon/avoid-ai-writing/issues",
     "privacyPolicyURL": "https://github.com/conorbronsdon/avoid-ai-writing/blob/main/PRIVACY.md",
     "termsOfServiceURL": "https://github.com/conorbronsdon/avoid-ai-writing/blob/main/TERMS.md",
-    "version": "3.33.0",
+    "version": "3.33.1",
     "packageName": "avoid-ai-writing",
     "capabilities": ["AI-pattern audit","Detect-only review","Voice-preserving rewrite","Targeted file editing","Preservation verification","False-positive review","Multi-step writing cleanup"],
     "starterPrompts": [

--- a/submission/submission-pack.json
+++ b/submission/submission-pack.json
@@ -3,7 +3,7 @@
     "repository": "conorbronsdon/avoid-ai-writing",
     "baseRef": "main",
     "baseCommit": "d8c235186ff764ac20a0464ca8b1a13993ea37e4",
-    "canonicalSkillVersion": "3.33.0"
+    "canonicalSkillVersion": "3.33.1"
   },
   "architecture": "skills-only",
   "publicSkills": ["avoid-ai-writing","avoid-ai-writing-router","ai-writing-detector","voice-preserving-rewriter","file-edit-in-place","preservation-verifier","false-positive-reviewer"],


### PR DESCRIPTION
Quote normalization now keeps both prose quotes editable around a bare URL with an unmatched opening parenthesis. For example, `(see 'https://example.com/(unclosed').` converts both surrounding apostrophes to curly quotes. An explicit closing quote followed only by terminal punctuation takes precedence over URL parenthesis balancing.

Internal URL apostrophes, balanced URL parentheses, Markdown destinations and autolinks remain protected. The ambiguity policy is documented, bundled copies are synchronized, and package metadata advances to 3.33.1.

Validation: the new regression fails on the original implementation and passes with the fix; all npm tests (including 54 quote cases), the self-scan gate, OpenAI package validation and PR CI pass. Root also verified four bidirectional controls for double-quoted URLs, literal trailing apostrophes and the documented single-quote ambiguity.

Exact-SHA reviews at `28ba61bc9f680fc367bbb2dcd2d30c78a8e0afb0`: authenticated `claude-sonnet-5` and free `opencode/mimo-v2.5-free`. The free review ran outside the checkout with all tools disabled; raw events show zero tool calls and zero cost. An initial Claude connection failure produced no review; the completed retry is recorded separately. Raw receipts are retained locally.

Finding disposition: both reviewers' double-quote concern is contradicted by the URL regex and direct bidirectional controls. Literal apostrophe ambiguity is explicitly documented and pre-existing; explicit link syntax preserves a literal destination. The three copies are generated package resources with an existing synchronization check, verified identical. No verified blocker remains.

Fixes #150.
