### PR TITLE
Treat em-dash frequency as style-only guidance

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "avoid-ai-writing",
-  "version": "3.33.1",
+  "version": "3.33.2",
   "description": "Audit AI-writing patterns, rewrite text while preserving voice and facts, edit files carefully, and verify that protected content survives the rewrite.",
   "author": {
     "name": "Conor Bronsdon",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- 2026-09-06: Keep em-dash overuse as a P2 writing-quality flag while excluding it from the authorship score, label, probabilities, confidence, and classification (#73). Existing rate thresholds and carve-outs are unchanged. Scores may be lower for text where em-dash overuse previously contributed weight.
 - 2026-09-06: Keep paired prose quotes around bare URLs visible to quote normalization even when the URL contains an unmatched opening parenthesis. Preserve internal URL apostrophes and explicit Markdown link destinations.
 - 2026-09-05: Add a GitHub follow invitation to the README's maintainer section.
 

--- a/SKILL.full.md
+++ b/SKILL.full.md
@@ -1,7 +1,7 @@
 ---
 name: avoid-ai-writing
 description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Use this skill when asked to "remove AI-isms," "clean up AI writing," "edit writing for AI patterns," "audit writing for AI tells," or "make this sound less like AI." Supports a detect-only mode, an edit-in-place mode for files, an optional voice profile (casual / professional / technical / warm / blunt), and an iterate-to-convergence pass.
-version: 3.33.1
+version: 3.33.2
 license: MIT
 compatibility: Any AI coding assistant that supports agentskills.io SKILL.md format (Claude Code, Cursor, VS Code Copilot, Hermes Agent, OpenHands, etc.) or OpenClaw. No external tools or APIs required.
 metadata:
@@ -683,7 +683,6 @@ Not all AI-isms are equal. When doing a quick pass or triaging a large document,
 - Synonym cycling within a paragraph
 - Formulaic openings ("In the rapidly evolving world of...")
 - Bold overuse
-- Em dash frequency (above 1 per 1,000 words)
 - Generic future-narrative closers ("may become one of the most important narratives…")
 - Social endorsement closers ("This one is worth your time:", "thank me later")
 - Lingering-attention claims ("the line I keep coming back to," "I can't stop thinking about this")
@@ -696,6 +695,7 @@ Not all AI-isms are equal. When doing a quick pass or triaging a large document,
 - Tier 3 phrase clustering (≥3 distinct boilerplate phrases in one piece)
 
 ### P2 — Stylistic polish (fix when time allows)
+- Em dash frequency (above 1 per 1,000 words). This is writing-quality guidance, not evidence of machine authorship: usage has varied by model generation and vendor, so do not score or invert it as an authorship signal.
 - Generic conclusions ("The future looks bright")
 - Repeated setup/reversal punchlines when they replace concrete claims (isolated or supported reversals pass)
 - Judgment-only clarity checks: false agency, transformation crutch, ambiguous domain terminology, consequence-free explanations, and repeated empty concessions (apply each entry's pass conditions)

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: avoid-ai-writing
 description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Use this skill when asked to "remove AI-isms," "clean up AI writing," "edit writing for AI patterns," "audit writing for AI tells," or "make this sound less like AI." Supports a detect-only mode, an edit-in-place mode for files, an optional voice profile (casual / professional / technical / warm / blunt), and an iterate-to-convergence pass.
-version: 3.33.1
+version: 3.33.2
 license: MIT
 compatibility: Any AI coding assistant that supports agentskills.io SKILL.md format (Claude Code, Cursor, VS Code Copilot, Hermes Agent, OpenHands, etc.) or OpenClaw. No external tools or APIs required.
 metadata:
@@ -92,7 +92,6 @@ Not all AI-isms are equal. When doing a quick pass or triaging a large document,
 - Synonym cycling within a paragraph
 - Formulaic openings ("In the rapidly evolving world of...")
 - Bold overuse
-- Em dash frequency (above 1 per 1,000 words)
 - Generic future-narrative closers ("may become one of the most important narratives…")
 - Social endorsement closers ("This one is worth your time:", "thank me later")
 - Lingering-attention claims ("the line I keep coming back to," "I can't stop thinking about this")
@@ -105,6 +104,7 @@ Not all AI-isms are equal. When doing a quick pass or triaging a large document,
 - Tier 3 phrase clustering (≥3 distinct boilerplate phrases in one piece)
 
 ### P2 — Stylistic polish (fix when time allows)
+- Em dash frequency (above 1 per 1,000 words). This is writing-quality guidance, not evidence of machine authorship: usage has varied by model generation and vendor, so do not score or invert it as an authorship signal.
 - Generic conclusions ("The future looks bright")
 - Repeated setup/reversal punchlines when they replace concrete claims (isolated or supported reversals pass)
 - Judgment-only clarity checks: false agency, transformation crutch, ambiguous domain terminology, consequence-free explanations, and repeated empty concessions (apply each entry's pass conditions)

--- a/cursor-rules/avoid-ai-writing.mdc
+++ b/cursor-rules/avoid-ai-writing.mdc
@@ -1,5 +1,5 @@
 ---
-description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Activate whenever editing prose-heavy files (Markdown, documentation, blog posts, READMEs, release notes, emails). Cursor port of the avoid-ai-writing skill v3.33.1. See https://github.com/conorbronsdon/avoid-ai-writing.
+description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Activate whenever editing prose-heavy files (Markdown, documentation, blog posts, READMEs, release notes, emails). Cursor port of the avoid-ai-writing skill v3.33.2. See https://github.com/conorbronsdon/avoid-ai-writing.
 globs: ["**/*.md", "**/*.mdx", "**/*.txt", "**/*.rst", "**/*.adoc"]
 alwaysApply: false
 ---
@@ -677,7 +677,6 @@ Not all AI-isms are equal. When doing a quick pass or triaging a large document,
 - Synonym cycling within a paragraph
 - Formulaic openings ("In the rapidly evolving world of...")
 - Bold overuse
-- Em dash frequency (above 1 per 1,000 words)
 - Generic future-narrative closers ("may become one of the most important narratives…")
 - Social endorsement closers ("This one is worth your time:", "thank me later")
 - Lingering-attention claims ("the line I keep coming back to," "I can't stop thinking about this")
@@ -690,6 +689,7 @@ Not all AI-isms are equal. When doing a quick pass or triaging a large document,
 - Tier 3 phrase clustering (≥3 distinct boilerplate phrases in one piece)
 
 ### P2 — Stylistic polish (fix when time allows)
+- Em dash frequency (above 1 per 1,000 words). This is writing-quality guidance, not evidence of machine authorship: usage has varied by model generation and vendor, so do not score or invert it as an authorship signal.
 - Generic conclusions ("The future looks bright")
 - Repeated setup/reversal punchlines when they replace concrete claims (isolated or supported reversals pass)
 - Judgment-only clarity checks: false agency, transformation crutch, ambiguous domain terminology, consequence-free explanations, and repeated empty concessions (apply each entry's pass conditions)

--- a/detector/patterns.js
+++ b/detector/patterns.js
@@ -289,7 +289,9 @@ const AIDetector = (() => {
     'false-concession': 2,
     'rhetorical-question': 2,
     'confidence-calibration': 2,
-    'em-dash': 4,
+    // Writing-quality guidance whose authorship polarity changes across model
+    // generations. Keep the flag visible without moving authorship outputs.
+    'em-dash': 0,
     uniformity: 5,
     formatting: 3,
     'tier3-phrase': 3,

--- a/detector/patterns.js
+++ b/detector/patterns.js
@@ -1390,8 +1390,8 @@ const AIDetector = (() => {
 
     // Context mode gates rules that are noisy in technical writing. Modes:
     //   'general' (default) — full ruleset
-    //   'technical' — skip title-case headers, formulaic openers gated to
-    //                 prose-only structures; lower em-dash + formatting weights
+    //   'technical' — skip title-case headers; individual prose-only rules
+    //                 apply their own technical-context gates
     //   'marketing' — full ruleset + boost on formulaic-opener / future-narrative
     //   'personal'  — full ruleset, normal weights
     // Mode is purely a soft gate; nothing is silently suppressed without

--- a/detector/patterns.test.js
+++ b/detector/patterns.test.js
@@ -477,6 +477,22 @@ test('em-dash detector still fires on mid-sentence splices at the same density',
   assert.ok(emDashIssues.length >= 1, 'prose splices should still flag');
 });
 
+test('#73: em-dash overuse remains a P2 edit without affecting authorship output', () => {
+  const shared = 'The team reviewed the release notes carefully. '.repeat(40);
+  const baseline = AIDetector.analyzeText(`${shared}One point, another point, and a final point.`);
+  const result = AIDetector.analyzeText(`${shared}One point — another point — and a final point.`);
+  const emDashIssues = result.issues.filter((i) => i.type === 'em-dash');
+
+  assert.equal(emDashIssues.length, 1, 'over-limit em dashes must remain visible');
+  assert.equal(AIDetector.SEVERITY_LABELS[emDashIssues[0].severity], 'P2');
+  assert.equal(result.score, baseline.score, 'em-dash style edits must not change the AI score');
+  assert.equal(result.label, baseline.label, 'em-dash style edits must not change the AI label');
+  assert.equal(result.document_classification, baseline.document_classification);
+  assert.equal(result.confidence_category, baseline.confidence_category);
+  assert.deepEqual(result.class_probabilities, baseline.class_probabilities);
+  assert.deepEqual(result.highlight_sentence_for_ai, []);
+});
+
 test('em-dash detector ignores CLI flags like --save-dev', () => {
   const text = 'Run npm install --save-dev and then npm run build --no-verify --silent. Takes about ten seconds on this machine. The package is installed into node_modules directly after the install command completes successfully.';
   const r = AIDetector.analyzeText(text);

--- a/dist/avoid-ai-writing.md
+++ b/dist/avoid-ai-writing.md
@@ -1,7 +1,7 @@
 ---
 name: avoid-ai-writing
 description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Use this skill when asked to "remove AI-isms," "clean up AI writing," "edit writing for AI patterns," "audit writing for AI tells," or "make this sound less like AI." Supports a detect-only mode, an edit-in-place mode for files, an optional voice profile (casual / professional / technical / warm / blunt), and an iterate-to-convergence pass.
-version: 3.33.1
+version: 3.33.2
 license: MIT
 compatibility: Any AI coding assistant that supports agentskills.io SKILL.md format (Claude Code, Cursor, VS Code Copilot, Hermes Agent, OpenHands, etc.) or OpenClaw. No external tools or APIs required.
 metadata:
@@ -685,7 +685,6 @@ Not all AI-isms are equal. When doing a quick pass or triaging a large document,
 - Synonym cycling within a paragraph
 - Formulaic openings ("In the rapidly evolving world of...")
 - Bold overuse
-- Em dash frequency (above 1 per 1,000 words)
 - Generic future-narrative closers ("may become one of the most important narratives…")
 - Social endorsement closers ("This one is worth your time:", "thank me later")
 - Lingering-attention claims ("the line I keep coming back to," "I can't stop thinking about this")
@@ -698,6 +697,7 @@ Not all AI-isms are equal. When doing a quick pass or triaging a large document,
 - Tier 3 phrase clustering (≥3 distinct boilerplate phrases in one piece)
 
 ### P2 — Stylistic polish (fix when time allows)
+- Em dash frequency (above 1 per 1,000 words). This is writing-quality guidance, not evidence of machine authorship: usage has varied by model generation and vendor, so do not score or invert it as an authorship signal.
 - Generic conclusions ("The future looks bright")
 - Repeated setup/reversal punchlines when they replace concrete claims (isolated or supported reversals pass)
 - Judgment-only clarity checks: false agency, transformation crutch, ambiguous domain terminology, consequence-free explanations, and repeated empty concessions (apply each entry's pass conditions)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avoid-ai-writing-detector",
-  "version": "3.33.1",
+  "version": "3.33.2",
   "description": "Deterministic detection engine for the Avoid AI Writing skill — pattern + stylometric analysis of AI-generated text.",
   "license": "MIT",
   "repository": {

--- a/plugins/avoid-ai-writing/.claude-plugin/plugin.json
+++ b/plugins/avoid-ai-writing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "avoid-ai-writing",
   "description": "Audit & rewrite content to remove AI writing patterns (\"AI-isms\"). Supports detect-only and edit-in-place modes, voice profiles, and iterate-to-convergence.",
-  "version": "3.33.1",
+  "version": "3.33.2",
   "author": {
     "name": "Conor Bronsdon"
   },

--- a/plugins/avoid-ai-writing/skills/avoid-ai-writing/SKILL.md
+++ b/plugins/avoid-ai-writing/skills/avoid-ai-writing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: avoid-ai-writing
 description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Use this skill when asked to "remove AI-isms," "clean up AI writing," "edit writing for AI patterns," "audit writing for AI tells," or "make this sound less like AI." Supports a detect-only mode, an edit-in-place mode for files, an optional voice profile (casual / professional / technical / warm / blunt), and an iterate-to-convergence pass.
-version: 3.33.1
+version: 3.33.2
 license: MIT
 compatibility: Any AI coding assistant that supports agentskills.io SKILL.md format (Claude Code, Cursor, VS Code Copilot, Hermes Agent, OpenHands, etc.) or OpenClaw. No external tools or APIs required.
 metadata:
@@ -92,7 +92,6 @@ Not all AI-isms are equal. When doing a quick pass or triaging a large document,
 - Synonym cycling within a paragraph
 - Formulaic openings ("In the rapidly evolving world of...")
 - Bold overuse
-- Em dash frequency (above 1 per 1,000 words)
 - Generic future-narrative closers ("may become one of the most important narratives…")
 - Social endorsement closers ("This one is worth your time:", "thank me later")
 - Lingering-attention claims ("the line I keep coming back to," "I can't stop thinking about this")
@@ -105,6 +104,7 @@ Not all AI-isms are equal. When doing a quick pass or triaging a large document,
 - Tier 3 phrase clustering (≥3 distinct boilerplate phrases in one piece)
 
 ### P2 — Stylistic polish (fix when time allows)
+- Em dash frequency (above 1 per 1,000 words). This is writing-quality guidance, not evidence of machine authorship: usage has varied by model generation and vendor, so do not score or invert it as an authorship signal.
 - Generic conclusions ("The future looks bright")
 - Repeated setup/reversal punchlines when they replace concrete claims (isolated or supported reversals pass)
 - Judgment-only clarity checks: false agency, transformation crutch, ambiguous domain terminology, consequence-free explanations, and repeated empty concessions (apply each entry's pass conditions)

--- a/plugins/avoid-ai-writing/skills/avoid-ai-writing/detector/patterns.js
+++ b/plugins/avoid-ai-writing/skills/avoid-ai-writing/detector/patterns.js
@@ -289,7 +289,9 @@ const AIDetector = (() => {
     'false-concession': 2,
     'rhetorical-question': 2,
     'confidence-calibration': 2,
-    'em-dash': 4,
+    // Writing-quality guidance whose authorship polarity changes across model
+    // generations. Keep the flag visible without moving authorship outputs.
+    'em-dash': 0,
     uniformity: 5,
     formatting: 3,
     'tier3-phrase': 3,

--- a/plugins/avoid-ai-writing/skills/avoid-ai-writing/detector/patterns.js
+++ b/plugins/avoid-ai-writing/skills/avoid-ai-writing/detector/patterns.js
@@ -1390,8 +1390,8 @@ const AIDetector = (() => {
 
     // Context mode gates rules that are noisy in technical writing. Modes:
     //   'general' (default) — full ruleset
-    //   'technical' — skip title-case headers, formulaic openers gated to
-    //                 prose-only structures; lower em-dash + formatting weights
+    //   'technical' — skip title-case headers; individual prose-only rules
+    //                 apply their own technical-context gates
     //   'marketing' — full ruleset + boost on formulaic-opener / future-narrative
     //   'personal'  — full ruleset, normal weights
     // Mode is purely a soft gate; nothing is silently suppressed without

--- a/skills/ai-writing-detector/scripts/patterns.js
+++ b/skills/ai-writing-detector/scripts/patterns.js
@@ -289,7 +289,9 @@ const AIDetector = (() => {
     'false-concession': 2,
     'rhetorical-question': 2,
     'confidence-calibration': 2,
-    'em-dash': 4,
+    // Writing-quality guidance whose authorship polarity changes across model
+    // generations. Keep the flag visible without moving authorship outputs.
+    'em-dash': 0,
     uniformity: 5,
     formatting: 3,
     'tier3-phrase': 3,

--- a/skills/ai-writing-detector/scripts/patterns.js
+++ b/skills/ai-writing-detector/scripts/patterns.js
@@ -1390,8 +1390,8 @@ const AIDetector = (() => {
 
     // Context mode gates rules that are noisy in technical writing. Modes:
     //   'general' (default) — full ruleset
-    //   'technical' — skip title-case headers, formulaic openers gated to
-    //                 prose-only structures; lower em-dash + formatting weights
+    //   'technical' — skip title-case headers; individual prose-only rules
+    //                 apply their own technical-context gates
     //   'marketing' — full ruleset + boost on formulaic-opener / future-narrative
     //   'personal'  — full ruleset, normal weights
     // Mode is purely a soft gate; nothing is silently suppressed without

--- a/skills/avoid-ai-writing/SKILL.md
+++ b/skills/avoid-ai-writing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: avoid-ai-writing
 description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Use this skill when asked to "remove AI-isms," "clean up AI writing," "edit writing for AI patterns," "audit writing for AI tells," or "make this sound less like AI." Supports a detect-only mode, an edit-in-place mode for files, an optional voice profile (casual / professional / technical / warm / blunt), and an iterate-to-convergence pass.
-version: 3.33.1
+version: 3.33.2
 license: MIT
 compatibility: Any AI coding assistant that supports agentskills.io SKILL.md format (Claude Code, Cursor, VS Code Copilot, Hermes Agent, OpenHands, etc.) or OpenClaw. No external tools or APIs required.
 ---
@@ -85,7 +85,6 @@ Not all AI-isms are equal. When doing a quick pass or triaging a large document,
 - Synonym cycling within a paragraph
 - Formulaic openings ("In the rapidly evolving world of...")
 - Bold overuse
-- Em dash frequency (above 1 per 1,000 words)
 - Generic future-narrative closers ("may become one of the most important narratives…")
 - Social endorsement closers ("This one is worth your time:", "thank me later")
 - Lingering-attention claims ("the line I keep coming back to," "I can't stop thinking about this")
@@ -98,6 +97,7 @@ Not all AI-isms are equal. When doing a quick pass or triaging a large document,
 - Tier 3 phrase clustering (≥3 distinct boilerplate phrases in one piece)
 
 ### P2 — Stylistic polish (fix when time allows)
+- Em dash frequency (above 1 per 1,000 words). This is writing-quality guidance, not evidence of machine authorship: usage has varied by model generation and vendor, so do not score or invert it as an authorship signal.
 - Generic conclusions ("The future looks bright")
 - Repeated setup/reversal punchlines when they replace concrete claims (isolated or supported reversals pass)
 - Judgment-only clarity checks: false agency, transformation crutch, ambiguous domain terminology, consequence-free explanations, and repeated empty concessions (apply each entry's pass conditions)

--- a/skills/avoid-ai-writing/detector/patterns.js
+++ b/skills/avoid-ai-writing/detector/patterns.js
@@ -289,7 +289,9 @@ const AIDetector = (() => {
     'false-concession': 2,
     'rhetorical-question': 2,
     'confidence-calibration': 2,
-    'em-dash': 4,
+    // Writing-quality guidance whose authorship polarity changes across model
+    // generations. Keep the flag visible without moving authorship outputs.
+    'em-dash': 0,
     uniformity: 5,
     formatting: 3,
     'tier3-phrase': 3,

--- a/skills/avoid-ai-writing/detector/patterns.js
+++ b/skills/avoid-ai-writing/detector/patterns.js
@@ -1390,8 +1390,8 @@ const AIDetector = (() => {
 
     // Context mode gates rules that are noisy in technical writing. Modes:
     //   'general' (default) — full ruleset
-    //   'technical' — skip title-case headers, formulaic openers gated to
-    //                 prose-only structures; lower em-dash + formatting weights
+    //   'technical' — skip title-case headers; individual prose-only rules
+    //                 apply their own technical-context gates
     //   'marketing' — full ruleset + boost on formulaic-opener / future-narrative
     //   'personal'  — full ruleset, normal weights
     // Mode is purely a soft gate; nothing is silently suppressed without

--- a/skills/preservation-verifier/scripts/patterns.js
+++ b/skills/preservation-verifier/scripts/patterns.js
@@ -289,7 +289,9 @@ const AIDetector = (() => {
     'false-concession': 2,
     'rhetorical-question': 2,
     'confidence-calibration': 2,
-    'em-dash': 4,
+    // Writing-quality guidance whose authorship polarity changes across model
+    // generations. Keep the flag visible without moving authorship outputs.
+    'em-dash': 0,
     uniformity: 5,
     formatting: 3,
     'tier3-phrase': 3,

--- a/skills/preservation-verifier/scripts/patterns.js
+++ b/skills/preservation-verifier/scripts/patterns.js
@@ -1390,8 +1390,8 @@ const AIDetector = (() => {
 
     // Context mode gates rules that are noisy in technical writing. Modes:
     //   'general' (default) — full ruleset
-    //   'technical' — skip title-case headers, formulaic openers gated to
-    //                 prose-only structures; lower em-dash + formatting weights
+    //   'technical' — skip title-case headers; individual prose-only rules
+    //                 apply their own technical-context gates
     //   'marketing' — full ruleset + boost on formulaic-opener / future-narrative
     //   'personal'  — full ruleset, normal weights
     // Mode is purely a soft gate; nothing is silently suppressed without

--- a/submission/listing.json
+++ b/submission/listing.json
@@ -2,7 +2,7 @@
   "source": {
     "repository": "https://github.com/conorbronsdon/avoid-ai-writing",
     "baseCommit": "d8c235186ff764ac20a0464ca8b1a13993ea37e4",
-    "version": "3.33.1",
+    "version": "3.33.2",
     "architecture": "skills-only"
   },
   "fields": {
@@ -15,7 +15,7 @@
     "supportURL": "https://github.com/conorbronsdon/avoid-ai-writing/issues",
     "privacyPolicyURL": "https://github.com/conorbronsdon/avoid-ai-writing/blob/main/PRIVACY.md",
     "termsOfServiceURL": "https://github.com/conorbronsdon/avoid-ai-writing/blob/main/TERMS.md",
-    "version": "3.33.1",
+    "version": "3.33.2",
     "packageName": "avoid-ai-writing",
     "capabilities": ["AI-pattern audit","Detect-only review","Voice-preserving rewrite","Targeted file editing","Preservation verification","False-positive review","Multi-step writing cleanup"],
     "starterPrompts": [

--- a/submission/submission-pack.json
+++ b/submission/submission-pack.json
@@ -3,7 +3,7 @@
     "repository": "conorbronsdon/avoid-ai-writing",
     "baseRef": "main",
     "baseCommit": "d8c235186ff764ac20a0464ca8b1a13993ea37e4",
-    "canonicalSkillVersion": "3.33.1"
+    "canonicalSkillVersion": "3.33.2"
   },
   "architecture": "skills-only",
   "publicSkills": ["avoid-ai-writing","avoid-ai-writing-router","ai-writing-detector","voice-preserving-rewriter","file-edit-in-place","preservation-verifier","false-positive-reviewer"],


### PR DESCRIPTION
Em-dash overuse remains a P2 writing-quality flag, but no longer adds authorship weight. Scores may fall for affected documents, and score-derived labels, classifications, probabilities and confidence may change. The existing issue type, text, severity, thresholds and carve-outs are unchanged. The separate smart-punctuation composite is outside this change.

Validation: the regression failed before the fix (`score 5 !== 3`) while the flag still fired. All eight npm test suites, self-scan budgets, package validation and three CI checks pass; root independently ran the full npm suite.

Exact head `e1603b3d4d74b0cf3cec5875c003cb20becd4a3b` received authenticated `claude-sonnet-5` and tool-free `opencode/mimo-v2.5-free` review. Sonnet's hypothetical severity mismatch was rejected against the unchanged `severity: 'medium'` emission, P2 mapping and passing assertion. MiMo found no regressions; raw events contain no tool calls and cost is zero. No verified blockers, setup failures or repair cycles.

Closes #73
