### PR TITLE
Fix the packaged house-style README link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- 2026-09-06: Point the bundled house-style examples at the canonical public README so the link still works when the skill package is installed without the repository root.
 - 2026-09-06: Keep em-dash overuse as a P2 writing-quality flag while excluding it from the authorship score, label, probabilities, confidence, and classification (#73). Existing rate thresholds and carve-outs are unchanged. Scores may be lower for text where em-dash overuse previously contributed weight.
 - 2026-09-06: Keep paired prose quotes around bare URLs visible to quote normalization even when the URL contains an unmatched opening parenthesis. Preserve internal URL apostrophes and explicit Markdown link destinations.
 - 2026-09-05: Add a GitHub follow invitation to the README's maintainer section.

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,7 +11,7 @@ format*; copy one and edit it.
 ## Where encoded guides live
 
 For a real published guide, don't reach for a bare name or expect a bundled config: see the
-README's [**House style is a different job**](../README.md#house-style-is-a-different-job)
+README's [**House style is a different job**](https://github.com/conorbronsdon/avoid-ai-writing/blob/main/README.md#house-style-is-a-different-job)
 section, which points at [Vale](https://github.com/vale-cli/vale) (where licensed, attributed
 guide packages live) and records the licensing decision in
 [#88](https://github.com/conorbronsdon/avoid-ai-writing/issues/88). In short: Vale enforces a

--- a/plugins/avoid-ai-writing/skills/avoid-ai-writing/examples/README.md
+++ b/plugins/avoid-ai-writing/skills/avoid-ai-writing/examples/README.md
@@ -11,7 +11,7 @@ format*; copy one and edit it.
 ## Where encoded guides live
 
 For a real published guide, don't reach for a bare name or expect a bundled config: see the
-README's [**House style is a different job**](../README.md#house-style-is-a-different-job)
+README's [**House style is a different job**](https://github.com/conorbronsdon/avoid-ai-writing/blob/main/README.md#house-style-is-a-different-job)
 section, which points at [Vale](https://github.com/vale-cli/vale) (where licensed, attributed
 guide packages live) and records the licensing decision in
 [#88](https://github.com/conorbronsdon/avoid-ai-writing/issues/88). In short: Vale enforces a

--- a/skills/avoid-ai-writing/examples/README.md
+++ b/skills/avoid-ai-writing/examples/README.md
@@ -11,7 +11,7 @@ format*; copy one and edit it.
 ## Where encoded guides live
 
 For a real published guide, don't reach for a bare name or expect a bundled config: see the
-README's [**House style is a different job**](../README.md#house-style-is-a-different-job)
+README's [**House style is a different job**](https://github.com/conorbronsdon/avoid-ai-writing/blob/main/README.md#house-style-is-a-different-job)
 section, which points at [Vale](https://github.com/vale-cli/vale) (where licensed, attributed
 guide packages live) and records the licensing decision in
 [#88](https://github.com/conorbronsdon/avoid-ai-writing/issues/88). In short: Vale enforces a


### PR DESCRIPTION
﻿The installed skill package does not include the repository-root README, so the house-style examples' relative `../README.md` link resolves to a missing file. This change points the canonical example and both generated copies at the public README's verified heading and records the correction under Unreleased.

Validation:
- `scripts/sync-plugin-skill.sh` completed at version 3.33.2
- `node scripts/test-canonical-skill-package.js .` passed for both bundle roots
- `python scripts/validate-openai-plugin.py . --json` passed with no errors or warnings
- `npm test` passed
- packaged Markdown closure: four Markdown files per bundle, one remaining real relative link (`SKILL.md` to `references/patterns.md`), zero missing targets
- old packaged relative destination reproduced as absent
- exact-SHA reviews: `claude-sonnet-5` and `opencode/mimo-v2.5-free`, no blockers

No version bump: the skill behavior and package manifest remain 3.33.2.

Reviewed head: a0128758c92e3e4f9333f977520111cec7f675d9. Root verified the heading and identical hashes across all three copies, and read both raw reviews. The first free attempt lacked the required resolved-agent preflight and was not counted. The completed replacement used all 13 resolved tools disabled and emitted zero tool events at zero cost. Future branch/heading drift is an ordinary external-link maintenance consideration; generated-copy parity is already covered by the existing packaging workflow.
