### PR TITLE
ci: add local SSOT pilot and pin promo checker

### DIFF
--- a/.github/workflows/promo-drift.yml
+++ b/.github/workflows/promo-drift.yml
@@ -52,6 +52,9 @@ jobs:
         run: |
           cd "$GITHUB_WORKSPACE/.."
           git clone --depth 1 --quiet https://github.com/conorbronsdon/ssot-check.git ssot-check
+          # Use the same reviewed revision as the repository-local SSOT pilot.
+          git -C ssot-check fetch --depth 1 origin f3289c400cd591cdcb6ce4016627a442d0804ce7
+          git -C ssot-check checkout --detach FETCH_HEAD
 
       - name: Check the promo surfaces
         id: check

--- a/.github/workflows/ssot.yml
+++ b/.github/workflows/ssot.yml
@@ -1,0 +1,31 @@
+name: SSOT
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  ssot:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Get the reviewed checker
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: conorbronsdon/ssot-check
+          ref: f3289c400cd591cdcb6ce4016627a442d0804ce7 # v0.1.3
+          path: .ssot-tool
+          persist-credentials: false
+      - name: Check registered compatibility claims
+        run: python3 .ssot-tool/ssot_check.py check --manifest .ssot-local.yaml
+      - name: Warn about possible unregistered copies
+        run: python3 .ssot-tool/ssot_check.py discover --manifest .ssot-local.yaml --untracked-only --github-annotations
+      - name: Exercise drift and advisory controls
+        run: python3 scripts/check-ssot-controls.py .ssot-tool/ssot_check.py

--- a/.ssot-local.yaml
+++ b/.ssot-local.yaml
@@ -20,3 +20,5 @@ facts:
         pattern: 'It works in Node \(`>=(\d+)`\)'
       - file: CONTRIBUTING.md
         pattern: 'dependencies to install; Node (\d+)\+ only\.'
+      - file: detector/README.md
+        pattern: 'It runs identically in Node \(`>=(\d+)`\)'

--- a/.ssot-local.yaml
+++ b/.ssot-local.yaml
@@ -1,0 +1,22 @@
+# Repository-local compatibility claims. Cross-repo counts remain in .ssot.yaml.
+# Historical releases, example corpora and generated bundles are not current prose.
+ignore_paths:
+  - "CHANGELOG.md"
+  - "corpus/**"
+  - "examples/**"
+  - "plugins/**"
+  - "skills/**"
+  - "cursor-rules/**"
+  - "SKILL.full.md"
+  - ".ssot-tool/**"
+facts:
+  - name: minimum-node-major
+    type: integer
+    canonical:
+      file: package.json
+      pattern: '"node": ">=(\d+)"'
+    copies:
+      - file: README.md
+        pattern: 'It works in Node \(`>=(\d+)`\)'
+      - file: CONTRIBUTING.md
+        pattern: 'dependencies to install; Node (\d+)\+ only\.'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Add repository-local SSOT CI checks for the detector's Node requirement,
+- 2026-09-10: Add repository-local SSOT CI checks for the detector's Node requirement,
   advisory discovery, and drift controls; pin the existing promo checker.
 
 - 2026-09-06: Point the bundled house-style examples at the canonical public README so the link still works when the skill package is installed without the repository root.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add repository-local SSOT CI checks for the detector's Node requirement,
+  advisory discovery, and drift controls; pin the existing promo checker.
+
 - 2026-09-06: Point the bundled house-style examples at the canonical public README so the link still works when the skill package is installed without the repository root.
 - 2026-09-06: Keep em-dash overuse as a P2 writing-quality flag while excluding it from the authorship score, label, probabilities, confidence, and classification (#73). Existing rate thresholds and carve-outs are unchanged. Scores may be lower for text where em-dash overuse previously contributed weight.
 - 2026-09-06: Keep paired prose quotes around bare URLs visible to quote normalization even when the URL contains an unmatched opening parenthesis. Preserve internal URL apostrophes and explicit Markdown link destinations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,43 @@ detector `type` must be documented, every documented type must be real, and ever
 prose statement of the engine `type` total must match the code. All must pass. No
 dependencies to install; Node 18+ only.
 
+## Documentation drift
+
+The `SSOT / ssot` CI job checks repository-local Node requirements using
+`.ssot-local.yaml` on every PR. `package.json` owns the detector's Node minimum;
+README and contributor instructions carry checked copies. Existing generated
+skill, version, and pattern-count checks keep their own ownership.
+
+The separate `.ssot.yaml` and `promo-drift` workflow track cross-repo promotional
+counts on release and schedule. Both workflows pin the checker revision; the
+local PR check needs no sibling repositories or private credentials.
+
+Registered drift, missing copies, and malformed manifests fail CI. Fix the
+claim and its copies, and explain any change to canonical ownership or removed
+locators. Do not remove checks merely to make a failure disappear.
+
+Discovery is advisory and scans prose, not every source format or value. The
+Node minimum needs its explicit locators. Historical releases, example corpora,
+and generated bundles are excluded from discovery. The initial remaining
+warnings are fictional funding/percentage examples and repeated editing-budget
+guidance. Inspect a warning before registering a fact or excluding a path;
+explicitly registered copies remain checked even in excluded files.
+
+To reproduce CI, check out the checker revision pinned in
+`.github/workflows/ssot.yml` into a sibling `ssot-check` directory, then run:
+
+```bash
+python3 ../ssot-check/ssot_check.py check --manifest .ssot-local.yaml
+python3 ../ssot-check/ssot_check.py discover --manifest .ssot-local.yaml --untracked-only --github-annotations
+python3 scripts/check-ssot-controls.py ../ssot-check/ssot_check.py
+```
+
+The controls mutate disposable copies and verify drift, restoration, missing
+locations/manifests, and invalid manifests. They also prove that history can be
+excluded while a new unregistered current copy still warns without failing
+`check`. Record useful findings, repeated warnings, and maintenance effort in
+the pilot PR or a follow-up issue before expanding coverage.
+
 ## Write clean prose
 
 This repo polices writing quality, so the prose you add has to clear the same

--- a/scripts/check-ssot-controls.py
+++ b/scripts/check-ssot-controls.py
@@ -56,6 +56,8 @@ def main():
                     raise AssertionError(f"Mutation did not report drift: {locator}")
                 # Discovery exclusions must not disable an explicitly registered copy.
                 ignored = manifest_text.replace("ignore_paths:\n", f'ignore_paths:\n  - "{locator["file"]}"\n', 1)
+                if locator["file"] not in checker.parse_manifest(ignored).get("ignore_paths", []):
+                    raise AssertionError("Exclusion control did not add the target path")
                 (scratch / manifest_name).write_text(ignored, encoding="utf-8")
                 run(scratch, "check", 1)
                 (scratch / manifest_name).write_text(manifest_text, encoding="utf-8")
@@ -75,6 +77,7 @@ def main():
         scratch = Path(directory)
         (scratch / manifest_name).write_text(r"""ignore_paths:
   - "CHANGELOG.md"
+  - "history/**"
 facts:
   - name: example-price
     type: currency
@@ -88,14 +91,21 @@ facts:
         for name in ("current.md", "guide.md"):
             (scratch / name).write_text("Price: $100\n", encoding="utf-8")
         (scratch / "CHANGELOG.md").write_text("Historical price: $50\nOld price: $50\n", encoding="utf-8")
+        (scratch / "history/nested").mkdir(parents=True)
+        (scratch / "history/nested/old.md").write_text("Price: $50\n", encoding="utf-8")
+        (scratch / "history/other.md").write_text("Price: $50\n", encoding="utf-8")
         run(scratch)
         clean = run(scratch, "discover", 0, "--untracked-only", "--github-annotations")
         if "::warning" in clean:
             raise AssertionError(f"Tracked or historical values generated warnings: {clean}")
         (scratch / "new-page.md").write_text("Price: $100\n", encoding="utf-8")
+        (scratch / "history-current.md").write_text("Price: $100\n", encoding="utf-8")
         run(scratch)
         warning = run(scratch, "discover", 0, "--untracked-only", "--github-annotations")
-        if "::warning file=new-page.md" not in warning or "::warning file=CHANGELOG.md" in warning:
+        if ("::warning file=new-page.md" not in warning
+                or "::warning file=history-current.md" not in warning
+                or "::warning file=CHANGELOG.md" in warning
+                or "::warning file=history/" in warning):
             raise AssertionError(f"Expected only the unregistered current copy warning: {warning}")
     print(f"SSOT controls passed: {tested} real copy locators; drift, restore, missing copy/manifest, invalid manifest, exclusion, advisory discovery.")
 

--- a/scripts/check-ssot-controls.py
+++ b/scripts/check-ssot-controls.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Exercise this repository's SSOT locators in disposable copies, without edits."""
+import importlib.util
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+
+
+def main():
+    cli = Path(sys.argv[1]).resolve()
+    root = Path(__file__).resolve().parents[1]
+    manifest_name = ".ssot-local.yaml" if (root / ".ssot-local.yaml").exists() else ".ssot.yaml"
+    manifest_text = (root / manifest_name).read_text(encoding="utf-8")
+    spec = importlib.util.spec_from_file_location("ssot_check", cli)
+    checker = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(checker)
+    manifest = checker.parse_manifest(manifest_text)
+
+    def run(at, command="check", expected=0, *extra):
+        result = subprocess.run(
+            [sys.executable, "-X", "utf8", str(cli), command, "--manifest", str(at / manifest_name), *extra],
+            text=True, capture_output=True, encoding="utf-8", cwd=at,
+            env={**os.environ, "GITHUB_WORKSPACE": str(at)},
+        )
+        if result.returncode != expected:
+            raise AssertionError(f"{command}: expected {expected}, got {result.returncode}\n{result.stdout}\n{result.stderr}")
+        return result.stdout
+
+    run(root)
+    tested = 0
+    with tempfile.TemporaryDirectory(prefix="ssot-controls-") as directory:
+        scratch = Path(directory)
+        (scratch / manifest_name).write_text(manifest_text, encoding="utf-8")
+        for fact in manifest["facts"]:
+            for locator in [fact["canonical"], *fact["copies"]]:
+                relative = locator["file"]
+                target = scratch / relative
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_bytes((root / relative).read_bytes())
+        run(scratch)
+        for fact in manifest["facts"]:
+            for locator in fact["copies"]:
+                target = scratch / locator["file"]
+                original = target.read_text(encoding="utf-8")
+                match = re.search(locator["pattern"], original, re.MULTILINE)
+                if match is None:
+                    raise AssertionError(f"Unmatched locator: {locator}")
+                changed = original[:match.start(1)] + "987654" + original[match.end(1):]
+                target.write_text(changed, encoding="utf-8")
+                report = json.loads(run(scratch, "check", 1, "--json"))
+                if report["summary"]["drifted"] < 1:
+                    raise AssertionError(f"Mutation did not report drift: {locator}")
+                # Discovery exclusions must not disable an explicitly registered copy.
+                ignored = manifest_text.replace("ignore_paths:\n", f'ignore_paths:\n  - "{locator["file"]}"\n', 1)
+                (scratch / manifest_name).write_text(ignored, encoding="utf-8")
+                run(scratch, "check", 1)
+                (scratch / manifest_name).write_text(manifest_text, encoding="utf-8")
+                target.write_text(original, encoding="utf-8")
+                run(scratch)
+                target.unlink()
+                run(scratch, "check", 1)
+                target.write_text(original, encoding="utf-8")
+                tested += 1
+        (scratch / manifest_name).unlink()
+        run(scratch, "check", 2)
+        (scratch / manifest_name).write_text("facts: invalid\n", encoding="utf-8")
+        run(scratch, "check", 2)
+
+    # Synthetic, supported discovery values. Node/Python floors are not discoverable.
+    with tempfile.TemporaryDirectory(prefix="ssot-discovery-") as directory:
+        scratch = Path(directory)
+        (scratch / manifest_name).write_text(r"""ignore_paths:
+  - "CHANGELOG.md"
+facts:
+  - name: example-price
+    type: currency
+    canonical:
+      file: current.md
+      pattern: 'Price: \$(\d+)'
+    copies:
+      - file: guide.md
+        pattern: 'Price: \$(\d+)'
+""", encoding="utf-8")
+        for name in ("current.md", "guide.md"):
+            (scratch / name).write_text("Price: $100\n", encoding="utf-8")
+        (scratch / "CHANGELOG.md").write_text("Historical price: $50\nOld price: $50\n", encoding="utf-8")
+        run(scratch)
+        clean = run(scratch, "discover", 0, "--untracked-only", "--github-annotations")
+        if "::warning" in clean:
+            raise AssertionError(f"Tracked or historical values generated warnings: {clean}")
+        (scratch / "new-page.md").write_text("Price: $100\n", encoding="utf-8")
+        run(scratch)
+        warning = run(scratch, "discover", 0, "--untracked-only", "--github-annotations")
+        if "::warning file=new-page.md" not in warning or "::warning file=CHANGELOG.md" in warning:
+            raise AssertionError(f"Expected only the unregistered current copy warning: {warning}")
+    print(f"SSOT controls passed: {tested} real copy locators; drift, restore, missing copy/manifest, invalid manifest, exclusion, advisory discovery.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add repository-local SSOT coverage for the detector Node requirement in the root README, detector guide, and contributor instructions. The new PR job uses .ssot-local.yaml, while the existing .ssot.yaml retains cross-repo promotional-count ownership. Pin both checker workflows to the reviewed v0.1.3 commit.

Registered drift and missing locations fail the new job. Discovery remains advisory; eight baseline occurrences are known fictional examples and repeated editing-budget guidance. Contributor instructions explain repairs and exclusions. Disposable controls prove drift, restoration, missing/invalid manifests, and unregistered-copy warnings without modifying the checkout.

Validation: SSOT baseline and controls passed for all three real copy locators; actionlint passed for both changed workflows; npm test and self-scan:check passed. All hosted checks passed at final HEAD. Pilot observation and required-check configuration remain follow-up work after merge.


Independent review: authenticated claude-sonnet-5 plus tool-isolated opencode/muse-spark-1.3-contributor-free and opencode/nemotron-3-ultra-free completed full reviews. Claude's nested-glob control finding was fixed, and an ineffective-insertion guard was added. Final affected-control reviews completed; Claude and Muse found no actionable defects. Nemotron findings were checked against the actual source and rejected: SHA checkout is already immutable, downloaded code is not executed before checkout, unmatched locators fail rather than pass silently, exact-file canonical checks survive exclusions, parse_manifest takes text, and the nested-prefix/similarly named sibling assertions are intentional. Free review prices/cost were zero, all resolved tools were disabled, and no tool events occurred. Unchanged-file review coverage carries forward; raw receipts are retained locally.

Full review SHA: 717440dc6952d89b535d894f56b22e060e4b707b. Final affected-control review SHA: 52c4a94dbe487158618a9335ed49db2c4eae2a5a.

Qodo follow-up at final HEAD `6284af6e3e2d7ecdf7611794dc11bb8a0666d33a`: registered the previously omitted detector/README.md Node requirement and dated the changelog entry. The real-copy mutation controls now exercise all three documentation claims. Self-scan and all four hosted checks passed. Authenticated claude-sonnet-5 and tool-isolated opencode/muse-spark-1.3-contributor-free independently reviewed this exact delta with no findings; unchanged-content coverage carries forward.
