### PR TITLE
docs: show published detector npm install and import

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,18 @@ build step.
 It's also the single source of the numeric score: the skill itself (and `detect` mode) report *which* patterns are present and how severe (P0/P1/P2), and the engine is what turns those into one computed 0–100 `score`. There's deliberately no second, prose-estimated score in `SKILL.md` — one scorer, not two.
 
 ```bash
+npm install avoid-ai-writing-detector
+```
+
+```js
+const AIDetector = require("avoid-ai-writing-detector");
+const { score, label, issues } = AIDetector.analyzeText("Your text here…");
+console.log(score, label, issues.length);
+```
+
+When working from a cloned checkout instead of the published npm package:
+
+```bash
 npm test          # run the detector's fixtures (no deps to install)
 ```
 

--- a/detector/README.md
+++ b/detector/README.md
@@ -12,6 +12,24 @@ the two in sync.
 
 ## Run it
 
+### From npm
+
+Install the published detector package in another project:
+
+```bash
+npm install avoid-ai-writing-detector
+```
+
+```js
+const AIDetector = require("avoid-ai-writing-detector");
+const result = AIDetector.analyzeText("Your text here…");
+console.log(result.score, result.label, result.issues.length);
+```
+
+### From a local checkout
+
+Use the repository directly when developing or validating detector changes:
+
 ```bash
 npm test          # pattern, category-contract, and preservation tests (no deps)
 # or directly:
@@ -24,8 +42,10 @@ const result = AIDetector.analyzeText("Your text here…");
 console.log(result.score, result.label, result.issues.length);
 ```
 
-In the browser, load `patterns.js` as a plain script — it self-registers as a
-global `AIDetector` (the `module.exports` block is guarded and only runs under
+### In the browser
+
+Load `patterns.js` as a plain script — it self-registers as a global
+`AIDetector` (the `module.exports` block is guarded and only runs under
 CommonJS).
 
 ## `analyzeText(text, options?)` → result


### PR DESCRIPTION
Closes #156

## Summary

- add a copy-paste `npm install avoid-ai-writing-detector` example to the root README;
- show the published CommonJS import path (`require("avoid-ai-writing-detector")`);
- distinguish npm-package, local-checkout, and browser usage in `detector/README.md`;
- keep existing local detector commands and browser guidance intact.

## Scope

Documentation only. No package API, detector behavior, scoring, or exports changed.

## Verification

- `package.json` declares `"main": "detector/patterns.js"` and publishes that file, matching the documented package import;
- the contribution changes only `README.md` and `detector/README.md`;
- repository CI is expected to run `npm test` and the self-scan checks on this PR.

I also attempted the requested isolated `npm pack` verification locally, but the execution environment available for this contribution has no outbound DNS/network access to clone the fork into the shell. I am not claiming that manual check as passed; the documented import matches the repository's current package metadata and the PR remains ready for CI/reviewer verification.