### PR TITLE
docs: show how to install and import the published npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,24 @@ const AIDetector = require("./detector/patterns.js");
 const { score, label, issues } = AIDetector.analyzeText("Your text here…");
 ```
 
+### Install from npm
+
+The detector is also published on npm as
+[`avoid-ai-writing-detector`](https://www.npmjs.com/package/avoid-ai-writing-detector),
+so you can use it in another project without cloning this repo:
+
+```bash
+npm install avoid-ai-writing-detector
+```
+
+```js
+const AIDetector = require("avoid-ai-writing-detector");
+const result = AIDetector.analyzeText("Your text here…");
+console.log(result.score, result.label, result.issues.length);
+```
+
+The local-checkout example above and the browser usage below keep working unchanged.
+
 When the input is a Markdown source file, pass
 `{ sourceMode: "rendered-markdown" }` to exclude initial YAML frontmatter and
 HTML comments from the score while keeping issue offsets aligned with the

--- a/detector/README.md
+++ b/detector/README.md
@@ -24,6 +24,25 @@ const result = AIDetector.analyzeText("Your text here…");
 console.log(result.score, result.label, result.issues.length);
 ```
 
+### Use it from npm
+
+The engine is published as
+[`avoid-ai-writing-detector`](https://www.npmjs.com/package/avoid-ai-writing-detector),
+so it can be consumed in another project without cloning this repo:
+
+```bash
+npm install avoid-ai-writing-detector
+```
+
+```js
+const AIDetector = require("avoid-ai-writing-detector");
+const result = AIDetector.analyzeText("Your text here…");
+console.log(result.score, result.label, result.issues.length);
+```
+
+The published package is the same `patterns.js` engine described on this page —
+the local-checkout example above needs no changes.
+
 In the browser, load `patterns.js` as a plain script — it self-registers as a
 global `AIDetector` (the `module.exports` block is guarded and only runs under
 CommonJS).


### PR DESCRIPTION
Fixes #156. Adds the missing npm usage example: a concise install/import snippet in the README's **Run the detector** section, plus the fuller explanation in `detector/README.md`. The existing local-checkout and browser examples are unchanged.