### PR TITLE
docs: add a pattern proposal issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/pattern_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/pattern_proposal.yml
@@ -1,0 +1,120 @@
+name: Pattern proposal
+description: Propose a new AI-writing pattern for the catalog or the detector
+title: "Pattern proposal: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing a pattern. Two questions decide what happens to it:
+        whether a regex can find it, and who gets flagged by mistake if it ships.
+        This form asks both up front so the proposal can be evaluated on its
+        evidence rather than on a round of follow-up questions.
+
+        `CONTRIBUTING.md` has the full picture of where a rule lands once it is
+        accepted. You do not need to have read it to file this.
+
+        Please do not paste anything you would mind seeing in a public repo.
+
+  - type: input
+    id: name
+    attributes:
+      label: Pattern name
+      description: A short handle for the thing itself, not a description of it.
+      placeholder: Synonym cycling
+    validations:
+      required: true
+
+  - type: textarea
+    id: should-fire
+    attributes:
+      label: Text that should be flagged
+      description: The shortest example that shows the pattern. A sentence or two is usually enough.
+      placeholder: Paste the exact text here.
+    validations:
+      required: true
+
+  - type: textarea
+    id: must-not-fire
+    attributes:
+      label: Nearby text that must stay clean
+      description: Writing that looks close to the example above but is ordinary human prose. This is the harder half of the proposal, and a rule without one tends to fire on everything.
+      placeholder: Paste the exact text here.
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why this is a tell
+      description: What makes the first example machine-shaped and the second one not?
+    validations:
+      required: true
+
+  - type: textarea
+    id: false-positives
+    attributes:
+      label: Who gets flagged by mistake
+      description: Legitimate uses you know of, registers where the rule would misfire, carve-outs it would need. Write "none I could find" if you looked and came up empty; that is an answer.
+      placeholder: Fiction uses this deliberately in dialogue.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: detectability
+    attributes:
+      label: Can a regex find it?
+      description: Regex-detectable rules go to the engine with a fixture. Judgment-only rules stay in the catalog for the model to apply. Unsure is a fine answer and gets sorted during triage.
+      options:
+        - Regex-detectable (a phrase, a character, or a structural shape)
+        - Judgment-only (needs reading for meaning)
+        - Unsure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: fixture
+    attributes:
+      label: May we use these examples as public test fixtures?
+      description: Fixtures live in the repo and run in CI. If you say no, the proposal is still usable; the examples just get replaced with ones written for the purpose.
+      options:
+        - "Yes, use them as public fixtures"
+        - "No, keep the text out of the repo"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: register
+    attributes:
+      label: Register
+      description: Where you have seen the pattern. Rules that hold in a blog post often misfire in a changelog, so this scopes the proposal.
+      options:
+        - Blog or essay
+        - Technical documentation or README
+        - Technical blog or architecture writeup
+        - Academic or research writing
+        - Social post (LinkedIn, X)
+        - Email or DM
+        - Issue, PR, or code comment
+        - Changelog or release notes
+        - Fiction or creative
+        - Across several registers
+        - Other
+    validations:
+      required: false
+
+  - type: textarea
+    id: sources
+    attributes:
+      label: Sources
+      description: Link anything that backs a factual claim about how models or people write. Skip this if the proposal rests on your own examples rather than on a claim about frequency.
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        **What happens next.** Triage decides which of the two homes the rule
+        gets, or records why it stays out. A rule that cannot survive its
+        must-not-fire example does not ship, and the reasoning gets written
+        down either way.

--- a/.github/ISSUE_TEMPLATE/pattern_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/pattern_proposal.yml
@@ -76,10 +76,10 @@ body:
     id: fixture
     attributes:
       label: May we use these examples as public test fixtures?
-      description: Fixtures live in the repo and run in CI. If you say no, the proposal is still usable; the examples just get replaced with ones written for the purpose.
+      description: The issue is public. Choose whether the examples may also be copied into files that run in CI.
       options:
         - "Yes, use them as public fixtures"
-        - "No, keep the text out of the repo"
+        - "No, do not copy them into committed fixtures"
     validations:
       required: true
 
@@ -118,3 +118,5 @@ body:
         gets, or records why it stays out. A rule that cannot survive its
         must-not-fire example does not ship, and the reasoning gets written
         down either way.
+
+        First-time contributors are welcome to ask for a review in the issue.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- 2026-09-11: Add a pattern proposal issue form so a new rule arrives with a should-fire
+  example, a must-not-fire example, and its false-positive risk; link it from `CONTRIBUTING.md`.
+
 - 2026-09-10: Add repository-local SSOT CI checks for the detector's Node requirement,
   advisory discovery, and drift controls; pin the existing promo checker.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,8 @@ First decide which kind of rule it is:
   `detector/CATEGORIES.md`. There is no detector type for these.
 
 If you are unsure which it is, open an issue first and we will sort it out.
+The [pattern proposal form](https://github.com/conorbronsdon/avoid-ai-writing/issues/new?template=pattern_proposal.yml)
+asks for what triage needs, including the example that must stay clean.
 
 ## Precision over recall
 


### PR DESCRIPTION
## Summary

Closes #157. A pattern suggestion currently arrives as a blank issue, so triage asks for the same details every time. This adds `.github/ISSUE_TEMPLATE/pattern_proposal.yml` and links it from `CONTRIBUTING.md`.

The form asks for a should-fire example, a must-not-fire example, the false-positive risk, and whether a regex can reach the pattern at all. The detectability dropdown offers the same three outcomes `CONTRIBUTING.md` already describes, including "Unsure", so the split can be sorted during triage rather than by the reporter. Fixture consent is asked the way the false-positive form asks it, and the wording, dropdown values, and closing "What happens next" note follow that form so the two read as one set.

On required fields: name, both examples, why it is a tell, false-positive risk, detectability, and fixture consent are required. Register and sources are optional. Register can usually be read off the examples, and a source only applies when the proposal makes a claim about how models or people write. The false-positive field accepts "none I could find" rather than blocking someone who looked and came up empty.

The `CONTRIBUTING.md` change is two lines on the existing "open an issue first" sentence. It links the form and names one field as a hint, without restating the list.

No detector or rule change, so no `SKILL.md` version bump. `CHANGELOG.md` gets a dated Unreleased entry.

Verified locally:

```
npm test                 # exit 0
npm run self-scan:check  # PASS, CONTRIBUTING.md 1 of 15 budget
```

The YAML parses and passes a schema check for block types, unique ids, and dropdown options. The form's prose avoids em dashes.

## Checklist

- [x] `npm test` passes (engine fixtures + `CATEGORIES.md` contract check)
- [ ] If I added a detector `type`: it's documented in `detector/CATEGORIES.md` and has a fixture in `detector/patterns.test.js` (a true positive **and** a must-not-fire case) — n/a, no detector change
- [ ] If I added a judgment-only rule: it's listed under "Skill-only" in `detector/CATEGORIES.md` — n/a, no rule change
- [x] I considered false positives and added carve-outs for legitimate human writing — the form makes the must-not-fire example and the false-positive risk required
- [x] Any factual claim about how AI or humans write cites a source — none made; the form asks proposers for sources
- [x] The prose I added passes the skill's own audit (no AI-writing tells, terse bullets, no hollow intensifiers)
- [x] `CHANGELOG.md` entry added under a dated heading; no `SKILL.md` `version:` bump, since no rule changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015w3yGvreSY5CLyBG7zgCKK