### PR TITLE
docs: correct the analyzeText result contract in detector/README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- 2026-09-11: Correct the `analyzeText()` result table in `detector/README.md`: the six score labels the
+  engine returns, the `UNSCORED` classification on early-exit paths, and all four accepted `contextMode` values.
+
 - 2026-09-10: Add repository-local SSOT CI checks for the detector's Node requirement,
   advisory discovery, and drift controls; pin the existing promo checker.
 

--- a/detector/README.md
+++ b/detector/README.md
@@ -53,17 +53,25 @@ CommonJS).
 | Field | Type | Meaning |
 |---|---|---|
 | `score` | `0–100` | 0 = clean, 100 = heavy AI |
-| `label` | string | `Minimal` / `Some` / `Strong` / `Heavy` (or `Empty` / `Too short` / `Text too long`) |
+| `label` | string | scored: `Clean` (0) / `Minimal AI signals` (1–15) / `Some AI patterns` (16–35) / `Moderate AI signals` (36–60) / `Strong AI signals` (61–80) / `Heavy AI patterns` (81–100). Unscored: `Empty` / `Too short` / `Text too long` |
 | `issues[]` | `{type, text, severity, …}` | one entry per detected pattern; `type` keys map to [`CATEGORIES.md`](./CATEGORIES.md) |
 | `stats` | object | `wordCount`, per-tier counts, `contextMode`, `sourceMode`, masked-span counts, `denseAIVocab`, normalization flags, etc. |
-| `document_classification` | string | trinary `HUMAN_ONLY` / `MIXED` / `AI_ONLY` (shape mirrors GPTZero for swap-in) |
+| `document_classification` | string | `HUMAN_ONLY` / `MIXED` / `AI_ONLY` (shape mirrors GPTZero for swap-in), or `UNSCORED` on the early-exit paths |
 | `class_probabilities` | `{human, mixed, ai}` | sums to exactly 1.0 |
 | `confidence_category` | `low` / `medium` / `high` | |
 | `highlight_sentence_for_ai` | region[] | sentence spans with source offsets + per-region score, for UI highlighting |
 
-`options.contextMode` accepts `general` (default) or `technical`; technical mode
-suppresses flags that are legitimate in code-adjacent prose (e.g. Title Case
-headers). Invalid modes fall back to `general` and set `stats.contextModeFallback`.
+The three unscored labels share one result shape: `score` 0,
+`document_classification` `UNSCORED`, an even `class_probabilities` split, and
+`confidence_category` `low`. Branch on that classification rather than on the
+score, since clean text also scores 0 and is labeled `Clean`.
+
+`options.contextMode` accepts `general` (default), `technical`, `marketing`, and
+`personal`. Technical mode suppresses flags that are legitimate in code-adjacent
+prose (e.g. Title Case headers); `marketing` and `personal` are accepted and
+reported in `stats.contextMode`, but currently score the same as `general`.
+Invalid modes fall back to `general` and set `stats.contextModeFallback` to the
+value you passed.
 
 `options.sourceMode` accepts `plain` (default) or `rendered-markdown`. Rendered
 Markdown mode masks initial YAML frontmatter and HTML comments before pattern


### PR DESCRIPTION
## Summary

Three rows of the `analyzeText()` result table describe values the engine does not return. `README.md` sends API readers here, and the detector is now published to npm, so a caller who branches on `label` or `document_classification`, or who validates `contextMode` against this table, writes code that cannot match.

**`label`.** `getLabel()` in `detector/patterns.js` returns six scored strings. The table listed four, and those four were truncated forms of the real ones. `Clean` (score 0) and `Moderate AI signals` (36-60) were missing entirely, and every scored string carries an `AI signals` or `AI patterns` suffix, so `result.label === "Minimal"` is never true.

```
$ node -e "const D=require('./detector/patterns.js'); for (const s of [0,1,15,16,35,36,60,61,80,81,100]) console.log(s, D.getLabel(s))"
0 Clean
1 Minimal AI signals
15 Minimal AI signals
16 Some AI patterns
35 Some AI patterns
36 Moderate AI signals
60 Moderate AI signals
61 Strong AI signals
80 Strong AI signals
81 Heavy AI patterns
100 Heavy AI patterns
```

Scores are integers (`Math.round` in `calculateScore`), so the bands are written as integer ranges.

**`document_classification`.** The early-exit paths return a fourth value the table called trinary:

```
$ node -e "const D=require('./detector/patterns.js'); for (const t of ['', 'Hi there.']) { const r=D.analyzeText(t); console.log(JSON.stringify(r.label), r.document_classification, r.confidence_category, JSON.stringify(r.class_probabilities)) }"
"Empty" UNSCORED low {"human":0.333,"mixed":0.334,"ai":0.333}
"Too short" UNSCORED low {"human":0.333,"mixed":0.334,"ai":0.333}
```

The same holds for over-length input. I added one short paragraph for that result shape, because `score` is 0 for unscored input and also 0 for genuinely clean text, so the classification is the field to branch on. The `class_probabilities` row is untouched: `0.333 + 0.334 + 0.333` is exactly 1 in JS, so "sums to exactly 1.0" is correct.

**`contextMode`.** `VALID_CONTEXT_MODES` accepts four modes. The table named two and framed the rest as invalid, which is misleading in both directions: passing `marketing` or `personal` is accepted and reported in `stats.contextMode`, and neither currently changes the score. The new wording names all four and keeps the "only technical alters flagging" fact explicit.

```
$ node -e "const D=require('./detector/patterns.js'); const t='## Strategic Negotiations And Key Partnerships\n\n'+'Certainly! This serves as a vibrant testament to transformative power. '.repeat(6); for (const m of ['general','technical','marketing','personal','bogus']) { const r=D.analyzeText(t,{contextMode:m}); console.log(m, r.score, r.stats.contextMode, JSON.stringify(r.stats.contextModeFallback)) }"
general 30 general null
technical 28 technical null
marketing 30 marketing null
personal 30 personal null
bogus 30 general "bogus"
```

Documentation only. No detector logic, no rule change, and `detector/README.md` is not a generated file, so no bundle sync is needed.

One note: `detector/CATEGORIES.md` describes `contextMode` as `general` / `technical` in its partial-coverage callout. That file is mirrored into `plugins/` and `skills/`, so correcting it means regenerating bundles. I left it out to keep this PR to a single file. Happy to send it separately if you want it.

## Checklist

- [x] `npm test` passes (engine fixtures + `CATEGORIES.md` contract check)
- [ ] If I added a detector `type`: documented in `detector/CATEGORIES.md` with fixtures — n/a, no detector change
- [ ] If I added a judgment-only rule: listed under "Skill-only" — n/a, no rule change
- [x] I considered false positives — n/a, no rule behavior touched
- [x] Any factual claim about how AI or humans write cites a source — none made; every claim here cites the engine and the command that shows it
- [x] The prose I added passes the skill's own audit (`npm run self-scan:check` passes; `detector/README.md` scores 1 against its budget of 15)
- [x] `CHANGELOG.md` entry added under the dated `Unreleased` list; no `SKILL.md` `version:` bump, since no rule changed

The changelog line is the only thing this shares with my other open PRs (#161 and the README link fixes). Whichever lands first, I will rebase the others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015w3yGvreSY5CLyBG7zgCKK