### PR TITLE
docs: fix three README link targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- 2026-09-11: Fix three README link targets: the dead Cowork URL, the pattern-catalog pointer, and the
+  voice-profile link that led to the triggering section.
+
 - 2026-09-10: Add repository-local SSOT CI checks for the detector's Node requirement,
   advisory discovery, and drift controls; pin the existing promo checker.
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Then use `/clean-ai-writing <your text>` in Claude Code.
 
 ### Claude Cowork — install as a plugin
 
-[Cowork](https://www.anthropic.com/cowork) loads skills only from **installed plugins** — it doesn't scan `~/.claude/skills/`, so a bare clone (the Claude Code steps above) won't be discovered there. This repo doubles as a single-plugin [marketplace](https://code.claude.com/docs/en/plugin-marketplaces), so install it as a plugin instead:
+[Cowork](https://claude.com/product/cowork) loads skills only from **installed plugins** — it doesn't scan `~/.claude/skills/`, so a bare clone (the Claude Code steps above) won't be discovered there. This repo doubles as a single-plugin [marketplace](https://code.claude.com/docs/en/plugin-marketplaces), so install it as a plugin instead:
 
 ```bash
 /plugin marketplace add conorbronsdon/avoid-ai-writing
@@ -200,7 +200,7 @@ Trigger detect mode with: "detect," "flag only," "audit only," "just flag," "sca
 
 ## Pattern reference
 
-> Representative examples from the catalog — not the exhaustive list (that's [`SKILL.md`](./SKILL.md)). The skill's human-facing prose catalog and the [detector engine](./detector/) use **different counts on purpose**: the engine implements 54 `type` categories because it splits the vocabulary tiers and adds stylometric/fingerprint signals (punctuation distribution, function-word entropy, bypass-trick detection) that work as math over a document rather than as a rule you'd look up. The two are mapped in [`detector/CATEGORIES.md`](./detector/CATEGORIES.md); don't "fix" one count to match the other.
+> Representative examples from the catalog — not the exhaustive list (that's [`references/patterns.md`](./references/patterns.md)). The skill's human-facing prose catalog and the [detector engine](./detector/) use **different counts on purpose**: the engine implements 54 `type` categories because it splits the vocabulary tiers and adds stylometric/fingerprint signals (punctuation distribution, function-word entropy, bypass-trick detection) that work as math over a document rather than as a rule you'd look up. The two are mapped in [`detector/CATEGORIES.md`](./detector/CATEGORIES.md); don't "fix" one count to match the other.
 
 ### Content Patterns
 
@@ -430,7 +430,7 @@ the model applies, and a `mechanics` object whose checkable rules
 abbreviations gate the exit code; heading case, em-dash rate, and number spelling
 are advisory). [`examples/`](./examples/) has the schema. You can skip the input
 entirely and put your guide in your agent's context alongside a
-[voice profile](#triggering-the-skill), as instructions rather than as a checked
+[voice profile](./references/patterns.md#voice-profiles), as instructions rather than as a checked
 rule set.
 
 After a rewrite, `node scripts/normalize-quotes.js draft.md --reference original.md`


### PR DESCRIPTION
## Summary

Three links in `README.md` point somewhere other than what the surrounding text promises. One is dead, two send the reader to a file or section that does not contain the thing being linked. Link destinations only, no prose changes.

**1. The Cowork link 404s.**

```
$ curl -s -o /dev/null -w "%{http_code} -> %{url_effective}\n" -L https://www.anthropic.com/cowork
404 -> https://www.anthropic.com/cowork
$ curl -s -o /dev/null -w "%{http_code} -> %{url_effective}\n" -L https://claude.com/cowork
200 -> https://claude.com/product/cowork
```

The page moved to claude.com. I used the canonical `https://claude.com/product/cowork` rather than the `/cowork` vanity path, which 301s to it. Happy to switch to the shorter one if you prefer it. This is the only occurrence in the repo; the `dist/`, `plugins/`, and `skills/` copies do not carry the URL.

**2. The pattern-reference callout names the wrong catalog file.** It says the exhaustive list is `SKILL.md`, but the catalog moved to `references/patterns.md` when the skill was split.

```
$ grep -c '^### ' SKILL.md references/patterns.md
SKILL.md:7
references/patterns.md:80
```

The feature list higher up in the same file already says "The full catalog lives in `references/patterns.md`", so this fixes a contradiction inside one document. `SKILL.md` still tells the agent to read `references/patterns.md` in full, so the pointer is the only thing that is stale.

**3. The voice-profile link lands on the wrong section.** It points at `#triggering-the-skill`, which is about how to invoke the skill and says nothing about voice profiles. The profiles are defined under "Voice profiles" in `references/patterns.md`, which is where the sentence is sending people.

## Verification

```
grep -c 'anthropic.com/cowork' README.md    # 0
grep -c '^## Voice profiles' references/patterns.md    # 1
npm test                                    # exit 0
npm run self-scan:check                     # PASS
```

I also checked the rest of the external links in `README.md` with curl. Everything else returns 200.

## Checklist

- [x] `npm test` passes (engine fixtures + `CATEGORIES.md` contract check)
- [ ] If I added a detector `type` — n/a, no detector change
- [ ] If I added a judgment-only rule — n/a, no rule change
- [x] I considered false positives — n/a, no rule behavior touched
- [x] Any factual claim about how AI or humans write cites a source — none made
- [x] The prose I added passes the skill's own audit — no prose added, and `self-scan:check` passes
- [x] `CHANGELOG.md` entry added under the dated `Unreleased` list; no `SKILL.md` `version:` bump, since no rule changed

The changelog line is the only overlap with my other open PRs (#161, #164). Whichever lands first, I will rebase the others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015w3yGvreSY5CLyBG7zgCKK