### PR TITLE
docs: correct plugin version sync instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,8 +19,11 @@ A directory-based writing skill (`SKILL.md` plus `references/patterns.md`) that 
 
 Edit `SKILL.md` and `references/patterns.md` directly. When making changes:
 
-- Bump the version in the SKILL.md frontmatter (`version: X.Y.Z`)
-- Run `bash scripts/sync-plugin-skill.sh`. The two canonical files are the source of truth; the plugin's bundled copy and `plugin.json`'s version are generated from it, and CI fails on a mismatch. Bumping the frontmatter without this step fails the `check` job with `version mismatch: SKILL.md=X plugin.json=Y`.
+- Bump the version in the SKILL.md frontmatter (`version: X.Y.Z`).
+- Update the same version manually in both plugin manifests before syncing:
+  - `plugins/avoid-ai-writing/.claude-plugin/plugin.json`
+  - `.codex-plugin/plugin.json`
+- Run `bash scripts/sync-plugin-skill.sh`. The script validates both manifest versions against `SKILL.md` and regenerates the bundled skill copies, detector resources, scripts, examples, and portable skill artifacts; it does not generate the manifest versions. A mismatch fails with messages such as `version mismatch: SKILL.md=X Claude plugin=Y` or `version mismatch: SKILL.md=X OpenAI plugin=Y`.
 - Run `npm test` to exercise the detector, category contract, validator, corpus helpers, and style checks.
 - Add a dated entry to CHANGELOG.md
 - Update README.md if the change affects installation, usage, feature list, or pattern count

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Edit `SKILL.md` and `references/patterns.md` directly. When making changes:
 - Update the same version manually in both plugin manifests before syncing:
   - `plugins/avoid-ai-writing/.claude-plugin/plugin.json`
   - `.codex-plugin/plugin.json`
-- Run `bash scripts/sync-plugin-skill.sh`. The script validates both manifest versions against `SKILL.md` and regenerates the bundled skill copies, detector resources, scripts, examples, and portable skill artifacts; it does not generate the manifest versions. A mismatch fails with messages such as `version mismatch: SKILL.md=X Claude plugin=Y` or `version mismatch: SKILL.md=X OpenAI plugin=Y`.
+- Run `bash scripts/sync-plugin-skill.sh && bash scripts/sync-cursor-rules.sh`. The first script validates both manifest versions against `SKILL.md` and regenerates bundled skill copies, detector resources, scripts, and examples; the second regenerates the portable paste/Cursor artifacts. Neither script generates the manifest versions. A mismatch fails with messages such as `version mismatch: SKILL.md=X Claude plugin=Y` or `version mismatch: SKILL.md=X OpenAI plugin=Y`.
 - Run `npm test` to exercise the detector, category contract, validator, corpus helpers, and style checks.
 - Add a dated entry to CHANGELOG.md
 - Update README.md if the change affects installation, usage, feature list, or pattern count


### PR DESCRIPTION
Closes #168

## What changed

- document that both plugin manifests must be version-bumped manually;
- clarify that `scripts/sync-plugin-skill.sh` validates manifest versions and regenerates bundled artifacts rather than generating manifest versions;
- use the actual Claude/OpenAI mismatch messages emitted by the script;
- preserve the rest of the release checklist unchanged.

## Verification

- change is documentation-only and limited to `CLAUDE.md`;
- wording was checked directly against `scripts/sync-plugin-skill.sh`;
- the branch is based on the current upstream `main`.

I did not run `npm run self-scan:check` from this environment, so I am not claiming that command as locally verified; CI can provide the final repository check.