### PR TITLE
fix: list mixed-register corpus bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented here.
 
 ### Fixed
 
+- Include every observed corpus register in `corpus.js list`; preserve the preferred accepted-register order and sort additional registers deterministically.
 - Fix three README link targets: the dead Cowork URL, the pattern-catalog pointer, and the
   voice-profile link that led to the triggering section.
 - Correct the `analyzeText()` result table in `detector/README.md`: the six score labels the

--- a/scripts/corpus.js
+++ b/scripts/corpus.js
@@ -298,17 +298,25 @@ function cmdVerify() {
   return 0;
 }
 
-function cmdList() {
-  const m = readManifest();
+function cmdList(manifest = readManifest()) {
+  const m = manifest;
   const byRegister = new Map();
   for (const doc of m.documents) {
     if (!byRegister.has(doc.register)) byRegister.set(doc.register, []);
     byRegister.get(doc.register).push(doc);
   }
+
+  const extraRegisters = [...byRegister.keys()]
+    .filter((register) => !REGISTERS.includes(register))
+    .sort();
+  const displayRegisters = [
+    ...REGISTERS.filter((register) => byRegister.has(register)),
+    ...extraRegisters,
+  ];
+
   console.log(`\n${m.documents.length} document(s) across ${byRegister.size} register(s)\n`);
-  for (const reg of REGISTERS) {
+  for (const reg of displayRegisters) {
     const docs = byRegister.get(reg);
-    if (!docs) continue;
     const words = docs.reduce((s, d) => s + (d.words || 0), 0);
     console.log(`  ${reg}  (${docs.length} docs, ${words.toLocaleString()} words)`);
     for (const d of docs) {
@@ -384,4 +392,4 @@ async function main() {
 
 if (require.main === module) main();
 
-module.exports = { readManifest, loadText, loadRows, sha256, REGISTERS, AUTHORSHIP, stripGutenberg, htmlToText, applySlice };
+module.exports = { readManifest, loadText, loadRows, sha256, REGISTERS, AUTHORSHIP, stripGutenberg, htmlToText, applySlice, cmdList };

--- a/scripts/corpus.test.js
+++ b/scripts/corpus.test.js
@@ -9,7 +9,7 @@
  */
 
 const assert = require('node:assert/strict');
-const { stripGutenberg, htmlToText, applySlice, sha256 } = require('./corpus.js');
+const { stripGutenberg, htmlToText, applySlice, sha256, cmdList } = require('./corpus.js');
 const { parseCsv } = require('./csv-lite.js');
 const { DOMAIN_REGISTER } = require('./dataset-raid.js');
 
@@ -192,6 +192,61 @@ test('raid: only defensible registers are mapped', () => {
   assert.equal(DOMAIN_REGISTER.reddit, 'conversational');
   assert.equal(DOMAIN_REGISTER.code, undefined, 'code is not a prose register');
   assert.equal(DOMAIN_REGISTER.german, undefined, 'non-English domains are out of scope');
+});
+
+
+// ── Corpus listing ─────────────────────────────────────────────────────
+
+test('list prints observed mixed registers after the preferred register order', () => {
+  const manifest = {
+    version: 1,
+    documents: [
+      {
+        id: 'blog-one',
+        year: 2020,
+        register: 'blog',
+        words: 100,
+        source: { type: 'local', path: '/missing/blog-one.txt', license: 'test' },
+      },
+      {
+        id: 'raid-en',
+        year: 2026,
+        register: 'mixed',
+        words: 0,
+        source: { type: 'local', path: '/missing/raid-en.txt', license: 'test' },
+      },
+      {
+        id: 'hc3-en',
+        year: 2026,
+        register: 'mixed',
+        words: 0,
+        source: { type: 'local', path: '/missing/hc3-en.txt', license: 'test' },
+      },
+    ],
+  };
+
+  const lines = [];
+  const originalLog = console.log;
+  console.log = (...args) => lines.push(args.join(' '));
+  try {
+    assert.equal(cmdList(manifest), 0);
+  } finally {
+    console.log = originalLog;
+  }
+
+  const output = lines.join('\n');
+  assert.ok(output.includes('3 document(s) across 2 register(s)'));
+  assert.ok(output.includes('  blog  (1 docs, 100 words)'));
+  assert.ok(output.includes('  mixed  (2 docs, 0 words)'));
+  assert.ok(output.indexOf('  blog  ') < output.indexOf('  mixed  '));
+  assert.ok(output.includes('raid-en'));
+  assert.ok(output.includes('hc3-en'));
+
+  const printedRows = ['blog-one', 'raid-en', 'hc3-en'].filter((id) =>
+    output.includes(id)
+  );
+  assert.equal(printedRows.length, manifest.documents.length);
+  assert.ok(output.includes('registers with no coverage yet: technical-blog'));
 });
 
 // ── Hashing ────────────────────────────────────────────────────────────

--- a/scripts/corpus.test.js
+++ b/scripts/corpus.test.js
@@ -197,16 +197,30 @@ test('raid: only defensible registers are mapped', () => {
 
 // ── Corpus listing ─────────────────────────────────────────────────────
 
-test('list prints observed mixed registers after the preferred register order', () => {
+test('list preserves preferred register order and sorts observed extras', () => {
   const manifest = {
     version: 1,
     documents: [
+      {
+        id: 'academic-one',
+        year: 2021,
+        register: 'academic',
+        words: 80,
+        source: { type: 'local', path: '/missing/academic-one.txt', license: 'test' },
+      },
       {
         id: 'blog-one',
         year: 2020,
         register: 'blog',
         words: 100,
         source: { type: 'local', path: '/missing/blog-one.txt', license: 'test' },
+      },
+      {
+        id: 'zeta-extra',
+        year: 2026,
+        register: 'zeta',
+        words: 0,
+        source: { type: 'local', path: '/missing/zeta.txt', license: 'test' },
       },
       {
         id: 'raid-en',
@@ -222,6 +236,13 @@ test('list prints observed mixed registers after the preferred register order', 
         words: 0,
         source: { type: 'local', path: '/missing/hc3-en.txt', license: 'test' },
       },
+      {
+        id: 'alpha-extra',
+        year: 2026,
+        register: 'alpha-extra',
+        words: 0,
+        source: { type: 'local', path: '/missing/alpha.txt', license: 'test' },
+      },
     ],
   };
 
@@ -235,17 +256,30 @@ test('list prints observed mixed registers after the preferred register order', 
   }
 
   const output = lines.join('\n');
-  assert.ok(output.includes('3 document(s) across 2 register(s)'));
-  assert.ok(output.includes('  blog  (1 docs, 100 words)'));
-  assert.ok(output.includes('  mixed  (2 docs, 0 words)'));
-  assert.ok(output.indexOf('  blog  ') < output.indexOf('  mixed  '));
-  assert.ok(output.includes('raid-en'));
-  assert.ok(output.includes('hc3-en'));
+  assert.ok(output.includes('6 document(s) across 5 register(s)'));
 
-  const printedRows = ['blog-one', 'raid-en', 'hc3-en'].filter((id) =>
-    output.includes(id)
-  );
-  assert.equal(printedRows.length, manifest.documents.length);
+  const blogPos = output.indexOf('  blog  ');
+  const academicPos = output.indexOf('  academic  ');
+  const alphaPos = output.indexOf('  alpha-extra  ');
+  const mixedPos = output.indexOf('  mixed  ');
+  const zetaPos = output.indexOf('  zeta  ');
+
+  assert.ok(blogPos !== -1 && academicPos !== -1);
+  assert.ok(blogPos < academicPos, 'accepted registers keep REGISTERS order');
+  assert.ok(academicPos < alphaPos, 'extra registers come after accepted registers');
+  assert.ok(alphaPos < mixedPos && mixedPos < zetaPos, 'extra registers sort alphabetically');
+
+  for (const id of [
+    'academic-one',
+    'blog-one',
+    'zeta-extra',
+    'raid-en',
+    'hc3-en',
+    'alpha-extra',
+  ]) {
+    assert.ok(output.includes(id), `missing printed row for ${id}`);
+  }
+
   assert.ok(output.includes('registers with no coverage yet: technical-blog'));
 });
 


### PR DESCRIPTION
Closes #172

## What changed

- make `corpus.js list` print every register present in the manifest;
- preserve the existing preferred order for accepted human registers;
- append observed extra registers, such as `mixed`, in deterministic alphabetical order;
- leave `add-local --register` validation unchanged;
- add focused coverage for mixed-register output, row/header consistency, preferred ordering, and missing accepted-register reporting.

## Why

The manifest can contain dataset bundles in a `mixed` register, but the list command only iterated the fixed accepted-human register list. That caused the header count to report more documents than the command actually printed.

## Verification

The change is scoped to `scripts/corpus.js` and `scripts/corpus.test.js`. I did not run `npm test` in this environment, so I am not claiming a local pass; repository CI can provide the final execution validation.