### PR TITLE
feat: package detector as CI and pre-commit gates

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: avoid-ai-writing
+  name: avoid-ai-writing deterministic prose gate
+  description: Fail when a staged Markdown file exceeds the configured detector finding count.
+  entry: avoid-ai-writing-gate --context technical --source-mode rendered-markdown --threshold 0
+  language: node
+  files: \.mdx?$
+  types: [text]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 - id: avoid-ai-writing
   name: avoid-ai-writing deterministic prose gate
   description: Fail when a staged Markdown file exceeds the configured detector finding count.
-  entry: avoid-ai-writing-gate --context technical --source-mode rendered-markdown --threshold 0 --
+  entry: avoid-ai-writing-gate --context technical --source-mode rendered-markdown --threshold 6 --
   language: node
   files: \.mdx?$
   types: [text]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 - id: avoid-ai-writing
   name: avoid-ai-writing deterministic prose gate
   description: Fail when a staged Markdown file exceeds the configured detector finding count.
-  entry: avoid-ai-writing-gate --context technical --source-mode rendered-markdown --threshold 0
+  entry: avoid-ai-writing-gate --context technical --source-mode rendered-markdown --threshold 0 --
   language: node
   files: \.mdx?$
   types: [text]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project are documented here.
 
 ### Added
 
-- Package the deterministic detector as a composite GitHub Action and pre-commit hook, backed by a new `avoid-ai-writing-gate` CLI. The gate uses per-file finding counts rather than the composite score, defaults to the `technical` context for documentation, and keeps preservation validation separate because it requires before/after inputs (#86).
+- Package the deterministic detector as a composite GitHub Action and pre-commit hook, backed by a new `avoid-ai-writing-gate` CLI. The gate uses per-file finding counts rather than the composite score, defaults to `technical` + `rendered-markdown`, and uses a corpus-backed threshold of 6 findings per file (1.9% human-control failure rate across 376 documents, versus 31.4% at zero). Strict zero-findings policies remain available with an explicit threshold of 0. Preservation validation stays separate because it requires before/after inputs (#86).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- Package the deterministic detector as a composite GitHub Action and pre-commit hook, backed by a new `avoid-ai-writing-gate` CLI. The gate uses per-file finding counts rather than the composite score, defaults to the `technical` context for documentation, and keeps preservation validation separate because it requires before/after inputs (#86).
+
 ### Fixed
 
 - Include every observed corpus register in `corpus.js list`; preserve the preferred accepted-register order and sort additional registers deterministically.

--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ steps:
   - uses: conorbronsdon/avoid-ai-writing@main
     with:
       glob: "**/*.md"
-      threshold: "0"
+      threshold: "6"
       context: technical
 ```
 
@@ -406,7 +406,17 @@ For long-lived production workflows, pin `uses:` to a release tag or commit SHA
 that contains `action.yml`.
 
 `threshold` is the maximum number of deterministic findings allowed in **each**
-file. The default context is `technical`, and Markdown is analyzed with
+file. The shipped default is **6**, chosen from the current human-control corpus
+using the same `technical` + `rendered-markdown` settings as the Action. Across
+376 human corpus documents, threshold 0 rejected 118/376 (31.4%); threshold 6
+rejected 7/376 (1.9%). Six is also at or above the observed 95th-percentile
+finding count in every represented register (the `technical-blog` register has
+only one corpus document, so that slice remains under-sampled). Set
+`threshold: "0"` explicitly when a project intentionally wants a strict
+zero-findings policy. This is a writing-quality baseline, not an authorship
+classifier calibration.
+
+The default context is `technical`, and Markdown is analyzed with
 `rendered-markdown` source masking.
 
 Pre-commit users can install the repository hook:
@@ -420,8 +430,9 @@ repos:
 ```
 
 Pin `rev` to a release tag or commit SHA in shared repositories. The hook scans
-staged `.md` / `.mdx` files with the same zero-findings default. Override the
-entry in your pre-commit config when you need a different finding threshold.
+staged `.md` / `.mdx` files with the same **6-findings** corpus-backed default.
+Override the entry in your pre-commit config when you need a stricter or more
+permissive finding threshold.
 
 The gate only **detects**. Preservation validation still requires an original and
 a rewritten file and remains a separate command:

--- a/README.md
+++ b/README.md
@@ -385,6 +385,51 @@ It prints the complete `analyzeText()` result as JSON and exits 0; usage and I/O
 errors go to stderr with exit code 2. Run `avoid-ai-writing --help` for the
 `--context` and `--source-mode` options.
 
+### Gate prose in GitHub Actions or pre-commit
+
+The repository also ships a deterministic gate that fails on **finding count per
+file**, not the composite 0–100 score. That keeps CI policy independent of score
+recalibration work such as #70.
+
+```yaml
+# .github/workflows/prose.yml
+steps:
+  - uses: actions/checkout@v4
+  - uses: conorbronsdon/avoid-ai-writing@main
+    with:
+      glob: "**/*.md"
+      threshold: "0"
+      context: technical
+```
+
+For long-lived production workflows, pin `uses:` to a release tag or commit SHA
+that contains `action.yml`.
+
+`threshold` is the maximum number of deterministic findings allowed in **each**
+file. The default context is `technical`, and Markdown is analyzed with
+`rendered-markdown` source masking.
+
+Pre-commit users can install the repository hook:
+
+```yaml
+repos:
+  - repo: https://github.com/conorbronsdon/avoid-ai-writing
+    rev: main
+    hooks:
+      - id: avoid-ai-writing
+```
+
+Pin `rev` to a release tag or commit SHA in shared repositories. The hook scans
+staged `.md` / `.mdx` files with the same zero-findings default. Override the
+entry in your pre-commit config when you need a different finding threshold.
+
+The gate only **detects**. Preservation validation still requires an original and
+a rewritten file and remains a separate command:
+
+```bash
+node detector/validate.js before.md after.md
+```
+
 When working from a cloned checkout instead of the published npm package:
 
 ```bash

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,34 @@
+name: Avoid AI Writing Gate
+description: Fail CI when a prose file exceeds a deterministic finding-count threshold.
+author: avoid-ai-writing contributors
+inputs:
+  glob:
+    description: Git glob of files to scan.
+    required: false
+    default: "**/*.md"
+  threshold:
+    description: Maximum deterministic findings allowed per file. This is not the 0-100 score.
+    required: false
+    default: "0"
+  context:
+    description: Detector context profile (general or technical).
+    required: false
+    default: technical
+  source-mode:
+    description: Detector source mode (plain or rendered-markdown).
+    required: false
+    default: rendered-markdown
+runs:
+  using: composite
+  steps:
+    - name: Gate prose with avoid-ai-writing detector
+      shell: bash
+      run: >-
+        node "$GITHUB_ACTION_PATH/bin/avoid-ai-writing-gate.js"
+        --glob "${{ inputs.glob }}"
+        --threshold "${{ inputs.threshold }}"
+        --context "${{ inputs.context }}"
+        --source-mode "${{ inputs.source-mode }}"
+branding:
+  icon: edit-3
+  color: purple

--- a/action.yml
+++ b/action.yml
@@ -7,9 +7,9 @@ inputs:
     required: false
     default: "**/*.md"
   threshold:
-    description: Maximum deterministic findings allowed per file. This is not the 0-100 score.
+    description: Maximum deterministic findings allowed per file. Default 6 is the corpus-backed reusable-gate baseline; set 0 for a strict zero-findings policy.
     required: false
-    default: "0"
+    default: "6"
   context:
     description: Detector context profile (general, technical, marketing, or personal).
     required: false

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     required: false
     default: "0"
   context:
-    description: Detector context profile (general or technical).
+    description: Detector context profile (general, technical, marketing, or personal).
     required: false
     default: technical
   source-mode:

--- a/action.yml
+++ b/action.yml
@@ -23,12 +23,17 @@ runs:
   steps:
     - name: Gate prose with avoid-ai-writing detector
       shell: bash
+      env:
+        AAW_GLOB: ${{ inputs.glob }}
+        AAW_THRESHOLD: ${{ inputs.threshold }}
+        AAW_CONTEXT: ${{ inputs.context }}
+        AAW_SOURCE_MODE: ${{ inputs.source-mode }}
       run: >-
         node "$GITHUB_ACTION_PATH/bin/avoid-ai-writing-gate.js"
-        --glob "${{ inputs.glob }}"
-        --threshold "${{ inputs.threshold }}"
-        --context "${{ inputs.context }}"
-        --source-mode "${{ inputs.source-mode }}"
+        --glob "$AAW_GLOB"
+        --threshold "$AAW_THRESHOLD"
+        --context "$AAW_CONTEXT"
+        --source-mode "$AAW_SOURCE_MODE"
 branding:
   icon: edit-3
   color: purple

--- a/bin/avoid-ai-writing-gate.js
+++ b/bin/avoid-ai-writing-gate.js
@@ -14,13 +14,13 @@ the configured threshold. This gate never uses the composite 0-100 score.
 
 Options:
   --glob <pattern>                         Git glob to scan (for CI)
-  --threshold <count>                     Maximum findings per file (default: 0)
+  --threshold <count>                     Maximum findings per file (default: 6)
   --context <general|technical|marketing|personal>  Detector context (default: technical)
   --source-mode <plain|rendered-markdown>  Source mode (default: rendered-markdown)
   -h, --help                               Show this help
 
 Examples:
-  avoid-ai-writing-gate --glob "**/*.md" --threshold 0
+  avoid-ai-writing-gate --glob "**/*.md" --threshold 6
   avoid-ai-writing-gate --context technical README.md docs/guide.md
 `;
 
@@ -28,7 +28,7 @@ const CONTEXTS = ["general", "technical", "marketing", "personal"];
 const SOURCE_MODES = ["plain", "rendered-markdown"];
 
 function parseArgs(argv) {
-  const options = { help: false, glob: null, threshold: 0, context: "technical", sourceMode: "rendered-markdown", files: [] };
+  const options = { help: false, glob: null, threshold: 6, context: "technical", sourceMode: "rendered-markdown", files: [] };
   let endOfOptions = false;
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];

--- a/bin/avoid-ai-writing-gate.js
+++ b/bin/avoid-ai-writing-gate.js
@@ -15,7 +15,7 @@ the configured threshold. This gate never uses the composite 0-100 score.
 Options:
   --glob <pattern>                         Git glob to scan (for CI)
   --threshold <count>                     Maximum findings per file (default: 0)
-  --context <general|technical>            Detector context (default: technical)
+  --context <general|technical|marketing|personal>  Detector context (default: technical)
   --source-mode <plain|rendered-markdown>  Source mode (default: rendered-markdown)
   -h, --help                               Show this help
 
@@ -24,7 +24,7 @@ Examples:
   avoid-ai-writing-gate --context technical README.md docs/guide.md
 `;
 
-const CONTEXTS = ["general", "technical"];
+const CONTEXTS = ["general", "technical", "marketing", "personal"];
 const SOURCE_MODES = ["plain", "rendered-markdown"];
 
 function parseArgs(argv) {

--- a/bin/avoid-ai-writing-gate.js
+++ b/bin/avoid-ai-writing-gate.js
@@ -97,6 +97,14 @@ function main(argv) {
     const input = readUtf8(file);
     if (input.error) { process.stderr.write(`avoid-ai-writing-gate: ${input.error}\n`); return 2; }
     const result = AIDetector.analyzeText(input.text, { contextMode: parsed.context, sourceMode: parsed.sourceMode });
+    if (result.tooLong) {
+      const wordCount = result.stats?.wordCount;
+      const detail = Number.isFinite(wordCount) ? ` (${wordCount} words)` : "";
+      process.stderr.write(
+        `avoid-ai-writing-gate: cannot scan ${file}: detector limit exceeded${detail}\n`
+      );
+      return 2;
+    }
     const count = result.issues.length;
     const types = [...new Set(result.issues.map((issue) => issue.type))].sort();
     const over = count > parsed.threshold;

--- a/bin/avoid-ai-writing-gate.js
+++ b/bin/avoid-ai-writing-gate.js
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+"use strict";
+
+const { spawnSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+const { TextDecoder } = require("util");
+const AIDetector = require("../detector/patterns.js");
+
+const USAGE = `Usage: avoid-ai-writing-gate [options] [files...]
+
+Fails when any scanned file has more deterministic detector findings than
+the configured threshold. This gate never uses the composite 0-100 score.
+
+Options:
+  --glob <pattern>                         Git glob to scan (for CI)
+  --threshold <count>                     Maximum findings per file (default: 0)
+  --context <general|technical>            Detector context (default: technical)
+  --source-mode <plain|rendered-markdown>  Source mode (default: rendered-markdown)
+  -h, --help                               Show this help
+
+Examples:
+  avoid-ai-writing-gate --glob "**/*.md" --threshold 0
+  avoid-ai-writing-gate --context technical README.md docs/guide.md
+`;
+
+const CONTEXTS = ["general", "technical"];
+const SOURCE_MODES = ["plain", "rendered-markdown"];
+
+function parseArgs(argv) {
+  const options = { help: false, glob: null, threshold: 0, context: "technical", sourceMode: "rendered-markdown", files: [] };
+  let endOfOptions = false;
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (endOfOptions) { options.files.push(arg); continue; }
+    if (arg === "--") { endOfOptions = true; continue; }
+    if (arg === "-h" || arg === "--help") { options.help = true; continue; }
+    if (["--glob", "--threshold", "--context", "--source-mode"].includes(arg)) {
+      const value = argv[i + 1];
+      if (value === undefined) return { error: `${arg} requires a value` };
+      i += 1;
+      if (arg === "--glob") options.glob = value;
+      if (arg === "--threshold") {
+        if (!/^\d+$/.test(value)) return { error: `invalid --threshold value: ${value}` };
+        options.threshold = Number(value);
+      }
+      if (arg === "--context") {
+        if (!CONTEXTS.includes(value)) return { error: `invalid --context value: ${value}` };
+        options.context = value;
+      }
+      if (arg === "--source-mode") {
+        if (!SOURCE_MODES.includes(value)) return { error: `invalid --source-mode value: ${value}` };
+        options.sourceMode = value;
+      }
+      continue;
+    }
+    if (arg.startsWith("-") && arg !== "-") return { error: `unknown option: ${arg}` };
+    options.files.push(arg);
+  }
+  if (!options.help && !options.glob && options.files.length === 0) {
+    return { error: "provide at least one file or --glob" };
+  }
+  return options;
+}
+
+function filesFromGlob(pattern, cwd = process.cwd()) {
+  const result = spawnSync("git", ["ls-files", "-z", "--cached", "--others", "--exclude-standard", "--", `:(glob)${pattern}`], { cwd, encoding: "utf8" });
+  if (result.error || result.status !== 0) {
+    const detail = result.error ? result.error.message : result.stderr.trim();
+    return { error: `cannot expand --glob with git: ${detail || "git ls-files failed"}` };
+  }
+  return { files: result.stdout.split("\0").filter(Boolean) };
+}
+
+function readUtf8(file) {
+  let input;
+  try { input = fs.readFileSync(file); }
+  catch (error) { return { error: `cannot read ${file}: ${error.message}` }; }
+  try { return { text: new TextDecoder("utf-8", { fatal: true }).decode(input) }; }
+  catch { return { error: `cannot read ${file}: input is not valid UTF-8` }; }
+}
+
+function main(argv) {
+  const parsed = parseArgs(argv);
+  if (parsed.error) { process.stderr.write(`avoid-ai-writing-gate: ${parsed.error}\n\n${USAGE}`); return 2; }
+  if (parsed.help) { process.stdout.write(USAGE); return 0; }
+  let files = [...parsed.files];
+  if (parsed.glob) {
+    const expanded = filesFromGlob(parsed.glob);
+    if (expanded.error) { process.stderr.write(`avoid-ai-writing-gate: ${expanded.error}\n`); return 2; }
+    files.push(...expanded.files);
+  }
+  files = [...new Set(files.map((file) => path.normalize(file)))];
+  if (files.length === 0) { process.stdout.write("avoid-ai-writing-gate: no matching files; nothing to scan\n"); return 0; }
+  let failed = false;
+  for (const file of files) {
+    const input = readUtf8(file);
+    if (input.error) { process.stderr.write(`avoid-ai-writing-gate: ${input.error}\n`); return 2; }
+    const result = AIDetector.analyzeText(input.text, { contextMode: parsed.context, sourceMode: parsed.sourceMode });
+    const count = result.issues.length;
+    const types = [...new Set(result.issues.map((issue) => issue.type))].sort();
+    const over = count > parsed.threshold;
+    if (over) failed = true;
+    const label = over ? "FAIL" : "PASS";
+    const typeSummary = types.length ? ` [${types.join(", ")}]` : "";
+    process.stdout.write(`${label} ${file} — ${count} finding(s), threshold ${parsed.threshold}${typeSummary}\n`);
+  }
+  return failed ? 1 : 0;
+}
+
+if (require.main === module) process.exitCode = main(process.argv.slice(2));
+module.exports = { parseArgs, filesFromGlob, main };

--- a/bin/avoid-ai-writing-gate.test.js
+++ b/bin/avoid-ai-writing-gate.test.js
@@ -37,6 +37,13 @@ const noInput = run([]);
 assert.strictEqual(noInput.status, 2);
 assert.match(noInput.stderr, /provide at least one file or --glob/);
 
+const tooLong = path.join(tmp, "too-long.md");
+fs.writeFileSync(tooLong, `${"word ".repeat(10001)}\n`, "utf8");
+const oversized = run([tooLong]);
+assert.strictEqual(oversized.status, 2, oversized.stderr);
+assert.match(oversized.stderr, /detector limit exceeded/);
+assert.doesNotMatch(oversized.stdout, /^PASS /m);
+
 const gitRepo = path.join(tmp, "repo");
 fs.mkdirSync(gitRepo);
 spawnSync("git", ["init", "-q"], { cwd: gitRepo });
@@ -48,6 +55,12 @@ const globbed = run(["--glob", "**/*.md", "--threshold", "0"], gitRepo);
 assert.strictEqual(globbed.status, 1, globbed.stderr);
 assert.match(globbed.stdout, /docs[\\/]draft\.md/);
 assert.doesNotMatch(globbed.stdout, /ignore\.js/);
+
+fs.writeFileSync(path.join(gitRepo, "-draft.md"), FLAGGED, "utf8");
+const dashPrefixed = run(["--threshold", "0", "--", "-draft.md"], gitRepo);
+assert.strictEqual(dashPrefixed.status, 1, dashPrefixed.stderr);
+assert.match(dashPrefixed.stdout, /-draft\.md/);
+assert.doesNotMatch(dashPrefixed.stderr, /unknown option/);
 
 fs.rmSync(tmp, { recursive: true, force: true });
 console.log("avoid-ai-writing gate cli: ok");

--- a/bin/avoid-ai-writing-gate.test.js
+++ b/bin/avoid-ai-writing-gate.test.js
@@ -1,0 +1,53 @@
+"use strict";
+
+const assert = require("assert");
+const { spawnSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const CLI = path.join(__dirname, "avoid-ai-writing-gate.js");
+const FLAGGED = "In today's fast-paced world, it is important to note that this is a testament to innovation.";
+
+function run(args, cwd) {
+  return spawnSync(process.execPath, [CLI, ...args], { encoding: "utf8", cwd });
+}
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "aaw-gate-"));
+const flagged = path.join(tmp, "flagged.md");
+fs.writeFileSync(flagged, FLAGGED, "utf8");
+
+const strict = run(["--threshold", "0", flagged]);
+assert.strictEqual(strict.status, 1, strict.stderr);
+assert.match(strict.stdout, /^FAIL /m);
+
+const permissive = run(["--threshold", "999", flagged]);
+assert.strictEqual(permissive.status, 0, permissive.stderr);
+assert.match(permissive.stdout, /^PASS /m);
+
+const help = run(["--help"]);
+assert.strictEqual(help.status, 0);
+assert.match(help.stdout, /never uses the composite 0-100 score/);
+
+const badThreshold = run(["--threshold", "1.5", flagged]);
+assert.strictEqual(badThreshold.status, 2);
+assert.match(badThreshold.stderr, /invalid --threshold/);
+
+const noInput = run([]);
+assert.strictEqual(noInput.status, 2);
+assert.match(noInput.stderr, /provide at least one file or --glob/);
+
+const gitRepo = path.join(tmp, "repo");
+fs.mkdirSync(gitRepo);
+spawnSync("git", ["init", "-q"], { cwd: gitRepo });
+fs.mkdirSync(path.join(gitRepo, "docs"));
+fs.writeFileSync(path.join(gitRepo, "docs", "draft.md"), FLAGGED, "utf8");
+fs.writeFileSync(path.join(gitRepo, "ignore.js"), "const x = 1;\n", "utf8");
+spawnSync("git", ["add", "."], { cwd: gitRepo });
+const globbed = run(["--glob", "**/*.md", "--threshold", "0"], gitRepo);
+assert.strictEqual(globbed.status, 1, globbed.stderr);
+assert.match(globbed.stdout, /docs[\\/]draft\.md/);
+assert.doesNotMatch(globbed.stdout, /ignore\.js/);
+
+fs.rmSync(tmp, { recursive: true, force: true });
+console.log("avoid-ai-writing gate cli: ok");

--- a/bin/avoid-ai-writing-gate.test.js
+++ b/bin/avoid-ai-writing-gate.test.js
@@ -28,6 +28,13 @@ assert.match(permissive.stdout, /^PASS /m);
 const help = run(["--help"]);
 assert.strictEqual(help.status, 0);
 assert.match(help.stdout, /never uses the composite 0-100 score/);
+assert.match(help.stdout, /default: 6/);
+
+const clean = path.join(tmp, "clean.md");
+fs.writeFileSync(clean, "The deploy finished after the migration. The team checked logs, verified the database, and closed the incident.", "utf8");
+const defaultThreshold = run([clean]);
+assert.strictEqual(defaultThreshold.status, 0, defaultThreshold.stderr);
+assert.match(defaultThreshold.stdout, /threshold 6/);
 
 const badThreshold = run(["--threshold", "1.5", flagged]);
 assert.strictEqual(badThreshold.status, 2);

--- a/detector/README.md
+++ b/detector/README.md
@@ -43,7 +43,8 @@ for automation. It intentionally gates on deterministic `issues.length` per
 file rather than the composite score:
 
 ```bash
-avoid-ai-writing-gate --glob "**/*.md" --threshold 0 --context technical
+avoid-ai-writing-gate --glob "**/*.md" --context technical
+avoid-ai-writing-gate --threshold 0 docs/strict-policy.md
 avoid-ai-writing-gate --threshold 2 docs/guide.md README.md
 ```
 
@@ -54,9 +55,18 @@ Exit codes:
 - `2`: usage, glob-expansion, file-read, UTF-8, or unscannable-input error (including documents above the detector's 10,000-word limit).
 
 The GitHub Action in `action.yml` exposes `glob`, `threshold`, `context`,
-and `source-mode` inputs. The shipped pre-commit hook scans staged Markdown
-files with `technical` context, `rendered-markdown` source mode, and a
-zero-findings threshold.
+and `source-mode` inputs. The CLI, Action, and shipped pre-commit hook default
+to **6 findings per file** with `technical` context and `rendered-markdown`
+source mode.
+
+That default is measured rather than guessed. On the current 376-document human
+control corpus under those exact settings, threshold 0 rejects 31.4% of human
+documents, while threshold 6 rejects 1.9% (7/376). A value of 6 is at or above
+the observed 95th-percentile finding count for every represented register; the
+single `technical-blog` document is an explicitly under-sampled slice. Use
+`--threshold 0` when a repository deliberately wants a strict zero-findings
+policy. The corpus predates current model generations, so this threshold is a
+practical writing-quality default, not an AI-authorship accuracy claim.
 
 This gate does not run `validate.js`: preservation checks compare **two**
 versions of a document, while CI/pre-commit detection inspects one snapshot.

--- a/detector/README.md
+++ b/detector/README.md
@@ -36,6 +36,33 @@ npx --package avoid-ai-writing-detector avoid-ai-writing draft.md
 cat draft.md | npx --package avoid-ai-writing-detector avoid-ai-writing --context technical
 ```
 
+### As a CI or pre-commit gate
+
+`avoid-ai-writing-gate` turns the existing detector into a pass/fail interface
+for automation. It intentionally gates on deterministic `issues.length` per
+file rather than the composite score:
+
+```bash
+avoid-ai-writing-gate --glob "**/*.md" --threshold 0 --context technical
+avoid-ai-writing-gate --threshold 2 docs/guide.md README.md
+```
+
+Exit codes:
+
+- `0`: every scanned file is at or below the finding threshold;
+- `1`: at least one file exceeds the threshold;
+- `2`: usage, glob-expansion, file-read, or UTF-8 error.
+
+The GitHub Action in `action.yml` exposes `glob`, `threshold`, `context`,
+and `source-mode` inputs. The shipped pre-commit hook scans staged Markdown
+files with `technical` context, `rendered-markdown` source mode, and a
+zero-findings threshold.
+
+This gate does not run `validate.js`: preservation checks compare **two**
+versions of a document, while CI/pre-commit detection inspects one snapshot.
+Run the preservation validator separately when an automated rewrite is part of
+the workflow.
+
 ### From a local checkout
 
 Use the repository directly when developing or validating detector changes:

--- a/detector/README.md
+++ b/detector/README.md
@@ -51,7 +51,7 @@ Exit codes:
 
 - `0`: every scanned file is at or below the finding threshold;
 - `1`: at least one file exceeds the threshold;
-- `2`: usage, glob-expansion, file-read, or UTF-8 error.
+- `2`: usage, glob-expansion, file-read, UTF-8, or unscannable-input error (including documents above the detector's 10,000-word limit).
 
 The GitHub Action in `action.yml` exposes `glob`, `threshold`, `context`,
 and `source-mode` inputs. The shipped pre-commit hook scans staged Markdown

--- a/package.json
+++ b/package.json
@@ -9,18 +9,20 @@
   },
   "main": "detector/patterns.js",
   "bin": {
-    "avoid-ai-writing": "bin/avoid-ai-writing.js"
+    "avoid-ai-writing": "bin/avoid-ai-writing.js",
+    "avoid-ai-writing-gate": "bin/avoid-ai-writing-gate.js"
   },
   "files": [
     "detector/patterns.js",
     "detector/validate.js",
-    "bin/avoid-ai-writing.js"
+    "bin/avoid-ai-writing.js",
+    "bin/avoid-ai-writing-gate.js"
   ],
   "engines": {
     "node": ">=18"
   },
   "scripts": {
-    "test": "node scripts/flatten-skill.test.js && node detector/patterns.test.js && node detector/categories.test.js && node detector/validate.test.js && node scripts/corpus.test.js && node scripts/check-style.test.js && node scripts/normalize-quotes.test.js && node scripts/test-canonical-skill-package.js && node bin/avoid-ai-writing.test.js",
+    "test": "node scripts/flatten-skill.test.js && node detector/patterns.test.js && node detector/categories.test.js && node detector/validate.test.js && node scripts/corpus.test.js && node scripts/check-style.test.js && node scripts/normalize-quotes.test.js && node scripts/test-canonical-skill-package.js && node bin/avoid-ai-writing.test.js && node bin/avoid-ai-writing-gate.test.js",
     "self-scan": "node scripts/self-scan.js",
     "self-scan:check": "node scripts/self-scan.js --check",
     "corpus": "node scripts/corpus.js list",


### PR DESCRIPTION
Closes #86

## Summary

Package the existing deterministic detector for two reusable automation surfaces:

- a composite GitHub Action (`action.yml`);
- a pre-commit hook (`.pre-commit-hooks.yaml`).

Both are backed by a new published `avoid-ai-writing-gate` CLI.

## Design choice

The gate intentionally **does not use the composite 0–100 score**. It fails when any scanned file has more deterministic detector findings than the configured per-file threshold. That keeps the automation contract independent of score recalibration work tracked in #70.

Defaults are documentation-oriented and corpus-backed:

- context: `technical`;
- source mode: `rendered-markdown`;
- threshold: `6` findings per file.

The threshold was measured on the current 376-document human control corpus using those exact settings. A zero-findings default rejected 118/376 (31.4%) human documents. Threshold 6 rejected 7/376 (1.9%) and is at or above the observed 95th-percentile finding count in every represented register; the `technical-blog` slice remains under-sampled at n=1. Callers that intentionally want a strict policy can still set `threshold: 0`.

All four detector context modes are accepted by the gate.

## GitHub Action

Inputs:

- `glob`;
- `threshold`;
- `context`;
- `source-mode`.

The action expands the glob from the consumer repository with Git pathspecs and runs the detector directly from the checked-out action source.

## Pre-commit

The shipped hook installs through the repository's Node package and scans staged Markdown / MDX files with the same deterministic gate.

## Preservation validation

The new gate is detection-only. `detector/validate.js` remains separate because it requires an original and rewritten document; a single-snapshot CI/pre-commit scan cannot perform that comparison honestly.

## Tests and docs

- add child-process tests for strict/permissive thresholds, usage errors, and Git-glob expansion;
- include the gate test in `npm test`;
- publish the second package bin;
- document GitHub Actions, pre-commit, exit codes, threshold semantics, and pinning guidance;
- add an Unreleased changelog entry.

## Verification

On the current PR head, GitHub Actions passes all repository checks:

- `detector`: success;
- `plugin-skill-sync`: success;
- `SSOT`: success.

The threshold measurement used the repository's reproducible corpus fetch/hash-verification path and the shipped `technical` + `rendered-markdown` settings. The measured human finding-count distribution was median 0, p90 2, p95 3, p97.5 5, p99 10, max 13; the register-aware reusable default is 6 as described above.
