### PR TITLE
fix: retain max-size paragraph after heading

### DIFF
--- a/scripts/fp-measure.js
+++ b/scripts/fp-measure.js
@@ -95,7 +95,10 @@ function normalizeBlock(block) {
   // public-domain corpus.
   const nextLineContinuesSentence = lines.length > 1 && /^[a-z]/.test(lines[1]);
   if (lines.length > 1 && looksLikeHeading(lines[0]) && !nextLineContinuesSentence) {
-    return `${collapseWhitespace(lines[0])}\n${collapseWhitespace(lines.slice(1).join(' '))}`;
+    const heading = collapseWhitespace(lines[0]);
+    const body = collapseWhitespace(lines.slice(1).join(' '));
+    const joined = `${heading}\n${body}`;
+    return ((joined.match(/\S+/g) || []).length <= MAX_WORDS) ? joined : body;
   }
   return collapseWhitespace(block);
 }

--- a/scripts/fp-measure.js
+++ b/scripts/fp-measure.js
@@ -119,8 +119,13 @@ function splitUnits(text) {
     let unit = blocks[i];
     let words = (unit.match(/\S+/g) || []).length;
     if (words < MIN_WORDS && looksLikeHeading(unit) && i + 1 < blocks.length) {
-      unit = `${unit}\n${blocks[++i]}`;
-      words = (unit.match(/\S+/g) || []).length;
+      const combined = `${unit}\n${blocks[i + 1]}`;
+      const combinedWords = (combined.match(/\S+/g) || []).length;
+      if (combinedWords <= MAX_WORDS) {
+        unit = combined;
+        words = combinedWords;
+        i++;
+      }
     }
     if (words >= MIN_WORDS && words <= MAX_WORDS) units.push(unit);
   }

--- a/scripts/fp-measure.test.js
+++ b/scripts/fp-measure.test.js
@@ -65,5 +65,25 @@ for (const unit of ['document', 'paragraph']) {
   });
 }
 
+test('paragraph preprocessing retains a 400-word paragraph after a short heading', () => {
+  const paragraph = Array.from({ length: 400 }, (_, i) => `word${i}`).join(' ');
+  const standalone = unitsForText(paragraph, 'paragraph');
+  const afterHeading = unitsForText(`Context:\n\n${paragraph}`, 'paragraph');
+
+  assert.equal(standalone.length, 1);
+  assert.equal(afterHeading.length, 1);
+  assert.equal(afterHeading[0], paragraph);
+  assert.equal((afterHeading[0].match(/\S+/g) || []).length, 400);
+});
+
+test('paragraph preprocessing still attaches a short heading when the combined unit fits', () => {
+  const paragraph = Array.from({ length: 399 }, (_, i) => `word${i}`).join(' ');
+  const chunks = unitsForText(`Context:\n\n${paragraph}`, 'paragraph');
+
+  assert.equal(chunks.length, 1);
+  assert.ok(chunks[0].startsWith('Context:\n'));
+  assert.equal((chunks[0].match(/\S+/g) || []).length, 400);
+});
+
 console.log(`\n${failed === 0 ? 'all fp-measure tests passed' : `${failed} test(s) failed`}\n`);
 process.exit(failed === 0 ? 0 : 1);

--- a/scripts/fp-measure.test.js
+++ b/scripts/fp-measure.test.js
@@ -85,5 +85,25 @@ test('paragraph preprocessing still attaches a short heading when the combined u
   assert.equal((chunks[0].match(/\S+/g) || []).length, 400);
 });
 
+for (const heading of ['Context:', '## Context']) {
+  test(`paragraph preprocessing retains a 400-word paragraph after single-newline heading: ${heading}`, () => {
+    const paragraph = Array.from({ length: 400 }, (_, i) => `Word${i}`).join(' ');
+    const chunks = unitsForText(`${heading}\n${paragraph}`, 'paragraph');
+
+    assert.equal(chunks.length, 1);
+    assert.equal(chunks[0], paragraph);
+    assert.equal((chunks[0].match(/\S+/g) || []).length, 400);
+  });
+}
+
+test('paragraph preprocessing still attaches a single-newline heading when the combined unit fits', () => {
+  const paragraph = Array.from({ length: 399 }, (_, i) => `Word${i}`).join(' ');
+  const chunks = unitsForText(`Context:\n${paragraph}`, 'paragraph');
+
+  assert.equal(chunks.length, 1);
+  assert.ok(chunks[0].startsWith('Context:\n'));
+  assert.equal((chunks[0].match(/\S+/g) || []).length, 400);
+});
+
 console.log(`\n${failed === 0 ? 'all fp-measure tests passed' : `${failed} test(s) failed`}\n`);
 process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
Follow-up for #179 and the measurement blocker on #178.

## Problem

`splitUnits()` attached a short heading to the following block by incrementing `i` before checking the combined word count. A valid 400-word paragraph therefore disappeared from measurement when a one-word heading pushed the combined unit over `MAX_WORDS`.

## Fix

- compute the heading+paragraph candidate without consuming the next block;
- advance `i` only when the combined unit is within `MAX_WORDS`;
- otherwise leave the following paragraph untouched so the next loop iteration can measure it independently.

## Regression coverage

Added both sides of the boundary:

- a 400-word paragraph preceded by `Context:` remains one measurable 400-word unit and does not inherit the heading;
- a 399-word paragraph plus the one-word heading still combines into the intended 400-word unit.

## Validation

On exact head `32125528009f7d08066aa4c565f44e75a316d6b4` in my fork:

- `npm test` ✅
- `npm run self-scan:check` ✅
- detector workflow ✅

This PR intentionally targets the maintainer branch for #178 rather than `main`, so it only repairs the measurement work under review.