### PR TITLE
docs: document required pattern-count updates for rule changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,3 +11,4 @@
 - [ ] Any factual claim about how AI or humans write (e.g. "ChatGPT emits X", "humans rarely do Y") cites a source
 - [ ] The prose I added passes the skill's own audit (no AI-writing tells, terse bullets, no hollow intensifiers)
 - [ ] `CHANGELOG.md` entry added under a dated `## [X.Y.Z]` heading, and `SKILL.md` `version:` bumped if a rule changed
+- [ ] If I added or removed a detection `###` in `references/patterns.md`: the `**NN pattern categories**` bullet in `README.md` and the quoted count in `CLAUDE.md` match `scripts/check-pattern-count.sh`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Edit `SKILL.md` and `references/patterns.md` directly. When making changes:
 - Run `npm test` to exercise the detector, category contract, validator, corpus helpers, and style checks.
 - Add a dated entry to CHANGELOG.md
 - Update README.md if the change affects installation, usage, feature list, or pattern count
-- The pattern count lives in **one** place — the README "74 pattern categories" bullet — and is derived from references/patterns.md's detection `###` entries. Don't restate it elsewhere; CI (`scripts/check-pattern-count.sh`) fails the build if the README number drifts from references/patterns.md, so just add the new `###` entry and bump the README bullet.
+- The pattern count is canonical in the README "74 pattern categories" bullet (derived from references/patterns.md's detection `###` entries). This bullet quotes that number here as a **checked copy** for agent context — update README and this sentence when you add or remove a detection category. Don't restate the count elsewhere; CI (`scripts/check-pattern-count.sh`) fails if either literal drifts from `references/patterns.md`.
 
 ## Architecture of the skill
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,21 @@ If you are unsure which it is, open an issue first and we will sort it out.
 The [pattern proposal form](https://github.com/conorbronsdon/avoid-ai-writing/issues/new?template=pattern_proposal.yml)
 asks for what triage needs, including the example that must stay clean.
 
+### Pattern-category count (detection catalog)
+
+When you add or remove a detection `###` under `## What to remove or fix` in
+`references/patterns.md` (not judgment-only prose or writer-side tests), CI
+derives the new total and compares it to two literals:
+
+1. **`README.md`** — update the `**NN pattern categories**` feature bullet to
+   match the derived count.
+2. **`CLAUDE.md`** — update the quoted `README "NN pattern categories" bullet`
+   phrase in the pattern-count guidance so it matches the same number.
+
+`scripts/check-pattern-count.sh` enforces both on every PR. Adding a word-table
+row instead only requires bumping the separate `**NN-entry word replacement
+table**` README bullet (same script).
+
 ## Precision over recall
 
 This skill is deliberately biased toward false negatives: a rule that wrongly


### PR DESCRIPTION
## Summary

Documents the two pattern-count updates enforced by `scripts/check-pattern-count.sh` when detection `###` headings change: the README pattern-categories bullet and the matching checked phrase in `CLAUDE.md`. Also adds a PR template checklist item.

## Test plan

- [x] `scripts/check-pattern-count.sh`
- [x] `npm test`
- [x] `npm run self-scan:check`

Fixes #170