### PR TITLE
docs: name references/patterns.md in pattern-count checks

### DIFF
--- a/.github/workflows/plugin-skill-sync.yml
+++ b/.github/workflows/plugin-skill-sync.yml
@@ -78,7 +78,7 @@ jobs:
           python3 -m json.tool submission/discovery-evals.json > /dev/null
           python3 -m json.tool submission/submission-pack.json > /dev/null
 
-      - name: Check README pattern count matches SKILL.md
+      - name: Check README pattern count matches references/patterns.md
         run: bash scripts/check-pattern-count.sh
 
       - name: Regenerate bundled canonical resources

--- a/.github/workflows/promo-drift.yml
+++ b/.github/workflows/promo-drift.yml
@@ -84,7 +84,7 @@ jobs:
             cat report.md
             echo
             echo "Canonical is this repo. Fix the surfaces, not the README —"
-            echo "the README is already asserted against SKILL.md by"
+            echo "the README is already asserted against references/patterns.md by"
             echo "\`scripts/check-pattern-count.sh\`."
             echo
             echo "_Opened by [promo-drift](.github/workflows/promo-drift.yml)._"

--- a/.ssot.yaml
+++ b/.ssot.yaml
@@ -2,11 +2,11 @@
 #
 # There are two links in this chain and they are policed separately:
 #
-#   SKILL.md  ->  README.md          scripts/check-pattern-count.sh (every push)
-#   README.md ->  promo surfaces     this manifest (.github/workflows/promo-drift.yml)
+#   references/patterns.md  ->  README.md          scripts/check-pattern-count.sh (every push)
+#   README.md               ->  promo surfaces     this manifest (.github/workflows/promo-drift.yml)
 #
 # The first link derives the count from the catalog, so the README cannot lie
-# about SKILL.md. The second link is the one that actually rots: a release moves
+# about references/patterns.md. The second link is the one that actually rots: a release moves
 # the number here, the four surfaces below sit still, and nothing in *their*
 # repos changes — so no pre-commit hook over there can ever fire on it. That is
 # why this check is a release/cron job and not a hook.


### PR DESCRIPTION
## Summary

Aligns contributor-facing pattern-count wording with what `check-pattern-count.sh` actually reads: **`references/patterns.md`** (not `SKILL.md`).

- `.github/workflows/plugin-skill-sync.yml` step title
- `.github/workflows/promo-drift.yml` drift issue text
- `.ssot.yaml` diagram/prose

## Test plan

- [x] `npm test`
- [x] `npm run self-scan:check`

Fixes #169