### PR TITLE
docs: align contextMode comments with runtime behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ All notable changes to this project are documented here.
   voice-profile link that led to the triggering section.
 - Correct the `analyzeText()` result table in `detector/README.md`: the six score labels the
   engine returns, the `UNSCORED` classification on early-exit paths, and all four accepted `contextMode` values.
+- Align `contextMode` comments in `detector/patterns.js` and mode list in
+  `detector/CATEGORIES.md` with runtime behavior: four accepted modes, only
+  `technical` changes flagging (#173).
 
 ## [3.34.0] — 2026-09-11
 

--- a/detector/CATEGORIES.md
+++ b/detector/CATEGORIES.md
@@ -138,5 +138,7 @@ mistake their absence for a coverage gap:
 
 > **Partial:** the skill's **Context profiles / Tolerance matrix / Auto-detection
 > cues** are partly realized by the engine's `options.contextMode`
-> (`general` / `technical`), which suppresses context-inappropriate flags. Full
+> (`general`, `technical`, `marketing`, `personal`). Only `technical` currently
+> changes flagging (e.g. suppresses context-inappropriate flags); `marketing` and
+> `personal` are accepted and reported in stats but score like `general`. Full
 > profile-based tolerance remains an LLM-side judgment.

--- a/detector/patterns.js
+++ b/detector/patterns.js
@@ -1209,8 +1209,8 @@ const AIDetector = (() => {
   // ─── Title Case Section Headers in non-technical prose ─────────────
   // "Strategic Negotiations And Key Partnerships" — every content word
   // capitalized. Acceptable in API docs, ML papers, news headlines. Tell
-  // in marketing/personal/blog prose. Gated to "personal" / "marketing"
-  // context modes (technical mode skips this check).
+  // in marketing/personal/blog prose. Skipped when contextMode is
+  // 'technical'; runs for general, marketing, and personal.
   //
   // The optional `#{1,6}` prefix is load-bearing (#62): without it the `^[A-Z]`
   // anchor required the line to START with a capital, so `## Benefits And
@@ -1388,14 +1388,14 @@ const AIDetector = (() => {
       return { ...buildV2Defaults('UNSCORED', 'low'), score: 0, label: 'Empty', issues: [], stats: {}, tooShort: true };
     }
 
-    // Context mode gates rules that are noisy in technical writing. Modes:
+    // Context mode selects context-appropriate flagging. Accepted values:
     //   'general' (default) — full ruleset
     //   'technical' — skip title-case headers; individual prose-only rules
-    //                 apply their own technical-context gates
-    //   'marketing' — full ruleset + boost on formulaic-opener / future-narrative
-    //   'personal'  — full ruleset, normal weights
-    // Mode is purely a soft gate; nothing is silently suppressed without
-    // being reflected in stats.contextMode for transparency.
+    //                 apply their own technical-context gates (only mode
+    //                 that currently changes scoring)
+    //   'marketing' — accepted; recorded in stats; scores same as general
+    //   'personal'  — accepted; recorded in stats; scores same as general
+    // Invalid values fall back to 'general' with stats.contextModeFallback set.
     // Mode validation: an unknown string (e.g. typo "tecnical") would
     // otherwise silently downgrade to general-mode behavior. Coerce to
     // 'general' and surface the original value in stats for traceability.

--- a/plugins/avoid-ai-writing/skills/avoid-ai-writing/detector/CATEGORIES.md
+++ b/plugins/avoid-ai-writing/skills/avoid-ai-writing/detector/CATEGORIES.md
@@ -138,5 +138,7 @@ mistake their absence for a coverage gap:
 
 > **Partial:** the skill's **Context profiles / Tolerance matrix / Auto-detection
 > cues** are partly realized by the engine's `options.contextMode`
-> (`general` / `technical`), which suppresses context-inappropriate flags. Full
+> (`general`, `technical`, `marketing`, `personal`). Only `technical` currently
+> changes flagging (e.g. suppresses context-inappropriate flags); `marketing` and
+> `personal` are accepted and reported in stats but score like `general`. Full
 > profile-based tolerance remains an LLM-side judgment.

--- a/plugins/avoid-ai-writing/skills/avoid-ai-writing/detector/patterns.js
+++ b/plugins/avoid-ai-writing/skills/avoid-ai-writing/detector/patterns.js
@@ -1209,8 +1209,8 @@ const AIDetector = (() => {
   // ─── Title Case Section Headers in non-technical prose ─────────────
   // "Strategic Negotiations And Key Partnerships" — every content word
   // capitalized. Acceptable in API docs, ML papers, news headlines. Tell
-  // in marketing/personal/blog prose. Gated to "personal" / "marketing"
-  // context modes (technical mode skips this check).
+  // in marketing/personal/blog prose. Skipped when contextMode is
+  // 'technical'; runs for general, marketing, and personal.
   //
   // The optional `#{1,6}` prefix is load-bearing (#62): without it the `^[A-Z]`
   // anchor required the line to START with a capital, so `## Benefits And
@@ -1388,14 +1388,14 @@ const AIDetector = (() => {
       return { ...buildV2Defaults('UNSCORED', 'low'), score: 0, label: 'Empty', issues: [], stats: {}, tooShort: true };
     }
 
-    // Context mode gates rules that are noisy in technical writing. Modes:
+    // Context mode selects context-appropriate flagging. Accepted values:
     //   'general' (default) — full ruleset
     //   'technical' — skip title-case headers; individual prose-only rules
-    //                 apply their own technical-context gates
-    //   'marketing' — full ruleset + boost on formulaic-opener / future-narrative
-    //   'personal'  — full ruleset, normal weights
-    // Mode is purely a soft gate; nothing is silently suppressed without
-    // being reflected in stats.contextMode for transparency.
+    //                 apply their own technical-context gates (only mode
+    //                 that currently changes scoring)
+    //   'marketing' — accepted; recorded in stats; scores same as general
+    //   'personal'  — accepted; recorded in stats; scores same as general
+    // Invalid values fall back to 'general' with stats.contextModeFallback set.
     // Mode validation: an unknown string (e.g. typo "tecnical") would
     // otherwise silently downgrade to general-mode behavior. Coerce to
     // 'general' and surface the original value in stats for traceability.

--- a/skills/ai-writing-detector/scripts/patterns.js
+++ b/skills/ai-writing-detector/scripts/patterns.js
@@ -1209,8 +1209,8 @@ const AIDetector = (() => {
   // ─── Title Case Section Headers in non-technical prose ─────────────
   // "Strategic Negotiations And Key Partnerships" — every content word
   // capitalized. Acceptable in API docs, ML papers, news headlines. Tell
-  // in marketing/personal/blog prose. Gated to "personal" / "marketing"
-  // context modes (technical mode skips this check).
+  // in marketing/personal/blog prose. Skipped when contextMode is
+  // 'technical'; runs for general, marketing, and personal.
   //
   // The optional `#{1,6}` prefix is load-bearing (#62): without it the `^[A-Z]`
   // anchor required the line to START with a capital, so `## Benefits And
@@ -1388,14 +1388,14 @@ const AIDetector = (() => {
       return { ...buildV2Defaults('UNSCORED', 'low'), score: 0, label: 'Empty', issues: [], stats: {}, tooShort: true };
     }
 
-    // Context mode gates rules that are noisy in technical writing. Modes:
+    // Context mode selects context-appropriate flagging. Accepted values:
     //   'general' (default) — full ruleset
     //   'technical' — skip title-case headers; individual prose-only rules
-    //                 apply their own technical-context gates
-    //   'marketing' — full ruleset + boost on formulaic-opener / future-narrative
-    //   'personal'  — full ruleset, normal weights
-    // Mode is purely a soft gate; nothing is silently suppressed without
-    // being reflected in stats.contextMode for transparency.
+    //                 apply their own technical-context gates (only mode
+    //                 that currently changes scoring)
+    //   'marketing' — accepted; recorded in stats; scores same as general
+    //   'personal'  — accepted; recorded in stats; scores same as general
+    // Invalid values fall back to 'general' with stats.contextModeFallback set.
     // Mode validation: an unknown string (e.g. typo "tecnical") would
     // otherwise silently downgrade to general-mode behavior. Coerce to
     // 'general' and surface the original value in stats for traceability.

--- a/skills/avoid-ai-writing/detector/CATEGORIES.md
+++ b/skills/avoid-ai-writing/detector/CATEGORIES.md
@@ -138,5 +138,7 @@ mistake their absence for a coverage gap:
 
 > **Partial:** the skill's **Context profiles / Tolerance matrix / Auto-detection
 > cues** are partly realized by the engine's `options.contextMode`
-> (`general` / `technical`), which suppresses context-inappropriate flags. Full
+> (`general`, `technical`, `marketing`, `personal`). Only `technical` currently
+> changes flagging (e.g. suppresses context-inappropriate flags); `marketing` and
+> `personal` are accepted and reported in stats but score like `general`. Full
 > profile-based tolerance remains an LLM-side judgment.

--- a/skills/avoid-ai-writing/detector/patterns.js
+++ b/skills/avoid-ai-writing/detector/patterns.js
@@ -1209,8 +1209,8 @@ const AIDetector = (() => {
   // ─── Title Case Section Headers in non-technical prose ─────────────
   // "Strategic Negotiations And Key Partnerships" — every content word
   // capitalized. Acceptable in API docs, ML papers, news headlines. Tell
-  // in marketing/personal/blog prose. Gated to "personal" / "marketing"
-  // context modes (technical mode skips this check).
+  // in marketing/personal/blog prose. Skipped when contextMode is
+  // 'technical'; runs for general, marketing, and personal.
   //
   // The optional `#{1,6}` prefix is load-bearing (#62): without it the `^[A-Z]`
   // anchor required the line to START with a capital, so `## Benefits And
@@ -1388,14 +1388,14 @@ const AIDetector = (() => {
       return { ...buildV2Defaults('UNSCORED', 'low'), score: 0, label: 'Empty', issues: [], stats: {}, tooShort: true };
     }
 
-    // Context mode gates rules that are noisy in technical writing. Modes:
+    // Context mode selects context-appropriate flagging. Accepted values:
     //   'general' (default) — full ruleset
     //   'technical' — skip title-case headers; individual prose-only rules
-    //                 apply their own technical-context gates
-    //   'marketing' — full ruleset + boost on formulaic-opener / future-narrative
-    //   'personal'  — full ruleset, normal weights
-    // Mode is purely a soft gate; nothing is silently suppressed without
-    // being reflected in stats.contextMode for transparency.
+    //                 apply their own technical-context gates (only mode
+    //                 that currently changes scoring)
+    //   'marketing' — accepted; recorded in stats; scores same as general
+    //   'personal'  — accepted; recorded in stats; scores same as general
+    // Invalid values fall back to 'general' with stats.contextModeFallback set.
     // Mode validation: an unknown string (e.g. typo "tecnical") would
     // otherwise silently downgrade to general-mode behavior. Coerce to
     // 'general' and surface the original value in stats for traceability.

--- a/skills/preservation-verifier/scripts/patterns.js
+++ b/skills/preservation-verifier/scripts/patterns.js
@@ -1209,8 +1209,8 @@ const AIDetector = (() => {
   // ─── Title Case Section Headers in non-technical prose ─────────────
   // "Strategic Negotiations And Key Partnerships" — every content word
   // capitalized. Acceptable in API docs, ML papers, news headlines. Tell
-  // in marketing/personal/blog prose. Gated to "personal" / "marketing"
-  // context modes (technical mode skips this check).
+  // in marketing/personal/blog prose. Skipped when contextMode is
+  // 'technical'; runs for general, marketing, and personal.
   //
   // The optional `#{1,6}` prefix is load-bearing (#62): without it the `^[A-Z]`
   // anchor required the line to START with a capital, so `## Benefits And
@@ -1388,14 +1388,14 @@ const AIDetector = (() => {
       return { ...buildV2Defaults('UNSCORED', 'low'), score: 0, label: 'Empty', issues: [], stats: {}, tooShort: true };
     }
 
-    // Context mode gates rules that are noisy in technical writing. Modes:
+    // Context mode selects context-appropriate flagging. Accepted values:
     //   'general' (default) — full ruleset
     //   'technical' — skip title-case headers; individual prose-only rules
-    //                 apply their own technical-context gates
-    //   'marketing' — full ruleset + boost on formulaic-opener / future-narrative
-    //   'personal'  — full ruleset, normal weights
-    // Mode is purely a soft gate; nothing is silently suppressed without
-    // being reflected in stats.contextMode for transparency.
+    //                 apply their own technical-context gates (only mode
+    //                 that currently changes scoring)
+    //   'marketing' — accepted; recorded in stats; scores same as general
+    //   'personal'  — accepted; recorded in stats; scores same as general
+    // Invalid values fall back to 'general' with stats.contextModeFallback set.
     // Mode validation: an unknown string (e.g. typo "tecnical") would
     // otherwise silently downgrade to general-mode behavior. Coerce to
     // 'general' and surface the original value in stats for traceability.


### PR DESCRIPTION
## Summary

Aligns `contextMode` documentation with runtime:

- Documents all four accepted values (`general`, `technical`, `marketing`, `personal`)
- Clarifies only **`technical`** currently changes scoring; `marketing` / `personal` behave like `general` for flagging
- Updates `detector/patterns.js` comments, `detector/CATEGORIES.md`, synced plugin/skill mirrors, and CHANGELOG

## Test plan

- [x] `npm test`
- [x] `npm run self-scan:check`

Fixes #173