### PR TITLE
docs: integrate pattern-count guidance and reserve newcomer issues

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,3 +11,4 @@
 - [ ] Any factual claim about how AI or humans write (e.g. "ChatGPT emits X", "humans rarely do Y") cites a source
 - [ ] The prose I added passes the skill's own audit (no AI-writing tells, terse bullets, no hollow intensifiers)
 - [ ] `CHANGELOG.md` entry added under a dated `## [X.Y.Z]` heading, and `SKILL.md` `version:` bumped if a rule changed
+- [ ] If I added or removed a detection `###` in `references/patterns.md`: the `**NN pattern categories**` bullet in `README.md` and the quoted count in `CLAUDE.md` match `scripts/check-pattern-count.sh`

--- a/.github/workflows/plugin-skill-sync.yml
+++ b/.github/workflows/plugin-skill-sync.yml
@@ -78,7 +78,7 @@ jobs:
           python3 -m json.tool submission/discovery-evals.json > /dev/null
           python3 -m json.tool submission/submission-pack.json > /dev/null
 
-      - name: Check README pattern count matches SKILL.md
+      - name: Check README pattern count matches references/patterns.md
         run: bash scripts/check-pattern-count.sh
 
       - name: Regenerate bundled canonical resources

--- a/.github/workflows/promo-drift.yml
+++ b/.github/workflows/promo-drift.yml
@@ -84,7 +84,7 @@ jobs:
             cat report.md
             echo
             echo "Canonical is this repo. Fix the surfaces, not the README —"
-            echo "the README is already asserted against SKILL.md by"
+            echo "the README is already asserted against references/patterns.md by"
             echo "\`scripts/check-pattern-count.sh\`."
             echo
             echo "_Opened by [promo-drift](.github/workflows/promo-drift.yml)._"

--- a/.ssot.yaml
+++ b/.ssot.yaml
@@ -2,11 +2,11 @@
 #
 # There are two links in this chain and they are policed separately:
 #
-#   SKILL.md  ->  README.md          scripts/check-pattern-count.sh (every push)
-#   README.md ->  promo surfaces     this manifest (.github/workflows/promo-drift.yml)
+#   references/patterns.md  ->  README.md          scripts/check-pattern-count.sh (every push)
+#   README.md               ->  promo surfaces     this manifest (.github/workflows/promo-drift.yml)
 #
 # The first link derives the count from the catalog, so the README cannot lie
-# about SKILL.md. The second link is the one that actually rots: a release moves
+# about references/patterns.md. The second link is the one that actually rots: a release moves
 # the number here, the four surfaces below sit still, and nothing in *their*
 # repos changes — so no pre-commit hook over there can ever fire on it. That is
 # why this check is a release/cron job and not a hook.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,15 @@ All notable changes to this project are documented here.
 
 - Package the deterministic detector as a composite GitHub Action and pre-commit hook, backed by a new `avoid-ai-writing-gate` CLI. The gate uses per-file finding counts rather than the composite score, defaults to `technical` + `rendered-markdown`, and uses a corpus-backed threshold of 6 findings per file (1.9% human-control failure rate across 376 documents, versus 31.4% at zero). Strict zero-findings policies remain available with an explicit threshold of 0. Preservation validation stays separate because it requires before/after inputs (#86).
 
+### Changed
+
+- Document the two CI-checked pattern-category count copies in contributor guidance and the pull-request checklist (#170).
+- Reserve `good first issue` for a contributor's first PR and direct returning contributors to other issues or newcomer reviews.
+
 ### Fixed
 
+- Name `references/patterns.md` as the source used by pattern-count checks in
+  workflow and SSOT guidance (#169).
 - Include every observed corpus register in `corpus.js list`; preserve the preferred accepted-register order and sort additional registers deterministically.
 - Fix three README link targets: the dead Cowork URL, the pattern-catalog pointer, and the
   voice-profile link that led to the triggering section.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Edit `SKILL.md` and `references/patterns.md` directly. When making changes:
 - Run `npm test` to exercise the detector, category contract, validator, corpus helpers, and style checks.
 - Add a dated entry to CHANGELOG.md
 - Update README.md if the change affects installation, usage, feature list, or pattern count
-- The pattern count lives in **one** place — the README "74 pattern categories" bullet — and is derived from references/patterns.md's detection `###` entries. Don't restate it elsewhere; CI (`scripts/check-pattern-count.sh`) fails the build if the README number drifts from references/patterns.md, so just add the new `###` entry and bump the README bullet.
+- The pattern count is canonical in the README "74 pattern categories" bullet (derived from references/patterns.md's detection `###` entries). This bullet quotes that number here as a **checked copy** for agent context — update README and this sentence when you add or remove a detection category. Don't restate the count elsewhere; CI (`scripts/check-pattern-count.sh`) fails if either literal drifts from `references/patterns.md`.
 
 ## Architecture of the skill
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,21 @@ If you are unsure which it is, open an issue first and we will sort it out.
 The [pattern proposal form](https://github.com/conorbronsdon/avoid-ai-writing/issues/new?template=pattern_proposal.yml)
 asks for what triage needs, including the example that must stay clean.
 
+### Pattern-category count (detection catalog)
+
+When you add or remove a detection `###` under `## What to remove or fix` in
+`references/patterns.md` (not judgment-only prose or writer-side tests), CI
+derives the new total and compares it to two literals:
+
+1. **`README.md`** — update the `**NN pattern categories**` feature bullet to
+   match the derived count.
+2. **`CLAUDE.md`** — update the quoted `README "NN pattern categories" bullet`
+   phrase in the pattern-count guidance so it matches the same number.
+
+`scripts/check-pattern-count.sh` enforces both on every PR. Adding a word-table
+row instead only requires bumping the separate `**NN-entry word replacement
+table**` README bullet (same script).
+
 ## Precision over recall
 
 This skill is deliberately biased toward false negatives: a rule that wrongly

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,18 @@ Thanks for helping improve this skill. It teaches an LLM (and now a deterministi
 engine) to spot and fix AI-writing tells. Contributions are welcome — a few things
 keep the project coherent.
 
+## Choosing an issue
+
+Issues labeled `good first issue` are reserved for people making their first
+contribution to this repository. Check the assignee and comments, then comment
+on one unclaimed issue before starting. Take only one `good first issue` for
+your first PR; leave the others for fellow newcomers, including while your PR
+is awaiting review.
+
+If you've already contributed here, choose a `help wanted` issue without the
+`good first issue` label, propose another improvement, or help review and test
+newcomer PRs.
+
 ## How the repo fits together
 
 | Path | What it holds |
@@ -31,6 +43,21 @@ First decide which kind of rule it is:
 If you are unsure which it is, open an issue first and we will sort it out.
 The [pattern proposal form](https://github.com/conorbronsdon/avoid-ai-writing/issues/new?template=pattern_proposal.yml)
 asks for what triage needs, including the example that must stay clean.
+
+### Pattern-category count (detection catalog)
+
+When you add or remove a detection `###` under `## What to remove or fix` in
+`references/patterns.md` (not judgment-only prose or writer-side tests), CI
+derives the new total and compares it to two literals:
+
+1. **`README.md`** — update the `**NN pattern categories**` feature bullet to
+   match the derived count.
+2. **`CLAUDE.md`** — update the quoted `README "NN pattern categories" bullet`
+   phrase in the pattern-count guidance so it matches the same number.
+
+`scripts/check-pattern-count.sh` enforces both on every PR. Adding a word-table
+row instead only requires bumping the separate `**NN-entry word replacement
+table**` README bullet (same script).
 
 ## Precision over recall
 


### PR DESCRIPTION
The pattern-count guard checks two documented count copies and reads `references/patterns.md`, but contributor guidance did not explain both updates and workflow descriptions still named `SKILL.md`. PRs #181 and #183 correct those gaps; review found that each also needed a changelog entry.

This PR incorporates both original contributor commits, adds the missing Unreleased entries, and records Conor's requested contribution policy: `good first issue` is reserved for a contributor's first PR, with one issue claimed at a time including while awaiting review. Returning contributors are directed to other issues or newcomer reviews and testing.

The contributor fork could not be updated from this session, so the fixes are assembled on a maintainer branch in this repository. The integration commit retains original heads `799acd5ba673dca6499ce817fb0840e4ec79365a` (#181) and `04449643ff4697b31f00efb456d0f7b7097bba53` (#183) as parents, alongside current main. **Merge with a merge commit to preserve this ancestry and the contributor's commits.**

Validation on the exact published tree `0c0e205804610d743334a30b17c4f7912754de4e`:

- `npm test`
- `npm run self-scan:check`
- `bash scripts/check-pattern-count.sh` (74 categories, both copies; 112 word-table entries)
- `git diff --check`
- Independent GPT-5.6 Sol / Codex reviews of the combined diff, Node 18+ sentence preservation, and SSOT diagram alignment

Closes #170.
Closes #169.