### PR TITLE
docs: require changelog entries for user-facing changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,5 +10,6 @@
 - [ ] I considered false positives and added carve-outs for legitimate human writing
 - [ ] Any factual claim about how AI or humans write (e.g. "ChatGPT emits X", "humans rarely do Y") cites a source
 - [ ] The prose I added passes the skill's own audit (no AI-writing tells, terse bullets, no hollow intensifiers)
-- [ ] `CHANGELOG.md` entry added under a dated `## [X.Y.Z]` heading, and `SKILL.md` `version:` bumped if a rule changed
+- [ ] I added an Unreleased `CHANGELOG.md` entry for a user-facing change, or this PR is exempt under the [changelog policy](https://github.com/conorbronsdon/avoid-ai-writing/blob/main/CONTRIBUTING.md#changelog-and-versioning)
+- [ ] If this PR prepares a release: the dated changelog heading and skill/package/plugin versions agree
 - [ ] If I added or removed a detection `###` in `references/patterns.md`: the `**NN pattern categories**` bullet in `README.md` and the quoted count in `CLAUDE.md` match `scripts/check-pattern-count.sh`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,8 @@ All notable changes to this project are documented here.
 
 - Package the deterministic detector as a composite GitHub Action and pre-commit hook, backed by a new `avoid-ai-writing-gate` CLI. The gate uses per-file finding counts rather than the composite score, defaults to `technical` + `rendered-markdown`, and uses a corpus-backed threshold of 6 findings per file (1.9% human-control failure rate across 376 documents, versus 31.4% at zero). Strict zero-findings policies remain available with an explicit threshold of 0. Preservation validation stays separate because it requires before/after inputs (#86).
 
-### Changed
-
-- Document the two CI-checked pattern-category count copies in contributor guidance and the pull-request checklist (#170).
-- Reserve `good first issue` for a contributor's first PR and direct returning contributors to other issues or newcomer reviews.
-
 ### Fixed
 
-- Name `references/patterns.md` as the source used by pattern-count checks in
-  workflow and SSOT guidance (#169).
 - Include every observed corpus register in `corpus.js list`; preserve the preferred accepted-register order and sort additional registers deterministically.
 - Fix three README link targets: the dead Cowork URL, the pattern-catalog pointer, and the
   voice-profile link that led to the triggering section.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,13 +19,12 @@ A directory-based writing skill (`SKILL.md` plus `references/patterns.md`) that 
 
 Edit `SKILL.md` and `references/patterns.md` directly. When making changes:
 
-- Bump the version in the SKILL.md frontmatter (`version: X.Y.Z`).
-- Update the same version manually in both plugin manifests before syncing:
+- Follow the [changelog and versioning policy](CONTRIBUTING.md#changelog-and-versioning): add an Unreleased entry for user-facing changes; routine docs corrections, tests, and maintenance with no user-facing effect need no entry or version bump.
+- When preparing a release, update the SKILL.md frontmatter (`version: X.Y.Z`), `package.json`, and the dated changelog heading. Update the same version manually in both plugin manifests before syncing:
   - `plugins/avoid-ai-writing/.claude-plugin/plugin.json`
   - `.codex-plugin/plugin.json`
 - Run `bash scripts/sync-plugin-skill.sh && bash scripts/sync-cursor-rules.sh`. The first script validates both manifest versions against `SKILL.md` and regenerates bundled skill copies, detector resources, scripts, and examples; the second regenerates the portable paste/Cursor artifacts. Neither script generates the manifest versions. A mismatch fails with messages such as `version mismatch: SKILL.md=X Claude plugin=Y` or `version mismatch: SKILL.md=X OpenAI plugin=Y`.
 - Run `npm test` to exercise the detector, category contract, validator, corpus helpers, and style checks.
-- Add a dated entry to CHANGELOG.md
 - Update README.md if the change affects installation, usage, feature list, or pattern count
 - The pattern count is canonical in the README "74 pattern categories" bullet (derived from references/patterns.md's detection `###` entries). This bullet quotes that number here as a **checked copy** for agent context — update README and this sentence when you add or remove a detection category. Don't restate the count elsewhere; CI (`scripts/check-pattern-count.sh`) fails if either literal drifts from `references/patterns.md`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,8 +142,20 @@ its own.
 
 ## Changelog and versioning
 
-Add an entry to `CHANGELOG.md` under a dated, versioned heading
-(`## [X.Y.Z] — YYYY-MM-DD`), matching the existing entries. A new rule is a minor
-version bump; update the `version:` field in the `SKILL.md` frontmatter to match.
+Add an entry under `## [Unreleased]` in `CHANGELOG.md` when a change affects
+users: detection or rewriting behavior, writing rules, public APIs or CLI
+options, configuration, installation or packaging, compatibility, or security.
+
+Skip the changelog for routine docs corrections, links, formatting, contributor
+guidance, tests, and internal refactoring or CI maintenance with no user-facing
+effect. Describe those changes in the PR. A docs or maintenance label does not
+exempt a change that affects how the tool works, is installed or used, or is
+supported.
+
+When preparing a release, move its Unreleased entries under a dated, versioned
+heading (`## [X.Y.Z] — YYYY-MM-DD`) and update the matching versions in
+`SKILL.md`, `package.json`, and both plugin manifests. A release that adds a
+writing rule needs a minor version bump. Exempt changes need no version bump;
+leave published release entries intact.
 
 After changing either canonical file, run `bash scripts/sync-plugin-skill.sh && bash scripts/sync-cursor-rules.sh`. This regenerates both bundles, `SKILL.full.md`, and the portable paste/Cursor artifacts; CI checks parity. Do not edit generated copies.


### PR DESCRIPTION
The previous guidance required a changelog entry for every change and mixed PR-time edits with release-time versioning. That made small contributor-docs corrections require release notes without helping users.

This PR makes the requirement depend on user impact. Detection and rewriting behavior, writing rules, public APIs and CLI options, configuration, installation and packaging, compatibility, and security need an Unreleased entry. Routine docs corrections, links, formatting, contributor guidance, tests, and internal maintenance may skip it when there is no user-facing effect. Changes to installation, usage, or support remain covered even when labeled docs or maintenance.

CONTRIBUTING.md owns the policy; CLAUDE.md and the PR checklist follow it. Entries move into a dated versioned section during release preparation, when skill/package/plugin versions are synchronized. Published release history stays intact. The three documentation-only Unreleased notes added in #185 are removed under this policy.

Requested by Conor during review of #181 and #183. This documentation policy update is itself exempt from a new changelog entry.

Validation on exact tree `66b5101b8ba4dca2b3ce72e922ebe9d43656b9ad`:

- `npm test`
- `npm run self-scan:check`
- `bash scripts/check-pattern-count.sh`
- `git diff --check`
- Independent GPT-5.6 Sol / Codex review of policy consistency, release workflow compatibility, and unchanged published changelog sections