### PR TITLE
fix: preserve source offsets through detector preprocessing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project are documented here.
 
 ### Fixed
 
+- Preserve detector issue indexes and sentence-highlight ranges against the original source after blockquote and normalization preprocessing (#189).
 - Include every observed corpus register in `corpus.js list`; preserve the preferred accepted-register order and sort additional registers deterministically.
 - Fix three README link targets: the dead Cowork URL, the pattern-catalog pointer, and the
   voice-profile link that led to the triggering section.

--- a/detector/patterns.js
+++ b/detector/patterns.js
@@ -44,79 +44,67 @@ const AIDetector = (() => {
   };
   const GREEK_LOOKALIKES = { 'ο': 'o', 'Ο': 'O', 'α': 'a', 'Α': 'A', 'ρ': 'p', 'Ρ': 'P' };
 
-  // ─── Source-coordinate map (issue #189) ─────────────────────────────
+  // ─── Source-coordinate mapping (issue #189) ─────────────────────────
   //
-  // Preprocessing deletes characters: `normalizeText` strips zero-width
-  // chars and *roleplay-action* markers, and plain mode drops whole quoted
-  // lines. Masking stages never delete — they blank spans in place so the
-  // string keeps its length — but those deletions shrink the working
-  // string, so `match.index` and sentence boundaries no longer address the
-  // caller's input. This map records each removed span (in original source
-  // code units) as preprocessing runs, so any coordinate in the final
-  // working string can be translated back to the original input. Nothing
-  // inserts or reorders, so the translation is monotonic and unambiguous
-  // for live positions. `this.text` is the deletions-only copy and always
-  // indexes identically to the caller's final working string.
-  function createOffsetMap(text) {
-    return {
-      text,            // mutated by record() — mirrors preprocessed deletions
-      runs: [],        // ascending, disjoint [srcStart, srcEnd) spans
-      // Forward: source position -> working position. Only meaningful at
-      // live positions (run starts), where every earlier run is fully past.
-      forward(p) {
-        let removed = 0;
-        for (const [s, e] of this.runs) {
-          if (p >= e) removed += e - s;
-        }
-        return p - removed;
-      },
-      // Inverse: working position -> original source position.
-      inverse(k) {
-        let p = k;
-        for (const [s, e] of this.runs) {
-          if (p >= s) p += e - s;
-        }
-        return p;
-      },
-      record(start, end) {
-        const curStart = this.forward(start);
-        const len = end - start;
-        this.text = this.text.slice(0, curStart) + this.text.slice(curStart + len);
-        this.runs.push([start, end]);
-      },
-    };
+  // Each entry maps one code unit in the working string to the matching
+  // code unit in the caller's source. Deletion passes copy the entries for
+  // retained characters once, so interleaved or overlapping removals cannot
+  // double-count offsets. Masking and homoglyph replacement keep their input
+  // length and therefore keep the current map unchanged.
+  function identitySourceMap(length) {
+    return Array.from({ length }, (_, index) => index);
   }
 
-  function normalizeText(text, coordMap) {
+  function appendMapRange(target, source, start, end) {
+    for (let index = start; index < end; index += 1) target.push(source[index]);
+  }
+
+  function remapFindingsToSource(issues, regions, sourceMap) {
+    for (const issue of issues) {
+      if (Number.isInteger(issue.index)) issue.index = sourceMap[issue.index];
+    }
+    for (const region of regions) {
+      region.start = sourceMap[region.start];
+      region.end = sourceMap[region.end - 1] + 1;
+    }
+  }
+
+  const ZERO_WIDTH_RE = /[​-‍﻿⁠]/u;
+  const ZERO_WIDTH_GLOBAL_RE = /[​-‍﻿⁠]/gu;
+  const HOMOGLYPH_GLOBAL_RE = /[Ѐ-ӿͰ-Ͽ]/gu;
+  const ROLEPLAY_VERBS_RE = /^(?:nods|sighs|laughs|smiles|frowns|shrugs|grins|winks|chuckles|gasps|pauses|thinks|wonders|whispers|shouts|gestures|raises|leans|turns|looks|glances|smirks|blinks|nodding|sighing|laughing|smiling|thinking|gesturing)\b/i;
+  const ROLEPLAY_MARKER_RE = /(?<!\*)\*([^*\n]{1,80}?)\*(?!\*)/gu;
+
+  function normalizeText(text, sourceMap) {
     const flags = { zeroWidth: 0, homoglyph: 0, roleplay: 0 };
     let out = text;
-
-    // Replace-pass offsets are positions in the string handed to `.replace()`
-    // (this pass's input), stable for every match — not offsets into a buffer
-    // that shrinks as earlier matches are removed. So each pass translates its
-    // match offsets to source coordinates against the map state that existed
-    // when that pass STARTED (only prior stages' deletions), then hands
-    // record() the resulting SOURCE spans. Translating against the live runs
-    // as records accumulate would shift each later match past the deletions
-    // this same pass just recorded, corrupting coordMap.text.
-    const srcIn = (snap, k) => {
-      let p = k;
-      for (const [s, e] of snap) if (p >= s) p += e - s;
-      return p;
-    };
+    let map = Array.isArray(sourceMap) ? sourceMap : null;
 
     // 1. Strip zero-width chars (ZWSP U+200B, ZWNJ U+200C, ZWJ U+200D,
     //    BOM U+FEFF, word joiner U+2060).
-    const zwSnap = coordMap ? coordMap.runs.slice() : null;
-    out = out.replace(/[​-‍﻿⁠]/g, (m, offset) => {
-      flags.zeroWidth++;
-      if (coordMap) coordMap.record(srcIn(zwSnap, offset), srcIn(zwSnap, offset + m.length));
-      return '';
-    });
+    if (map) {
+      const chars = [];
+      const nextMap = [];
+      for (let i = 0; i < out.length; i += 1) {
+        if (ZERO_WIDTH_RE.test(out[i])) {
+          flags.zeroWidth += 1;
+          continue;
+        }
+        chars.push(out[i]);
+        nextMap.push(map[i]);
+      }
+      out = chars.join('');
+      map = nextMap;
+    } else {
+      out = out.replace(ZERO_WIDTH_GLOBAL_RE, () => {
+        flags.zeroWidth += 1;
+        return '';
+      });
+    }
 
     // 2. Swap Cyrillic / Greek Latin-lookalike chars back to Latin so
     //    pattern matching catches obfuscated tokens.
-    out = out.replace(/[Ѐ-ӿͰ-Ͽ]/g, (m) => {
+    out = out.replace(HOMOGLYPH_GLOBAL_RE, (m) => {
       const swap = CYRILLIC_LOOKALIKES[m] ?? GREEK_LOOKALIKES[m];
       if (swap) { flags.homoglyph++; return swap; }
       return m;
@@ -128,18 +116,34 @@ const AIDetector = (() => {
     //    artifact shape. Markdown `**bold**` is rejected by the
     //    lookbehind/lookahead; legitimate multi-word `*italic*` is
     //    preserved because the verb whitelist is narrow.
-    const ROLEPLAY_VERBS = /^(?:nods|sighs|laughs|smiles|frowns|shrugs|grins|winks|chuckles|gasps|pauses|thinks|wonders|whispers|shouts|gestures|raises|leans|turns|looks|glances|smirks|blinks|nodding|sighing|laughing|smiling|thinking|gesturing)\b/i;
-    const rpSnap = coordMap ? coordMap.runs.slice() : null;
-    out = out.replace(/(?<!\*)\*([^*\n]{1,80}?)\*(?!\*)/gu, (m, inner, offset) => {
-      if (ROLEPLAY_VERBS.test(inner)) {
-        flags.roleplay++;
-        if (coordMap) coordMap.record(srcIn(rpSnap, offset), srcIn(rpSnap, offset + m.length));
-        return '';
+    if (map) {
+      const chars = [];
+      const nextMap = [];
+      const matcher = new RegExp(ROLEPLAY_MARKER_RE.source, ROLEPLAY_MARKER_RE.flags);
+      let cursor = 0;
+      let match;
+      while ((match = matcher.exec(out)) !== null) {
+        if (!ROLEPLAY_VERBS_RE.test(match[1])) continue;
+        chars.push(out.slice(cursor, match.index));
+        appendMapRange(nextMap, map, cursor, match.index);
+        flags.roleplay += 1;
+        cursor = match.index + match[0].length;
       }
-      return m;
-    });
+      chars.push(out.slice(cursor));
+      appendMapRange(nextMap, map, cursor, map.length);
+      out = chars.join('');
+      map = nextMap;
+    } else {
+      out = out.replace(ROLEPLAY_MARKER_RE, (m, inner) => {
+        if (ROLEPLAY_VERBS_RE.test(inner)) {
+          flags.roleplay += 1;
+          return '';
+        }
+        return m;
+      });
+    }
 
-    return { text: out, flags };
+    return map ? { text: out, flags, sourceMap: map } : { text: out, flags };
   }
 
   // ─── Tier 1: Always flag ───────────────────────────────────────────
@@ -1050,52 +1054,45 @@ const AIDetector = (() => {
   // Keep the historical deletion behavior for default plain mode. Paragraph-
   // scoped rules depend on the surrounding lines being rejoined exactly this
   // way, so changing this prepass would change scores for existing callers.
-  function stripMultilineBlockquotes(text, coordMap) {
+  function stripMultilineBlockquotes(text, sourceMap) {
     const rawLines = text.split(/\r?\n/);
     const isQuote = rawLines.map((line) => /^\s*>\s/.test(line));
     const stripIndexes = new Set();
     for (let i = 0; i < rawLines.length; i += 1) {
       if (isQuote[i] && ((isQuote[i - 1] && i > 0) || isQuote[i + 1])) stripIndexes.add(i);
     }
+    const kept = rawLines
+      .map((_, index) => index)
+      .filter((index) => !stripIndexes.has(index));
+    const result = {
+      text: kept.map((index) => rawLines[index]).join('\n'),
+      quotedLines: stripIndexes.size,
+    };
+    if (!Array.isArray(sourceMap)) return result;
 
-    // Record every character the join below actually drops, in original
-    // source coordinates, so reported issue/highlight offsets translate
-    // back to the caller's input exactly. Two kinds of spans:
-    //   - a stripped line removes its whole span, terminator included;
-    //   - a kept CRLF line is re-joined as '\n', so its '\r' alone is dropped.
-    // These spans index `text`, which is the caller's raw input in this
-    // stage (no deletion has run yet in plain mode), so they are already
-    // source coordinates and go straight to record(). Passing them back
-    // through inverse() would shift a source position past its own run.
-    if (coordMap) {
-      const spans = [];
-      const lineStarts = [];
-      let offset = 0;
-      for (let i = 0; i < rawLines.length; i += 1) {
-        lineStarts.push(offset);
-        const nextLf = text.indexOf('\n', offset + rawLines[i].length);
-        offset = nextLf === -1 ? text.length : nextLf + 1;
-      }
-      for (let i = 0; i < rawLines.length; i += 1) {
-        const start = lineStarts[i];
-        if (stripIndexes.has(i)) {
-          spans.push([start, i < rawLines.length - 1 ? lineStarts[i + 1] : text.length]);
-        } else if (text[start + rawLines[i].length] === '\r') {
-          // Kept CRLF line, blank lines included: the rejoin emits a single
-          // '\n', so the separator's '\r' alone (located right after the
-          // line's content) is dropped and must be recorded.
-          spans.push([start + rawLines[i].length, start + rawLines[i].length + 1]);
-        }
-      }
-      for (const [s, e] of spans) {
-        coordMap.record(s, e);
+    const lineStarts = [];
+    let offset = 0;
+    for (let i = 0; i < rawLines.length; i += 1) {
+      lineStarts.push(offset);
+      offset += rawLines[i].length;
+      if (i < rawLines.length - 1) {
+        if (text[offset] === '\r') offset += 1;
+        if (text[offset] === '\n') offset += 1;
       }
     }
 
-    return {
-      text: rawLines.filter((_, i) => !stripIndexes.has(i)).join('\n'),
-      quotedLines: stripIndexes.size,
-    };
+    const mapped = [];
+    for (let i = 0; i < kept.length; i += 1) {
+      const lineIndex = kept[i];
+      const start = lineStarts[lineIndex];
+      appendMapRange(mapped, sourceMap, start, start + rawLines[lineIndex].length);
+      if (i < kept.length - 1) {
+        const separatorStart = start + rawLines[lineIndex].length;
+        const newlineIndex = text[separatorStart] === '\r' ? separatorStart + 1 : separatorStart;
+        mapped.push(sourceMap[newlineIndex]);
+      }
+    }
+    return { ...result, sourceMap: mapped };
   }
 
   function maskTopLevelIndentedCode(chars, { listAware = false } = {}) {
@@ -1490,12 +1487,10 @@ const AIDetector = (() => {
       return { ...buildV2Defaults('UNSCORED', 'low'), score: 0, label: 'Empty', issues: [], stats: {}, tooShort: true };
     }
 
-    // Coordinate map over the caller's original string. Preprocessing may
-    // delete characters (plain-mode blockquote lines, zero-width chars,
-    // roleplay markers); anything that reports an offset into the working
-    // string is translated back through this map before it leaves the
-    // function, so issue.index and highlight ranges address the input.
-    const coordMap = createOffsetMap(text);
+    // Map each working-string code unit back to the caller's source. Every
+    // length-changing preprocessing stage composes this map as it removes
+    // characters, and results are translated before they leave the function.
+    let sourceMap = identitySourceMap(text.length);
 
     // Context mode selects context-appropriate flagging. Accepted values:
     //   'general' (default) — full ruleset
@@ -1538,16 +1533,17 @@ const AIDetector = (() => {
     // keeps later issue and highlight offsets aligned with the source file.
     const blockquotes = sourceMode === 'rendered-markdown'
       ? maskMultilineBlockquotes(text)
-      : stripMultilineBlockquotes(text, coordMap);
+      : stripMultilineBlockquotes(text, sourceMap);
     text = blockquotes.text;
+    if (blockquotes.sourceMap) sourceMap = blockquotes.sourceMap;
     const { quotedLines } = blockquotes;
 
     // Pre-pass: strip bypass-trick chars before pattern matching so
-    // "delve" with a Cyrillic 'е' still hits Tier 1. The coordinator is
-    // passed along so every dropped span is recorded; issue and highlight
-    // offsets are remapped to the source just before the result is built.
-    const norm = normalizeText(text, coordMap);
+    // "delve" with a Cyrillic 'е' still hits Tier 1. Compose the map while
+    // deleting characters so later offsets still address the source.
+    const norm = normalizeText(text, sourceMap);
     text = norm.text;
+    sourceMap = norm.sourceMap;
 
     const wordCount = countWords(text);
     if (wordCount < 10) {
@@ -2257,18 +2253,10 @@ const AIDetector = (() => {
       denseAIVocab,
     });
 
-    // Translate every offset produced against the (shortened) working
-    // string back to the caller's original input. Both the dense issue
-    // index and the coarser sentence-highlight boundaries must align.
-    for (const issue of deduped) {
-      if (Number.isInteger(issue.index)) {
-        issue.index = coordMap.inverse(issue.index);
-      }
-    }
-    for (const region of regions) {
-      region.start = coordMap.inverse(region.start);
-      region.end   = coordMap.inverse(region.end);
-    }
+    // Translate both dense issue indexes and half-open highlight boundaries.
+    // Mapping the region end from its final retained code unit avoids pulling
+    // a later removed roleplay marker into the highlighted source slice.
+    remapFindingsToSource(deduped, regions, sourceMap);
 
     return {
       // Legacy fields preserved for existing callers.
@@ -2601,7 +2589,6 @@ const AIDetector = (() => {
   return {
     analyzeText,
     normalizeText,
-    createOffsetMap,
     getLabel,
     getColor,
     SEVERITY_LABELS,

--- a/detector/patterns.js
+++ b/detector/patterns.js
@@ -44,13 +44,75 @@ const AIDetector = (() => {
   };
   const GREEK_LOOKALIKES = { 'ο': 'o', 'Ο': 'O', 'α': 'a', 'Α': 'A', 'ρ': 'p', 'Ρ': 'P' };
 
-  function normalizeText(text) {
+  // ─── Source-coordinate map (issue #189) ─────────────────────────────
+  //
+  // Preprocessing deletes characters: `normalizeText` strips zero-width
+  // chars and *roleplay-action* markers, and plain mode drops whole quoted
+  // lines. Masking stages never delete — they blank spans in place so the
+  // string keeps its length — but those deletions shrink the working
+  // string, so `match.index` and sentence boundaries no longer address the
+  // caller's input. This map records each removed span (in original source
+  // code units) as preprocessing runs, so any coordinate in the final
+  // working string can be translated back to the original input. Nothing
+  // inserts or reorders, so the translation is monotonic and unambiguous
+  // for live positions. `this.text` is the deletions-only copy and always
+  // indexes identically to the caller's final working string.
+  function createOffsetMap(text) {
+    return {
+      text,            // mutated by record() — mirrors preprocessed deletions
+      runs: [],        // ascending, disjoint [srcStart, srcEnd) spans
+      // Forward: source position -> working position. Only meaningful at
+      // live positions (run starts), where every earlier run is fully past.
+      forward(p) {
+        let removed = 0;
+        for (const [s, e] of this.runs) {
+          if (p >= e) removed += e - s;
+        }
+        return p - removed;
+      },
+      // Inverse: working position -> original source position.
+      inverse(k) {
+        let p = k;
+        for (const [s, e] of this.runs) {
+          if (p >= s) p += e - s;
+        }
+        return p;
+      },
+      record(start, end) {
+        const curStart = this.forward(start);
+        const len = end - start;
+        this.text = this.text.slice(0, curStart) + this.text.slice(curStart + len);
+        this.runs.push([start, end]);
+      },
+    };
+  }
+
+  function normalizeText(text, coordMap) {
     const flags = { zeroWidth: 0, homoglyph: 0, roleplay: 0 };
     let out = text;
 
+    // Replace-pass offsets are positions in the string handed to `.replace()`
+    // (this pass's input), stable for every match — not offsets into a buffer
+    // that shrinks as earlier matches are removed. So each pass translates its
+    // match offsets to source coordinates against the map state that existed
+    // when that pass STARTED (only prior stages' deletions), then hands
+    // record() the resulting SOURCE spans. Translating against the live runs
+    // as records accumulate would shift each later match past the deletions
+    // this same pass just recorded, corrupting coordMap.text.
+    const srcIn = (snap, k) => {
+      let p = k;
+      for (const [s, e] of snap) if (p >= s) p += e - s;
+      return p;
+    };
+
     // 1. Strip zero-width chars (ZWSP U+200B, ZWNJ U+200C, ZWJ U+200D,
     //    BOM U+FEFF, word joiner U+2060).
-    out = out.replace(/[​-‍﻿⁠]/g, () => { flags.zeroWidth++; return ''; });
+    const zwSnap = coordMap ? coordMap.runs.slice() : null;
+    out = out.replace(/[​-‍﻿⁠]/g, (m, offset) => {
+      flags.zeroWidth++;
+      if (coordMap) coordMap.record(srcIn(zwSnap, offset), srcIn(zwSnap, offset + m.length));
+      return '';
+    });
 
     // 2. Swap Cyrillic / Greek Latin-lookalike chars back to Latin so
     //    pattern matching catches obfuscated tokens.
@@ -67,8 +129,13 @@ const AIDetector = (() => {
     //    lookbehind/lookahead; legitimate multi-word `*italic*` is
     //    preserved because the verb whitelist is narrow.
     const ROLEPLAY_VERBS = /^(?:nods|sighs|laughs|smiles|frowns|shrugs|grins|winks|chuckles|gasps|pauses|thinks|wonders|whispers|shouts|gestures|raises|leans|turns|looks|glances|smirks|blinks|nodding|sighing|laughing|smiling|thinking|gesturing)\b/i;
-    out = out.replace(/(?<!\*)\*([^*\n]{1,80}?)\*(?!\*)/gu, (m, inner) => {
-      if (ROLEPLAY_VERBS.test(inner)) { flags.roleplay++; return ''; }
+    const rpSnap = coordMap ? coordMap.runs.slice() : null;
+    out = out.replace(/(?<!\*)\*([^*\n]{1,80}?)\*(?!\*)/gu, (m, inner, offset) => {
+      if (ROLEPLAY_VERBS.test(inner)) {
+        flags.roleplay++;
+        if (coordMap) coordMap.record(srcIn(rpSnap, offset), srcIn(rpSnap, offset + m.length));
+        return '';
+      }
       return m;
     });
 
@@ -983,13 +1050,48 @@ const AIDetector = (() => {
   // Keep the historical deletion behavior for default plain mode. Paragraph-
   // scoped rules depend on the surrounding lines being rejoined exactly this
   // way, so changing this prepass would change scores for existing callers.
-  function stripMultilineBlockquotes(text) {
+  function stripMultilineBlockquotes(text, coordMap) {
     const rawLines = text.split(/\r?\n/);
     const isQuote = rawLines.map((line) => /^\s*>\s/.test(line));
     const stripIndexes = new Set();
     for (let i = 0; i < rawLines.length; i += 1) {
       if (isQuote[i] && ((isQuote[i - 1] && i > 0) || isQuote[i + 1])) stripIndexes.add(i);
     }
+
+    // Record every character the join below actually drops, in original
+    // source coordinates, so reported issue/highlight offsets translate
+    // back to the caller's input exactly. Two kinds of spans:
+    //   - a stripped line removes its whole span, terminator included;
+    //   - a kept CRLF line is re-joined as '\n', so its '\r' alone is dropped.
+    // These spans index `text`, which is the caller's raw input in this
+    // stage (no deletion has run yet in plain mode), so they are already
+    // source coordinates and go straight to record(). Passing them back
+    // through inverse() would shift a source position past its own run.
+    if (coordMap) {
+      const spans = [];
+      const lineStarts = [];
+      let offset = 0;
+      for (let i = 0; i < rawLines.length; i += 1) {
+        lineStarts.push(offset);
+        const nextLf = text.indexOf('\n', offset + rawLines[i].length);
+        offset = nextLf === -1 ? text.length : nextLf + 1;
+      }
+      for (let i = 0; i < rawLines.length; i += 1) {
+        const start = lineStarts[i];
+        if (stripIndexes.has(i)) {
+          spans.push([start, i < rawLines.length - 1 ? lineStarts[i + 1] : text.length]);
+        } else if (text[start + rawLines[i].length] === '\r') {
+          // Kept CRLF line, blank lines included: the rejoin emits a single
+          // '\n', so the separator's '\r' alone (located right after the
+          // line's content) is dropped and must be recorded.
+          spans.push([start + rawLines[i].length, start + rawLines[i].length + 1]);
+        }
+      }
+      for (const [s, e] of spans) {
+        coordMap.record(s, e);
+      }
+    }
+
     return {
       text: rawLines.filter((_, i) => !stripIndexes.has(i)).join('\n'),
       quotedLines: stripIndexes.size,
@@ -1388,6 +1490,13 @@ const AIDetector = (() => {
       return { ...buildV2Defaults('UNSCORED', 'low'), score: 0, label: 'Empty', issues: [], stats: {}, tooShort: true };
     }
 
+    // Coordinate map over the caller's original string. Preprocessing may
+    // delete characters (plain-mode blockquote lines, zero-width chars,
+    // roleplay markers); anything that reports an offset into the working
+    // string is translated back through this map before it leaves the
+    // function, so issue.index and highlight ranges address the input.
+    const coordMap = createOffsetMap(text);
+
     // Context mode selects context-appropriate flagging. Accepted values:
     //   'general' (default) — full ruleset
     //   'technical' — skip title-case headers; individual prose-only rules
@@ -1429,14 +1538,15 @@ const AIDetector = (() => {
     // keeps later issue and highlight offsets aligned with the source file.
     const blockquotes = sourceMode === 'rendered-markdown'
       ? maskMultilineBlockquotes(text)
-      : stripMultilineBlockquotes(text);
+      : stripMultilineBlockquotes(text, coordMap);
     text = blockquotes.text;
     const { quotedLines } = blockquotes;
 
     // Pre-pass: strip bypass-trick chars before pattern matching so
-    // "delve" with a Cyrillic 'е' still hits Tier 1. Original text is
-    // preserved so reported `match.index` values remain visually accurate.
-    const norm = normalizeText(text);
+    // "delve" with a Cyrillic 'е' still hits Tier 1. The coordinator is
+    // passed along so every dropped span is recorded; issue and highlight
+    // offsets are remapped to the source just before the result is built.
+    const norm = normalizeText(text, coordMap);
     text = norm.text;
 
     const wordCount = countWords(text);
@@ -2147,6 +2257,19 @@ const AIDetector = (() => {
       denseAIVocab,
     });
 
+    // Translate every offset produced against the (shortened) working
+    // string back to the caller's original input. Both the dense issue
+    // index and the coarser sentence-highlight boundaries must align.
+    for (const issue of deduped) {
+      if (Number.isInteger(issue.index)) {
+        issue.index = coordMap.inverse(issue.index);
+      }
+    }
+    for (const region of regions) {
+      region.start = coordMap.inverse(region.start);
+      region.end   = coordMap.inverse(region.end);
+    }
+
     return {
       // Legacy fields preserved for existing callers.
       score: normalizedScore,
@@ -2478,6 +2601,7 @@ const AIDetector = (() => {
   return {
     analyzeText,
     normalizeText,
+    createOffsetMap,
     getLabel,
     getColor,
     SEVERITY_LABELS,

--- a/detector/patterns.test.js
+++ b/detector/patterns.test.js
@@ -2185,6 +2185,154 @@ test('dev-blog-boilerplate: ordinary prose stays clean', () => {
   assert.equal(hits.length, 0, `false positives: ${JSON.stringify(hits.map((i) => i.text))}`);
 });
 
+// ── Issue #189 — preserve source offsets through preprocessing ─────────
+// Preprocessing that changes string length (plain-mode blockquote stripping,
+// zero-width-character and *roleplay-action* removal) must not shift the
+// issue.index and highlight-range coordinates reported against the caller's
+// original source. For every index-carrying issue, the source slice at its
+// coordinates must reproduce its text exactly; highlight regions must land on
+// real source chars. Masking stages are already covered by #123 — these tests
+// pin the length-changing stages.
+function assertIndexedIssuesSliceExactly(source, issues, label) {
+  for (const issue of issues) {
+    if (!Number.isInteger(issue.index)) continue;
+    assert.equal(
+      source.slice(issue.index, issue.index + issue.text.length),
+      issue.text,
+      `${label}: source.slice(index, index+len) must reproduce the reported ${issue.type} text`,
+    );
+  }
+}
+
+test('#189: plain-mode multiline blockquote (LF) keeps issue and highlight offsets on source', () => {
+  const source = '> quoted line one\n> quoted line two\n\nIt is important to note that the system works well and the team shipped it.';
+  const result = AIDetector.analyzeText(source, { sourceMode: 'plain' });
+  const filler = result.issues.find((issue) => issue.type === 'filler');
+
+  assert.equal(result.stats.quotedLines, 2);
+  assert.ok(filler, 'prose after the stripped quote must still be analyzed');
+  assert.equal(filler.index, source.indexOf('It is important'), 'filler index must address the source');
+  assert.equal(source.slice(filler.index, filler.index + filler.text.length), filler.text);
+  assertIndexedIssuesSliceExactly(source, result.issues, 'plain LF blockquote');
+
+  const [region] = result.highlight_sentence_for_ai;
+  assert.deepEqual([region.start, region.end], [36, 112], 'highlight must span from the newline before the sentence to the end');
+  assert.equal(
+    source.slice(region.start, region.end),
+    '\nIt is important to note that the system works well and the team shipped it.',
+  );
+});
+
+test('#189: plain-mode multiline blockquote (CRLF) keeps issue and highlight offsets on source', () => {
+  const source = '> quoted line one\r\n> quoted line two\r\n\r\nIt is important to note that the system works well and the team shipped it.';
+  const result = AIDetector.analyzeText(source, { sourceMode: 'plain' });
+  const filler = result.issues.find((issue) => issue.type === 'filler');
+
+  assert.equal(result.stats.quotedLines, 2);
+  assert.ok(filler, 'prose after the stripped quote must still be analyzed');
+  assert.equal(filler.index, source.indexOf('It is important'), 'filler index must address the source');
+  assert.equal(source.slice(filler.index, filler.index + filler.text.length), filler.text);
+  assertIndexedIssuesSliceExactly(source, result.issues, 'plain CRLF blockquote');
+
+  const [region] = result.highlight_sentence_for_ai;
+  assert.deepEqual([region.start, region.end], [39, 115], 'the leading \\r of the CRLF blank line must be accounted for too');
+  assert.equal(
+    source.slice(region.start, region.end),
+    '\nIt is important to note that the system works well and the team shipped it.',
+  );
+});
+
+test('#189: rendered-markdown multiline blockquotes keep offsets on source (LF and CRLF)', () => {
+  const prose = 'It is important to note that the system works well and the team shipped it.';
+  for (const [name, quote] of [
+    ['LF', '> quoted line one\n> quoted line two\n\n'],
+    ['CRLF', '> quoted line one\r\n> quoted line two\r\n\r\n'],
+  ]) {
+    const source = quote + prose;
+    const result = AIDetector.analyzeText(source, { sourceMode: 'rendered-markdown' });
+    const filler = result.issues.find((issue) => issue.type === 'filler');
+
+    assert.equal(result.stats.quotedLines, 2, `${name}: both quote lines counted`);
+    assert.ok(filler, `${name}: visible prose after the masked quote must still be analyzed`);
+    assert.equal(filler.index, quote.length, `${name}: masked quote must not shift the filler`);
+    assertIndexedIssuesSliceExactly(source, result.issues, `rendered ${name}`);
+
+    const [region] = result.highlight_sentence_for_ai;
+    assert.deepEqual([region.start, region.end], [quote.length, source.length], `${name}: highlight spans the visible prose`);
+    assert.equal(source.slice(region.start, region.end), prose);
+  }
+});
+
+test('#189: zero-width characters do not shift later offsets', () => {
+  const source = 'Powerful is the new baseline​‌ and truly robust and tough.';
+  const result = AIDetector.analyzeText(source, { sourceMode: 'plain' });
+  const truly = result.issues.find((issue) => issue.type === 'hollow-intensifier' && issue.text === 'truly');
+
+  assert.equal(result.stats.normalization.zeroWidth, 2);
+  assert.ok(truly, 'word after the zero-width chars must still be flagged');
+  assert.equal(truly.index, source.indexOf('truly'));
+  assert.equal(source.slice(truly.index, truly.index + truly.text.length), truly.text);
+  assertIndexedIssuesSliceExactly(source, result.issues, 'zero-width');
+});
+
+test('#189: zero-width chars separated by content record exact source runs', () => {
+  const source = 'This system works well​ across the board‌ and truly robust and tough for the final release today.';
+  const result = AIDetector.analyzeText(source, { sourceMode: 'plain' });
+  const truly = result.issues.find((issue) => issue.type === 'hollow-intensifier' && issue.text === 'truly');
+
+  assert.equal(result.stats.normalization.zeroWidth, 2);
+  assert.ok(truly, 'word after both separated zero-width chars must still be flagged');
+  assert.equal(truly.index, source.indexOf('truly'));
+  assert.equal(source.slice(truly.index, truly.index + truly.text.length), truly.text);
+  assertIndexedIssuesSliceExactly(source, result.issues, 'separated zero-width');
+});
+
+test('#189: roleplay-action markers do not shift later offsets', () => {
+  const source = 'It is important to note that the system works well. *nods* This is truly robust and the team shipped it.';
+  const result = AIDetector.analyzeText(source, { sourceMode: 'plain' });
+  const truly = result.issues.find((issue) => issue.type === 'hollow-intensifier' && issue.text === 'truly');
+
+  assert.equal(result.stats.normalization.roleplay, 1);
+  assert.ok(truly, 'word after the *nods* marker must still be flagged');
+  assert.equal(truly.index, source.indexOf('truly'));
+  assert.equal(source.slice(truly.index, truly.index + truly.text.length), truly.text);
+  assertIndexedIssuesSliceExactly(source, result.issues, 'roleplay marker');
+});
+
+test('#189: ordinary unchanged text reports native indexes and exact slices', () => {
+  const source = 'It is important to note that the system works well, and it is truly robust and tough.';
+  const result = AIDetector.analyzeText(source, { sourceMode: 'plain' });
+
+  for (const issue of result.issues) {
+    if (!Number.isInteger(issue.index)) continue;
+    assert.equal(issue.index, source.indexOf(issue.text), `${issue.type}: unchanged text keeps a native index`);
+  }
+  assertIndexedIssuesSliceExactly(source, result.issues, 'ordinary text');
+});
+
+test('#189: highlight regions land on real source bytes and slice back to the flagged sentence', () => {
+  for (const [name, lineEnd] of [['LF', '\n'], ['CRLF', '\r\n']]) {
+    const source = [
+      '> quoted line one',
+      '> quoted line two',
+      '',
+      'It is important to note that the system works well and the team shipped it.',
+    ].join(lineEnd);
+
+    const result = AIDetector.analyzeText(source, { sourceMode: 'plain' });
+    const filler = result.issues.find((issue) => issue.type === 'filler');
+    const [region] = result.highlight_sentence_for_ai;
+
+    assert.ok(Number.isInteger(region.start) && Number.isInteger(region.end), `${name}: region coords are integers`);
+    assert.ok(region.start < region.end && region.end <= source.length, `${name}: region stays inside source bounds`);
+    assert.ok(
+      source.slice(region.start, region.end).includes('It is important to note'),
+      `${name}: source slice at the region covers the flagged sentence`,
+    );
+    assert.ok(region.start <= filler.index && filler.index < region.end, `${name}: issue index sits inside the highlight`);
+  }
+});
+
 if (failed > 0) {
   console.error(`\n${failed} test(s) failed`);
   process.exit(1);

--- a/detector/patterns.test.js
+++ b/detector/patterns.test.js
@@ -2299,6 +2299,85 @@ test('#189: roleplay-action markers do not shift later offsets', () => {
   assertIndexedIssuesSliceExactly(source, result.issues, 'roleplay marker');
 });
 
+test('#189: interleaved preprocessing stages compose source offsets', () => {
+  const prose = 'Moreover, the editor checked the original document before changing the published account for the morning edition.';
+  for (const [name, prefix] of [
+    ['zero-width before quote', '\u200b\n> x\n> y\n'],
+    ['roleplay before quote', '*nods*\n> x\n> y\n'],
+    ['roleplay before zero-width', '*nods* later\u200b '],
+  ]) {
+    const source = prefix + prose;
+    const result = AIDetector.analyzeText(source);
+    const transition = result.issues.find((issue) => issue.type === 'transition');
+
+    assert.ok(transition, `${name}: visible prose must still be analyzed`);
+    assert.equal(transition.index, source.indexOf('Moreover'), `${name}: issue index must address source`);
+    const [region] = result.highlight_sentence_for_ai;
+    assert.ok(region.start <= transition.index && transition.index < region.end, `${name}: issue must sit inside highlight`);
+    assert.ok(region.end <= source.length, `${name}: highlight must stay within source`);
+  }
+});
+
+test('#189: overlapping normalization removals map once and keep staged semantics', () => {
+  const prose = 'Moreover, the editor checked the original document before changing the published account for the morning edition.';
+  const source = '*nod\u200bs* *nоds* ' + prose;
+  const result = AIDetector.analyzeText(source);
+  const transition = result.issues.find((issue) => issue.type === 'transition');
+
+  assert.deepEqual(result.stats.normalization, { zeroWidth: 1, homoglyph: 1, roleplay: 2 });
+  assert.ok(transition, 'prose after normalized roleplay markers must still be analyzed');
+  assert.equal(transition.index, source.indexOf('Moreover'));
+  assert.ok(result.highlight_sentence_for_ai.every((region) => region.end <= source.length));
+});
+
+test('#189: malformed emphasis is not reclassified as roleplay', () => {
+  const prose = 'Moreover, the editor checked the original document before changing the published account for the morning edition.';
+  const source = '**nods* **sighs* ' + prose;
+  const result = AIDetector.analyzeText(source);
+  const transition = result.issues.find((issue) => issue.type === 'transition');
+
+  assert.equal(result.stats.normalization.roleplay, 0);
+  assert.equal(transition.index, source.indexOf('Moreover'));
+});
+
+test('#189: a zero-width character inside a finding preserves its source start and region', () => {
+  const obfuscated = 'only ti\u200bme will tell';
+  const source = `Alpha beta gamma delta epsilon zeta eta theta iota kappa ${obfuscated} about systems.`;
+  const result = AIDetector.analyzeText(source);
+  const generic = result.issues.find((issue) => issue.type === 'generic-conclusion');
+
+  assert.ok(generic, 'normalization must not hide a phrase from detection');
+  assert.equal(generic.index, source.indexOf('only'));
+  assert.equal(source.slice(generic.index, generic.index + obfuscated.length), obfuscated);
+  const [region] = result.highlight_sentence_for_ai;
+  assert.ok(source.slice(region.start, region.end).includes(obfuscated));
+  assert.ok(region.end <= source.length);
+});
+
+test('#189: trailing removed markers stay outside the preceding highlight', () => {
+  const prose = 'Moreover, the editor checked the original document before changing the published account for the morning edition.';
+  const source = `${prose} *nods*`;
+  const result = AIDetector.analyzeText(source);
+  const [region] = result.highlight_sentence_for_ai;
+
+  assert.equal(region.end, prose.length);
+  assert.equal(source.slice(region.start, region.end), prose);
+});
+
+test('#189: direct normalization handles every occurrence and mapped analysis stays linear', () => {
+  const normalized = AIDetector.normalizeText('x\u200by\u200bz еx еy');
+  assert.equal(normalized.text, 'xyz ex ey');
+  assert.deepEqual(normalized.flags, { zeroWidth: 2, homoglyph: 2, roleplay: 0 });
+
+  const dense = '\u200b'.repeat(75000)
+    + 'Alpha beta gamma delta epsilon zeta eta theta iota kappa only time will tell about systems.';
+  const started = Date.now();
+  const denseResult = AIDetector.analyzeText(dense);
+  const elapsed = Date.now() - started;
+  assert.equal(denseResult.stats.normalization.zeroWidth, 75000);
+  assert.ok(elapsed < 1000, `dense mapped analysis took ${elapsed}ms; expected a linear pass under 1000ms`);
+});
+
 test('#189: ordinary unchanged text reports native indexes and exact slices', () => {
   const source = 'It is important to note that the system works well, and it is truly robust and tough.';
   const result = AIDetector.analyzeText(source, { sourceMode: 'plain' });

--- a/plugins/avoid-ai-writing/skills/avoid-ai-writing/detector/patterns.js
+++ b/plugins/avoid-ai-writing/skills/avoid-ai-writing/detector/patterns.js
@@ -44,79 +44,67 @@ const AIDetector = (() => {
   };
   const GREEK_LOOKALIKES = { 'ο': 'o', 'Ο': 'O', 'α': 'a', 'Α': 'A', 'ρ': 'p', 'Ρ': 'P' };
 
-  // ─── Source-coordinate map (issue #189) ─────────────────────────────
+  // ─── Source-coordinate mapping (issue #189) ─────────────────────────
   //
-  // Preprocessing deletes characters: `normalizeText` strips zero-width
-  // chars and *roleplay-action* markers, and plain mode drops whole quoted
-  // lines. Masking stages never delete — they blank spans in place so the
-  // string keeps its length — but those deletions shrink the working
-  // string, so `match.index` and sentence boundaries no longer address the
-  // caller's input. This map records each removed span (in original source
-  // code units) as preprocessing runs, so any coordinate in the final
-  // working string can be translated back to the original input. Nothing
-  // inserts or reorders, so the translation is monotonic and unambiguous
-  // for live positions. `this.text` is the deletions-only copy and always
-  // indexes identically to the caller's final working string.
-  function createOffsetMap(text) {
-    return {
-      text,            // mutated by record() — mirrors preprocessed deletions
-      runs: [],        // ascending, disjoint [srcStart, srcEnd) spans
-      // Forward: source position -> working position. Only meaningful at
-      // live positions (run starts), where every earlier run is fully past.
-      forward(p) {
-        let removed = 0;
-        for (const [s, e] of this.runs) {
-          if (p >= e) removed += e - s;
-        }
-        return p - removed;
-      },
-      // Inverse: working position -> original source position.
-      inverse(k) {
-        let p = k;
-        for (const [s, e] of this.runs) {
-          if (p >= s) p += e - s;
-        }
-        return p;
-      },
-      record(start, end) {
-        const curStart = this.forward(start);
-        const len = end - start;
-        this.text = this.text.slice(0, curStart) + this.text.slice(curStart + len);
-        this.runs.push([start, end]);
-      },
-    };
+  // Each entry maps one code unit in the working string to the matching
+  // code unit in the caller's source. Deletion passes copy the entries for
+  // retained characters once, so interleaved or overlapping removals cannot
+  // double-count offsets. Masking and homoglyph replacement keep their input
+  // length and therefore keep the current map unchanged.
+  function identitySourceMap(length) {
+    return Array.from({ length }, (_, index) => index);
   }
 
-  function normalizeText(text, coordMap) {
+  function appendMapRange(target, source, start, end) {
+    for (let index = start; index < end; index += 1) target.push(source[index]);
+  }
+
+  function remapFindingsToSource(issues, regions, sourceMap) {
+    for (const issue of issues) {
+      if (Number.isInteger(issue.index)) issue.index = sourceMap[issue.index];
+    }
+    for (const region of regions) {
+      region.start = sourceMap[region.start];
+      region.end = sourceMap[region.end - 1] + 1;
+    }
+  }
+
+  const ZERO_WIDTH_RE = /[​-‍﻿⁠]/u;
+  const ZERO_WIDTH_GLOBAL_RE = /[​-‍﻿⁠]/gu;
+  const HOMOGLYPH_GLOBAL_RE = /[Ѐ-ӿͰ-Ͽ]/gu;
+  const ROLEPLAY_VERBS_RE = /^(?:nods|sighs|laughs|smiles|frowns|shrugs|grins|winks|chuckles|gasps|pauses|thinks|wonders|whispers|shouts|gestures|raises|leans|turns|looks|glances|smirks|blinks|nodding|sighing|laughing|smiling|thinking|gesturing)\b/i;
+  const ROLEPLAY_MARKER_RE = /(?<!\*)\*([^*\n]{1,80}?)\*(?!\*)/gu;
+
+  function normalizeText(text, sourceMap) {
     const flags = { zeroWidth: 0, homoglyph: 0, roleplay: 0 };
     let out = text;
-
-    // Replace-pass offsets are positions in the string handed to `.replace()`
-    // (this pass's input), stable for every match — not offsets into a buffer
-    // that shrinks as earlier matches are removed. So each pass translates its
-    // match offsets to source coordinates against the map state that existed
-    // when that pass STARTED (only prior stages' deletions), then hands
-    // record() the resulting SOURCE spans. Translating against the live runs
-    // as records accumulate would shift each later match past the deletions
-    // this same pass just recorded, corrupting coordMap.text.
-    const srcIn = (snap, k) => {
-      let p = k;
-      for (const [s, e] of snap) if (p >= s) p += e - s;
-      return p;
-    };
+    let map = Array.isArray(sourceMap) ? sourceMap : null;
 
     // 1. Strip zero-width chars (ZWSP U+200B, ZWNJ U+200C, ZWJ U+200D,
     //    BOM U+FEFF, word joiner U+2060).
-    const zwSnap = coordMap ? coordMap.runs.slice() : null;
-    out = out.replace(/[​-‍﻿⁠]/g, (m, offset) => {
-      flags.zeroWidth++;
-      if (coordMap) coordMap.record(srcIn(zwSnap, offset), srcIn(zwSnap, offset + m.length));
-      return '';
-    });
+    if (map) {
+      const chars = [];
+      const nextMap = [];
+      for (let i = 0; i < out.length; i += 1) {
+        if (ZERO_WIDTH_RE.test(out[i])) {
+          flags.zeroWidth += 1;
+          continue;
+        }
+        chars.push(out[i]);
+        nextMap.push(map[i]);
+      }
+      out = chars.join('');
+      map = nextMap;
+    } else {
+      out = out.replace(ZERO_WIDTH_GLOBAL_RE, () => {
+        flags.zeroWidth += 1;
+        return '';
+      });
+    }
 
     // 2. Swap Cyrillic / Greek Latin-lookalike chars back to Latin so
     //    pattern matching catches obfuscated tokens.
-    out = out.replace(/[Ѐ-ӿͰ-Ͽ]/g, (m) => {
+    out = out.replace(HOMOGLYPH_GLOBAL_RE, (m) => {
       const swap = CYRILLIC_LOOKALIKES[m] ?? GREEK_LOOKALIKES[m];
       if (swap) { flags.homoglyph++; return swap; }
       return m;
@@ -128,18 +116,34 @@ const AIDetector = (() => {
     //    artifact shape. Markdown `**bold**` is rejected by the
     //    lookbehind/lookahead; legitimate multi-word `*italic*` is
     //    preserved because the verb whitelist is narrow.
-    const ROLEPLAY_VERBS = /^(?:nods|sighs|laughs|smiles|frowns|shrugs|grins|winks|chuckles|gasps|pauses|thinks|wonders|whispers|shouts|gestures|raises|leans|turns|looks|glances|smirks|blinks|nodding|sighing|laughing|smiling|thinking|gesturing)\b/i;
-    const rpSnap = coordMap ? coordMap.runs.slice() : null;
-    out = out.replace(/(?<!\*)\*([^*\n]{1,80}?)\*(?!\*)/gu, (m, inner, offset) => {
-      if (ROLEPLAY_VERBS.test(inner)) {
-        flags.roleplay++;
-        if (coordMap) coordMap.record(srcIn(rpSnap, offset), srcIn(rpSnap, offset + m.length));
-        return '';
+    if (map) {
+      const chars = [];
+      const nextMap = [];
+      const matcher = new RegExp(ROLEPLAY_MARKER_RE.source, ROLEPLAY_MARKER_RE.flags);
+      let cursor = 0;
+      let match;
+      while ((match = matcher.exec(out)) !== null) {
+        if (!ROLEPLAY_VERBS_RE.test(match[1])) continue;
+        chars.push(out.slice(cursor, match.index));
+        appendMapRange(nextMap, map, cursor, match.index);
+        flags.roleplay += 1;
+        cursor = match.index + match[0].length;
       }
-      return m;
-    });
+      chars.push(out.slice(cursor));
+      appendMapRange(nextMap, map, cursor, map.length);
+      out = chars.join('');
+      map = nextMap;
+    } else {
+      out = out.replace(ROLEPLAY_MARKER_RE, (m, inner) => {
+        if (ROLEPLAY_VERBS_RE.test(inner)) {
+          flags.roleplay += 1;
+          return '';
+        }
+        return m;
+      });
+    }
 
-    return { text: out, flags };
+    return map ? { text: out, flags, sourceMap: map } : { text: out, flags };
   }
 
   // ─── Tier 1: Always flag ───────────────────────────────────────────
@@ -1050,52 +1054,45 @@ const AIDetector = (() => {
   // Keep the historical deletion behavior for default plain mode. Paragraph-
   // scoped rules depend on the surrounding lines being rejoined exactly this
   // way, so changing this prepass would change scores for existing callers.
-  function stripMultilineBlockquotes(text, coordMap) {
+  function stripMultilineBlockquotes(text, sourceMap) {
     const rawLines = text.split(/\r?\n/);
     const isQuote = rawLines.map((line) => /^\s*>\s/.test(line));
     const stripIndexes = new Set();
     for (let i = 0; i < rawLines.length; i += 1) {
       if (isQuote[i] && ((isQuote[i - 1] && i > 0) || isQuote[i + 1])) stripIndexes.add(i);
     }
+    const kept = rawLines
+      .map((_, index) => index)
+      .filter((index) => !stripIndexes.has(index));
+    const result = {
+      text: kept.map((index) => rawLines[index]).join('\n'),
+      quotedLines: stripIndexes.size,
+    };
+    if (!Array.isArray(sourceMap)) return result;
 
-    // Record every character the join below actually drops, in original
-    // source coordinates, so reported issue/highlight offsets translate
-    // back to the caller's input exactly. Two kinds of spans:
-    //   - a stripped line removes its whole span, terminator included;
-    //   - a kept CRLF line is re-joined as '\n', so its '\r' alone is dropped.
-    // These spans index `text`, which is the caller's raw input in this
-    // stage (no deletion has run yet in plain mode), so they are already
-    // source coordinates and go straight to record(). Passing them back
-    // through inverse() would shift a source position past its own run.
-    if (coordMap) {
-      const spans = [];
-      const lineStarts = [];
-      let offset = 0;
-      for (let i = 0; i < rawLines.length; i += 1) {
-        lineStarts.push(offset);
-        const nextLf = text.indexOf('\n', offset + rawLines[i].length);
-        offset = nextLf === -1 ? text.length : nextLf + 1;
-      }
-      for (let i = 0; i < rawLines.length; i += 1) {
-        const start = lineStarts[i];
-        if (stripIndexes.has(i)) {
-          spans.push([start, i < rawLines.length - 1 ? lineStarts[i + 1] : text.length]);
-        } else if (text[start + rawLines[i].length] === '\r') {
-          // Kept CRLF line, blank lines included: the rejoin emits a single
-          // '\n', so the separator's '\r' alone (located right after the
-          // line's content) is dropped and must be recorded.
-          spans.push([start + rawLines[i].length, start + rawLines[i].length + 1]);
-        }
-      }
-      for (const [s, e] of spans) {
-        coordMap.record(s, e);
+    const lineStarts = [];
+    let offset = 0;
+    for (let i = 0; i < rawLines.length; i += 1) {
+      lineStarts.push(offset);
+      offset += rawLines[i].length;
+      if (i < rawLines.length - 1) {
+        if (text[offset] === '\r') offset += 1;
+        if (text[offset] === '\n') offset += 1;
       }
     }
 
-    return {
-      text: rawLines.filter((_, i) => !stripIndexes.has(i)).join('\n'),
-      quotedLines: stripIndexes.size,
-    };
+    const mapped = [];
+    for (let i = 0; i < kept.length; i += 1) {
+      const lineIndex = kept[i];
+      const start = lineStarts[lineIndex];
+      appendMapRange(mapped, sourceMap, start, start + rawLines[lineIndex].length);
+      if (i < kept.length - 1) {
+        const separatorStart = start + rawLines[lineIndex].length;
+        const newlineIndex = text[separatorStart] === '\r' ? separatorStart + 1 : separatorStart;
+        mapped.push(sourceMap[newlineIndex]);
+      }
+    }
+    return { ...result, sourceMap: mapped };
   }
 
   function maskTopLevelIndentedCode(chars, { listAware = false } = {}) {
@@ -1490,12 +1487,10 @@ const AIDetector = (() => {
       return { ...buildV2Defaults('UNSCORED', 'low'), score: 0, label: 'Empty', issues: [], stats: {}, tooShort: true };
     }
 
-    // Coordinate map over the caller's original string. Preprocessing may
-    // delete characters (plain-mode blockquote lines, zero-width chars,
-    // roleplay markers); anything that reports an offset into the working
-    // string is translated back through this map before it leaves the
-    // function, so issue.index and highlight ranges address the input.
-    const coordMap = createOffsetMap(text);
+    // Map each working-string code unit back to the caller's source. Every
+    // length-changing preprocessing stage composes this map as it removes
+    // characters, and results are translated before they leave the function.
+    let sourceMap = identitySourceMap(text.length);
 
     // Context mode selects context-appropriate flagging. Accepted values:
     //   'general' (default) — full ruleset
@@ -1538,16 +1533,17 @@ const AIDetector = (() => {
     // keeps later issue and highlight offsets aligned with the source file.
     const blockquotes = sourceMode === 'rendered-markdown'
       ? maskMultilineBlockquotes(text)
-      : stripMultilineBlockquotes(text, coordMap);
+      : stripMultilineBlockquotes(text, sourceMap);
     text = blockquotes.text;
+    if (blockquotes.sourceMap) sourceMap = blockquotes.sourceMap;
     const { quotedLines } = blockquotes;
 
     // Pre-pass: strip bypass-trick chars before pattern matching so
-    // "delve" with a Cyrillic 'е' still hits Tier 1. The coordinator is
-    // passed along so every dropped span is recorded; issue and highlight
-    // offsets are remapped to the source just before the result is built.
-    const norm = normalizeText(text, coordMap);
+    // "delve" with a Cyrillic 'е' still hits Tier 1. Compose the map while
+    // deleting characters so later offsets still address the source.
+    const norm = normalizeText(text, sourceMap);
     text = norm.text;
+    sourceMap = norm.sourceMap;
 
     const wordCount = countWords(text);
     if (wordCount < 10) {
@@ -2257,18 +2253,10 @@ const AIDetector = (() => {
       denseAIVocab,
     });
 
-    // Translate every offset produced against the (shortened) working
-    // string back to the caller's original input. Both the dense issue
-    // index and the coarser sentence-highlight boundaries must align.
-    for (const issue of deduped) {
-      if (Number.isInteger(issue.index)) {
-        issue.index = coordMap.inverse(issue.index);
-      }
-    }
-    for (const region of regions) {
-      region.start = coordMap.inverse(region.start);
-      region.end   = coordMap.inverse(region.end);
-    }
+    // Translate both dense issue indexes and half-open highlight boundaries.
+    // Mapping the region end from its final retained code unit avoids pulling
+    // a later removed roleplay marker into the highlighted source slice.
+    remapFindingsToSource(deduped, regions, sourceMap);
 
     return {
       // Legacy fields preserved for existing callers.
@@ -2601,7 +2589,6 @@ const AIDetector = (() => {
   return {
     analyzeText,
     normalizeText,
-    createOffsetMap,
     getLabel,
     getColor,
     SEVERITY_LABELS,

--- a/plugins/avoid-ai-writing/skills/avoid-ai-writing/detector/patterns.js
+++ b/plugins/avoid-ai-writing/skills/avoid-ai-writing/detector/patterns.js
@@ -44,13 +44,75 @@ const AIDetector = (() => {
   };
   const GREEK_LOOKALIKES = { 'ο': 'o', 'Ο': 'O', 'α': 'a', 'Α': 'A', 'ρ': 'p', 'Ρ': 'P' };
 
-  function normalizeText(text) {
+  // ─── Source-coordinate map (issue #189) ─────────────────────────────
+  //
+  // Preprocessing deletes characters: `normalizeText` strips zero-width
+  // chars and *roleplay-action* markers, and plain mode drops whole quoted
+  // lines. Masking stages never delete — they blank spans in place so the
+  // string keeps its length — but those deletions shrink the working
+  // string, so `match.index` and sentence boundaries no longer address the
+  // caller's input. This map records each removed span (in original source
+  // code units) as preprocessing runs, so any coordinate in the final
+  // working string can be translated back to the original input. Nothing
+  // inserts or reorders, so the translation is monotonic and unambiguous
+  // for live positions. `this.text` is the deletions-only copy and always
+  // indexes identically to the caller's final working string.
+  function createOffsetMap(text) {
+    return {
+      text,            // mutated by record() — mirrors preprocessed deletions
+      runs: [],        // ascending, disjoint [srcStart, srcEnd) spans
+      // Forward: source position -> working position. Only meaningful at
+      // live positions (run starts), where every earlier run is fully past.
+      forward(p) {
+        let removed = 0;
+        for (const [s, e] of this.runs) {
+          if (p >= e) removed += e - s;
+        }
+        return p - removed;
+      },
+      // Inverse: working position -> original source position.
+      inverse(k) {
+        let p = k;
+        for (const [s, e] of this.runs) {
+          if (p >= s) p += e - s;
+        }
+        return p;
+      },
+      record(start, end) {
+        const curStart = this.forward(start);
+        const len = end - start;
+        this.text = this.text.slice(0, curStart) + this.text.slice(curStart + len);
+        this.runs.push([start, end]);
+      },
+    };
+  }
+
+  function normalizeText(text, coordMap) {
     const flags = { zeroWidth: 0, homoglyph: 0, roleplay: 0 };
     let out = text;
 
+    // Replace-pass offsets are positions in the string handed to `.replace()`
+    // (this pass's input), stable for every match — not offsets into a buffer
+    // that shrinks as earlier matches are removed. So each pass translates its
+    // match offsets to source coordinates against the map state that existed
+    // when that pass STARTED (only prior stages' deletions), then hands
+    // record() the resulting SOURCE spans. Translating against the live runs
+    // as records accumulate would shift each later match past the deletions
+    // this same pass just recorded, corrupting coordMap.text.
+    const srcIn = (snap, k) => {
+      let p = k;
+      for (const [s, e] of snap) if (p >= s) p += e - s;
+      return p;
+    };
+
     // 1. Strip zero-width chars (ZWSP U+200B, ZWNJ U+200C, ZWJ U+200D,
     //    BOM U+FEFF, word joiner U+2060).
-    out = out.replace(/[​-‍﻿⁠]/g, () => { flags.zeroWidth++; return ''; });
+    const zwSnap = coordMap ? coordMap.runs.slice() : null;
+    out = out.replace(/[​-‍﻿⁠]/g, (m, offset) => {
+      flags.zeroWidth++;
+      if (coordMap) coordMap.record(srcIn(zwSnap, offset), srcIn(zwSnap, offset + m.length));
+      return '';
+    });
 
     // 2. Swap Cyrillic / Greek Latin-lookalike chars back to Latin so
     //    pattern matching catches obfuscated tokens.
@@ -67,8 +129,13 @@ const AIDetector = (() => {
     //    lookbehind/lookahead; legitimate multi-word `*italic*` is
     //    preserved because the verb whitelist is narrow.
     const ROLEPLAY_VERBS = /^(?:nods|sighs|laughs|smiles|frowns|shrugs|grins|winks|chuckles|gasps|pauses|thinks|wonders|whispers|shouts|gestures|raises|leans|turns|looks|glances|smirks|blinks|nodding|sighing|laughing|smiling|thinking|gesturing)\b/i;
-    out = out.replace(/(?<!\*)\*([^*\n]{1,80}?)\*(?!\*)/gu, (m, inner) => {
-      if (ROLEPLAY_VERBS.test(inner)) { flags.roleplay++; return ''; }
+    const rpSnap = coordMap ? coordMap.runs.slice() : null;
+    out = out.replace(/(?<!\*)\*([^*\n]{1,80}?)\*(?!\*)/gu, (m, inner, offset) => {
+      if (ROLEPLAY_VERBS.test(inner)) {
+        flags.roleplay++;
+        if (coordMap) coordMap.record(srcIn(rpSnap, offset), srcIn(rpSnap, offset + m.length));
+        return '';
+      }
       return m;
     });
 
@@ -983,13 +1050,48 @@ const AIDetector = (() => {
   // Keep the historical deletion behavior for default plain mode. Paragraph-
   // scoped rules depend on the surrounding lines being rejoined exactly this
   // way, so changing this prepass would change scores for existing callers.
-  function stripMultilineBlockquotes(text) {
+  function stripMultilineBlockquotes(text, coordMap) {
     const rawLines = text.split(/\r?\n/);
     const isQuote = rawLines.map((line) => /^\s*>\s/.test(line));
     const stripIndexes = new Set();
     for (let i = 0; i < rawLines.length; i += 1) {
       if (isQuote[i] && ((isQuote[i - 1] && i > 0) || isQuote[i + 1])) stripIndexes.add(i);
     }
+
+    // Record every character the join below actually drops, in original
+    // source coordinates, so reported issue/highlight offsets translate
+    // back to the caller's input exactly. Two kinds of spans:
+    //   - a stripped line removes its whole span, terminator included;
+    //   - a kept CRLF line is re-joined as '\n', so its '\r' alone is dropped.
+    // These spans index `text`, which is the caller's raw input in this
+    // stage (no deletion has run yet in plain mode), so they are already
+    // source coordinates and go straight to record(). Passing them back
+    // through inverse() would shift a source position past its own run.
+    if (coordMap) {
+      const spans = [];
+      const lineStarts = [];
+      let offset = 0;
+      for (let i = 0; i < rawLines.length; i += 1) {
+        lineStarts.push(offset);
+        const nextLf = text.indexOf('\n', offset + rawLines[i].length);
+        offset = nextLf === -1 ? text.length : nextLf + 1;
+      }
+      for (let i = 0; i < rawLines.length; i += 1) {
+        const start = lineStarts[i];
+        if (stripIndexes.has(i)) {
+          spans.push([start, i < rawLines.length - 1 ? lineStarts[i + 1] : text.length]);
+        } else if (text[start + rawLines[i].length] === '\r') {
+          // Kept CRLF line, blank lines included: the rejoin emits a single
+          // '\n', so the separator's '\r' alone (located right after the
+          // line's content) is dropped and must be recorded.
+          spans.push([start + rawLines[i].length, start + rawLines[i].length + 1]);
+        }
+      }
+      for (const [s, e] of spans) {
+        coordMap.record(s, e);
+      }
+    }
+
     return {
       text: rawLines.filter((_, i) => !stripIndexes.has(i)).join('\n'),
       quotedLines: stripIndexes.size,
@@ -1388,6 +1490,13 @@ const AIDetector = (() => {
       return { ...buildV2Defaults('UNSCORED', 'low'), score: 0, label: 'Empty', issues: [], stats: {}, tooShort: true };
     }
 
+    // Coordinate map over the caller's original string. Preprocessing may
+    // delete characters (plain-mode blockquote lines, zero-width chars,
+    // roleplay markers); anything that reports an offset into the working
+    // string is translated back through this map before it leaves the
+    // function, so issue.index and highlight ranges address the input.
+    const coordMap = createOffsetMap(text);
+
     // Context mode selects context-appropriate flagging. Accepted values:
     //   'general' (default) — full ruleset
     //   'technical' — skip title-case headers; individual prose-only rules
@@ -1429,14 +1538,15 @@ const AIDetector = (() => {
     // keeps later issue and highlight offsets aligned with the source file.
     const blockquotes = sourceMode === 'rendered-markdown'
       ? maskMultilineBlockquotes(text)
-      : stripMultilineBlockquotes(text);
+      : stripMultilineBlockquotes(text, coordMap);
     text = blockquotes.text;
     const { quotedLines } = blockquotes;
 
     // Pre-pass: strip bypass-trick chars before pattern matching so
-    // "delve" with a Cyrillic 'е' still hits Tier 1. Original text is
-    // preserved so reported `match.index` values remain visually accurate.
-    const norm = normalizeText(text);
+    // "delve" with a Cyrillic 'е' still hits Tier 1. The coordinator is
+    // passed along so every dropped span is recorded; issue and highlight
+    // offsets are remapped to the source just before the result is built.
+    const norm = normalizeText(text, coordMap);
     text = norm.text;
 
     const wordCount = countWords(text);
@@ -2147,6 +2257,19 @@ const AIDetector = (() => {
       denseAIVocab,
     });
 
+    // Translate every offset produced against the (shortened) working
+    // string back to the caller's original input. Both the dense issue
+    // index and the coarser sentence-highlight boundaries must align.
+    for (const issue of deduped) {
+      if (Number.isInteger(issue.index)) {
+        issue.index = coordMap.inverse(issue.index);
+      }
+    }
+    for (const region of regions) {
+      region.start = coordMap.inverse(region.start);
+      region.end   = coordMap.inverse(region.end);
+    }
+
     return {
       // Legacy fields preserved for existing callers.
       score: normalizedScore,
@@ -2478,6 +2601,7 @@ const AIDetector = (() => {
   return {
     analyzeText,
     normalizeText,
+    createOffsetMap,
     getLabel,
     getColor,
     SEVERITY_LABELS,

--- a/skills/ai-writing-detector/scripts/patterns.js
+++ b/skills/ai-writing-detector/scripts/patterns.js
@@ -44,79 +44,67 @@ const AIDetector = (() => {
   };
   const GREEK_LOOKALIKES = { 'ο': 'o', 'Ο': 'O', 'α': 'a', 'Α': 'A', 'ρ': 'p', 'Ρ': 'P' };
 
-  // ─── Source-coordinate map (issue #189) ─────────────────────────────
+  // ─── Source-coordinate mapping (issue #189) ─────────────────────────
   //
-  // Preprocessing deletes characters: `normalizeText` strips zero-width
-  // chars and *roleplay-action* markers, and plain mode drops whole quoted
-  // lines. Masking stages never delete — they blank spans in place so the
-  // string keeps its length — but those deletions shrink the working
-  // string, so `match.index` and sentence boundaries no longer address the
-  // caller's input. This map records each removed span (in original source
-  // code units) as preprocessing runs, so any coordinate in the final
-  // working string can be translated back to the original input. Nothing
-  // inserts or reorders, so the translation is monotonic and unambiguous
-  // for live positions. `this.text` is the deletions-only copy and always
-  // indexes identically to the caller's final working string.
-  function createOffsetMap(text) {
-    return {
-      text,            // mutated by record() — mirrors preprocessed deletions
-      runs: [],        // ascending, disjoint [srcStart, srcEnd) spans
-      // Forward: source position -> working position. Only meaningful at
-      // live positions (run starts), where every earlier run is fully past.
-      forward(p) {
-        let removed = 0;
-        for (const [s, e] of this.runs) {
-          if (p >= e) removed += e - s;
-        }
-        return p - removed;
-      },
-      // Inverse: working position -> original source position.
-      inverse(k) {
-        let p = k;
-        for (const [s, e] of this.runs) {
-          if (p >= s) p += e - s;
-        }
-        return p;
-      },
-      record(start, end) {
-        const curStart = this.forward(start);
-        const len = end - start;
-        this.text = this.text.slice(0, curStart) + this.text.slice(curStart + len);
-        this.runs.push([start, end]);
-      },
-    };
+  // Each entry maps one code unit in the working string to the matching
+  // code unit in the caller's source. Deletion passes copy the entries for
+  // retained characters once, so interleaved or overlapping removals cannot
+  // double-count offsets. Masking and homoglyph replacement keep their input
+  // length and therefore keep the current map unchanged.
+  function identitySourceMap(length) {
+    return Array.from({ length }, (_, index) => index);
   }
 
-  function normalizeText(text, coordMap) {
+  function appendMapRange(target, source, start, end) {
+    for (let index = start; index < end; index += 1) target.push(source[index]);
+  }
+
+  function remapFindingsToSource(issues, regions, sourceMap) {
+    for (const issue of issues) {
+      if (Number.isInteger(issue.index)) issue.index = sourceMap[issue.index];
+    }
+    for (const region of regions) {
+      region.start = sourceMap[region.start];
+      region.end = sourceMap[region.end - 1] + 1;
+    }
+  }
+
+  const ZERO_WIDTH_RE = /[​-‍﻿⁠]/u;
+  const ZERO_WIDTH_GLOBAL_RE = /[​-‍﻿⁠]/gu;
+  const HOMOGLYPH_GLOBAL_RE = /[Ѐ-ӿͰ-Ͽ]/gu;
+  const ROLEPLAY_VERBS_RE = /^(?:nods|sighs|laughs|smiles|frowns|shrugs|grins|winks|chuckles|gasps|pauses|thinks|wonders|whispers|shouts|gestures|raises|leans|turns|looks|glances|smirks|blinks|nodding|sighing|laughing|smiling|thinking|gesturing)\b/i;
+  const ROLEPLAY_MARKER_RE = /(?<!\*)\*([^*\n]{1,80}?)\*(?!\*)/gu;
+
+  function normalizeText(text, sourceMap) {
     const flags = { zeroWidth: 0, homoglyph: 0, roleplay: 0 };
     let out = text;
-
-    // Replace-pass offsets are positions in the string handed to `.replace()`
-    // (this pass's input), stable for every match — not offsets into a buffer
-    // that shrinks as earlier matches are removed. So each pass translates its
-    // match offsets to source coordinates against the map state that existed
-    // when that pass STARTED (only prior stages' deletions), then hands
-    // record() the resulting SOURCE spans. Translating against the live runs
-    // as records accumulate would shift each later match past the deletions
-    // this same pass just recorded, corrupting coordMap.text.
-    const srcIn = (snap, k) => {
-      let p = k;
-      for (const [s, e] of snap) if (p >= s) p += e - s;
-      return p;
-    };
+    let map = Array.isArray(sourceMap) ? sourceMap : null;
 
     // 1. Strip zero-width chars (ZWSP U+200B, ZWNJ U+200C, ZWJ U+200D,
     //    BOM U+FEFF, word joiner U+2060).
-    const zwSnap = coordMap ? coordMap.runs.slice() : null;
-    out = out.replace(/[​-‍﻿⁠]/g, (m, offset) => {
-      flags.zeroWidth++;
-      if (coordMap) coordMap.record(srcIn(zwSnap, offset), srcIn(zwSnap, offset + m.length));
-      return '';
-    });
+    if (map) {
+      const chars = [];
+      const nextMap = [];
+      for (let i = 0; i < out.length; i += 1) {
+        if (ZERO_WIDTH_RE.test(out[i])) {
+          flags.zeroWidth += 1;
+          continue;
+        }
+        chars.push(out[i]);
+        nextMap.push(map[i]);
+      }
+      out = chars.join('');
+      map = nextMap;
+    } else {
+      out = out.replace(ZERO_WIDTH_GLOBAL_RE, () => {
+        flags.zeroWidth += 1;
+        return '';
+      });
+    }
 
     // 2. Swap Cyrillic / Greek Latin-lookalike chars back to Latin so
     //    pattern matching catches obfuscated tokens.
-    out = out.replace(/[Ѐ-ӿͰ-Ͽ]/g, (m) => {
+    out = out.replace(HOMOGLYPH_GLOBAL_RE, (m) => {
       const swap = CYRILLIC_LOOKALIKES[m] ?? GREEK_LOOKALIKES[m];
       if (swap) { flags.homoglyph++; return swap; }
       return m;
@@ -128,18 +116,34 @@ const AIDetector = (() => {
     //    artifact shape. Markdown `**bold**` is rejected by the
     //    lookbehind/lookahead; legitimate multi-word `*italic*` is
     //    preserved because the verb whitelist is narrow.
-    const ROLEPLAY_VERBS = /^(?:nods|sighs|laughs|smiles|frowns|shrugs|grins|winks|chuckles|gasps|pauses|thinks|wonders|whispers|shouts|gestures|raises|leans|turns|looks|glances|smirks|blinks|nodding|sighing|laughing|smiling|thinking|gesturing)\b/i;
-    const rpSnap = coordMap ? coordMap.runs.slice() : null;
-    out = out.replace(/(?<!\*)\*([^*\n]{1,80}?)\*(?!\*)/gu, (m, inner, offset) => {
-      if (ROLEPLAY_VERBS.test(inner)) {
-        flags.roleplay++;
-        if (coordMap) coordMap.record(srcIn(rpSnap, offset), srcIn(rpSnap, offset + m.length));
-        return '';
+    if (map) {
+      const chars = [];
+      const nextMap = [];
+      const matcher = new RegExp(ROLEPLAY_MARKER_RE.source, ROLEPLAY_MARKER_RE.flags);
+      let cursor = 0;
+      let match;
+      while ((match = matcher.exec(out)) !== null) {
+        if (!ROLEPLAY_VERBS_RE.test(match[1])) continue;
+        chars.push(out.slice(cursor, match.index));
+        appendMapRange(nextMap, map, cursor, match.index);
+        flags.roleplay += 1;
+        cursor = match.index + match[0].length;
       }
-      return m;
-    });
+      chars.push(out.slice(cursor));
+      appendMapRange(nextMap, map, cursor, map.length);
+      out = chars.join('');
+      map = nextMap;
+    } else {
+      out = out.replace(ROLEPLAY_MARKER_RE, (m, inner) => {
+        if (ROLEPLAY_VERBS_RE.test(inner)) {
+          flags.roleplay += 1;
+          return '';
+        }
+        return m;
+      });
+    }
 
-    return { text: out, flags };
+    return map ? { text: out, flags, sourceMap: map } : { text: out, flags };
   }
 
   // ─── Tier 1: Always flag ───────────────────────────────────────────
@@ -1050,52 +1054,45 @@ const AIDetector = (() => {
   // Keep the historical deletion behavior for default plain mode. Paragraph-
   // scoped rules depend on the surrounding lines being rejoined exactly this
   // way, so changing this prepass would change scores for existing callers.
-  function stripMultilineBlockquotes(text, coordMap) {
+  function stripMultilineBlockquotes(text, sourceMap) {
     const rawLines = text.split(/\r?\n/);
     const isQuote = rawLines.map((line) => /^\s*>\s/.test(line));
     const stripIndexes = new Set();
     for (let i = 0; i < rawLines.length; i += 1) {
       if (isQuote[i] && ((isQuote[i - 1] && i > 0) || isQuote[i + 1])) stripIndexes.add(i);
     }
+    const kept = rawLines
+      .map((_, index) => index)
+      .filter((index) => !stripIndexes.has(index));
+    const result = {
+      text: kept.map((index) => rawLines[index]).join('\n'),
+      quotedLines: stripIndexes.size,
+    };
+    if (!Array.isArray(sourceMap)) return result;
 
-    // Record every character the join below actually drops, in original
-    // source coordinates, so reported issue/highlight offsets translate
-    // back to the caller's input exactly. Two kinds of spans:
-    //   - a stripped line removes its whole span, terminator included;
-    //   - a kept CRLF line is re-joined as '\n', so its '\r' alone is dropped.
-    // These spans index `text`, which is the caller's raw input in this
-    // stage (no deletion has run yet in plain mode), so they are already
-    // source coordinates and go straight to record(). Passing them back
-    // through inverse() would shift a source position past its own run.
-    if (coordMap) {
-      const spans = [];
-      const lineStarts = [];
-      let offset = 0;
-      for (let i = 0; i < rawLines.length; i += 1) {
-        lineStarts.push(offset);
-        const nextLf = text.indexOf('\n', offset + rawLines[i].length);
-        offset = nextLf === -1 ? text.length : nextLf + 1;
-      }
-      for (let i = 0; i < rawLines.length; i += 1) {
-        const start = lineStarts[i];
-        if (stripIndexes.has(i)) {
-          spans.push([start, i < rawLines.length - 1 ? lineStarts[i + 1] : text.length]);
-        } else if (text[start + rawLines[i].length] === '\r') {
-          // Kept CRLF line, blank lines included: the rejoin emits a single
-          // '\n', so the separator's '\r' alone (located right after the
-          // line's content) is dropped and must be recorded.
-          spans.push([start + rawLines[i].length, start + rawLines[i].length + 1]);
-        }
-      }
-      for (const [s, e] of spans) {
-        coordMap.record(s, e);
+    const lineStarts = [];
+    let offset = 0;
+    for (let i = 0; i < rawLines.length; i += 1) {
+      lineStarts.push(offset);
+      offset += rawLines[i].length;
+      if (i < rawLines.length - 1) {
+        if (text[offset] === '\r') offset += 1;
+        if (text[offset] === '\n') offset += 1;
       }
     }
 
-    return {
-      text: rawLines.filter((_, i) => !stripIndexes.has(i)).join('\n'),
-      quotedLines: stripIndexes.size,
-    };
+    const mapped = [];
+    for (let i = 0; i < kept.length; i += 1) {
+      const lineIndex = kept[i];
+      const start = lineStarts[lineIndex];
+      appendMapRange(mapped, sourceMap, start, start + rawLines[lineIndex].length);
+      if (i < kept.length - 1) {
+        const separatorStart = start + rawLines[lineIndex].length;
+        const newlineIndex = text[separatorStart] === '\r' ? separatorStart + 1 : separatorStart;
+        mapped.push(sourceMap[newlineIndex]);
+      }
+    }
+    return { ...result, sourceMap: mapped };
   }
 
   function maskTopLevelIndentedCode(chars, { listAware = false } = {}) {
@@ -1490,12 +1487,10 @@ const AIDetector = (() => {
       return { ...buildV2Defaults('UNSCORED', 'low'), score: 0, label: 'Empty', issues: [], stats: {}, tooShort: true };
     }
 
-    // Coordinate map over the caller's original string. Preprocessing may
-    // delete characters (plain-mode blockquote lines, zero-width chars,
-    // roleplay markers); anything that reports an offset into the working
-    // string is translated back through this map before it leaves the
-    // function, so issue.index and highlight ranges address the input.
-    const coordMap = createOffsetMap(text);
+    // Map each working-string code unit back to the caller's source. Every
+    // length-changing preprocessing stage composes this map as it removes
+    // characters, and results are translated before they leave the function.
+    let sourceMap = identitySourceMap(text.length);
 
     // Context mode selects context-appropriate flagging. Accepted values:
     //   'general' (default) — full ruleset
@@ -1538,16 +1533,17 @@ const AIDetector = (() => {
     // keeps later issue and highlight offsets aligned with the source file.
     const blockquotes = sourceMode === 'rendered-markdown'
       ? maskMultilineBlockquotes(text)
-      : stripMultilineBlockquotes(text, coordMap);
+      : stripMultilineBlockquotes(text, sourceMap);
     text = blockquotes.text;
+    if (blockquotes.sourceMap) sourceMap = blockquotes.sourceMap;
     const { quotedLines } = blockquotes;
 
     // Pre-pass: strip bypass-trick chars before pattern matching so
-    // "delve" with a Cyrillic 'е' still hits Tier 1. The coordinator is
-    // passed along so every dropped span is recorded; issue and highlight
-    // offsets are remapped to the source just before the result is built.
-    const norm = normalizeText(text, coordMap);
+    // "delve" with a Cyrillic 'е' still hits Tier 1. Compose the map while
+    // deleting characters so later offsets still address the source.
+    const norm = normalizeText(text, sourceMap);
     text = norm.text;
+    sourceMap = norm.sourceMap;
 
     const wordCount = countWords(text);
     if (wordCount < 10) {
@@ -2257,18 +2253,10 @@ const AIDetector = (() => {
       denseAIVocab,
     });
 
-    // Translate every offset produced against the (shortened) working
-    // string back to the caller's original input. Both the dense issue
-    // index and the coarser sentence-highlight boundaries must align.
-    for (const issue of deduped) {
-      if (Number.isInteger(issue.index)) {
-        issue.index = coordMap.inverse(issue.index);
-      }
-    }
-    for (const region of regions) {
-      region.start = coordMap.inverse(region.start);
-      region.end   = coordMap.inverse(region.end);
-    }
+    // Translate both dense issue indexes and half-open highlight boundaries.
+    // Mapping the region end from its final retained code unit avoids pulling
+    // a later removed roleplay marker into the highlighted source slice.
+    remapFindingsToSource(deduped, regions, sourceMap);
 
     return {
       // Legacy fields preserved for existing callers.
@@ -2601,7 +2589,6 @@ const AIDetector = (() => {
   return {
     analyzeText,
     normalizeText,
-    createOffsetMap,
     getLabel,
     getColor,
     SEVERITY_LABELS,

--- a/skills/ai-writing-detector/scripts/patterns.js
+++ b/skills/ai-writing-detector/scripts/patterns.js
@@ -44,13 +44,75 @@ const AIDetector = (() => {
   };
   const GREEK_LOOKALIKES = { 'ο': 'o', 'Ο': 'O', 'α': 'a', 'Α': 'A', 'ρ': 'p', 'Ρ': 'P' };
 
-  function normalizeText(text) {
+  // ─── Source-coordinate map (issue #189) ─────────────────────────────
+  //
+  // Preprocessing deletes characters: `normalizeText` strips zero-width
+  // chars and *roleplay-action* markers, and plain mode drops whole quoted
+  // lines. Masking stages never delete — they blank spans in place so the
+  // string keeps its length — but those deletions shrink the working
+  // string, so `match.index` and sentence boundaries no longer address the
+  // caller's input. This map records each removed span (in original source
+  // code units) as preprocessing runs, so any coordinate in the final
+  // working string can be translated back to the original input. Nothing
+  // inserts or reorders, so the translation is monotonic and unambiguous
+  // for live positions. `this.text` is the deletions-only copy and always
+  // indexes identically to the caller's final working string.
+  function createOffsetMap(text) {
+    return {
+      text,            // mutated by record() — mirrors preprocessed deletions
+      runs: [],        // ascending, disjoint [srcStart, srcEnd) spans
+      // Forward: source position -> working position. Only meaningful at
+      // live positions (run starts), where every earlier run is fully past.
+      forward(p) {
+        let removed = 0;
+        for (const [s, e] of this.runs) {
+          if (p >= e) removed += e - s;
+        }
+        return p - removed;
+      },
+      // Inverse: working position -> original source position.
+      inverse(k) {
+        let p = k;
+        for (const [s, e] of this.runs) {
+          if (p >= s) p += e - s;
+        }
+        return p;
+      },
+      record(start, end) {
+        const curStart = this.forward(start);
+        const len = end - start;
+        this.text = this.text.slice(0, curStart) + this.text.slice(curStart + len);
+        this.runs.push([start, end]);
+      },
+    };
+  }
+
+  function normalizeText(text, coordMap) {
     const flags = { zeroWidth: 0, homoglyph: 0, roleplay: 0 };
     let out = text;
 
+    // Replace-pass offsets are positions in the string handed to `.replace()`
+    // (this pass's input), stable for every match — not offsets into a buffer
+    // that shrinks as earlier matches are removed. So each pass translates its
+    // match offsets to source coordinates against the map state that existed
+    // when that pass STARTED (only prior stages' deletions), then hands
+    // record() the resulting SOURCE spans. Translating against the live runs
+    // as records accumulate would shift each later match past the deletions
+    // this same pass just recorded, corrupting coordMap.text.
+    const srcIn = (snap, k) => {
+      let p = k;
+      for (const [s, e] of snap) if (p >= s) p += e - s;
+      return p;
+    };
+
     // 1. Strip zero-width chars (ZWSP U+200B, ZWNJ U+200C, ZWJ U+200D,
     //    BOM U+FEFF, word joiner U+2060).
-    out = out.replace(/[​-‍﻿⁠]/g, () => { flags.zeroWidth++; return ''; });
+    const zwSnap = coordMap ? coordMap.runs.slice() : null;
+    out = out.replace(/[​-‍﻿⁠]/g, (m, offset) => {
+      flags.zeroWidth++;
+      if (coordMap) coordMap.record(srcIn(zwSnap, offset), srcIn(zwSnap, offset + m.length));
+      return '';
+    });
 
     // 2. Swap Cyrillic / Greek Latin-lookalike chars back to Latin so
     //    pattern matching catches obfuscated tokens.
@@ -67,8 +129,13 @@ const AIDetector = (() => {
     //    lookbehind/lookahead; legitimate multi-word `*italic*` is
     //    preserved because the verb whitelist is narrow.
     const ROLEPLAY_VERBS = /^(?:nods|sighs|laughs|smiles|frowns|shrugs|grins|winks|chuckles|gasps|pauses|thinks|wonders|whispers|shouts|gestures|raises|leans|turns|looks|glances|smirks|blinks|nodding|sighing|laughing|smiling|thinking|gesturing)\b/i;
-    out = out.replace(/(?<!\*)\*([^*\n]{1,80}?)\*(?!\*)/gu, (m, inner) => {
-      if (ROLEPLAY_VERBS.test(inner)) { flags.roleplay++; return ''; }
+    const rpSnap = coordMap ? coordMap.runs.slice() : null;
+    out = out.replace(/(?<!\*)\*([^*\n]{1,80}?)\*(?!\*)/gu, (m, inner, offset) => {
+      if (ROLEPLAY_VERBS.test(inner)) {
+        flags.roleplay++;
+        if (coordMap) coordMap.record(srcIn(rpSnap, offset), srcIn(rpSnap, offset + m.length));
+        return '';
+      }
       return m;
     });
 
@@ -983,13 +1050,48 @@ const AIDetector = (() => {
   // Keep the historical deletion behavior for default plain mode. Paragraph-
   // scoped rules depend on the surrounding lines being rejoined exactly this
   // way, so changing this prepass would change scores for existing callers.
-  function stripMultilineBlockquotes(text) {
+  function stripMultilineBlockquotes(text, coordMap) {
     const rawLines = text.split(/\r?\n/);
     const isQuote = rawLines.map((line) => /^\s*>\s/.test(line));
     const stripIndexes = new Set();
     for (let i = 0; i < rawLines.length; i += 1) {
       if (isQuote[i] && ((isQuote[i - 1] && i > 0) || isQuote[i + 1])) stripIndexes.add(i);
     }
+
+    // Record every character the join below actually drops, in original
+    // source coordinates, so reported issue/highlight offsets translate
+    // back to the caller's input exactly. Two kinds of spans:
+    //   - a stripped line removes its whole span, terminator included;
+    //   - a kept CRLF line is re-joined as '\n', so its '\r' alone is dropped.
+    // These spans index `text`, which is the caller's raw input in this
+    // stage (no deletion has run yet in plain mode), so they are already
+    // source coordinates and go straight to record(). Passing them back
+    // through inverse() would shift a source position past its own run.
+    if (coordMap) {
+      const spans = [];
+      const lineStarts = [];
+      let offset = 0;
+      for (let i = 0; i < rawLines.length; i += 1) {
+        lineStarts.push(offset);
+        const nextLf = text.indexOf('\n', offset + rawLines[i].length);
+        offset = nextLf === -1 ? text.length : nextLf + 1;
+      }
+      for (let i = 0; i < rawLines.length; i += 1) {
+        const start = lineStarts[i];
+        if (stripIndexes.has(i)) {
+          spans.push([start, i < rawLines.length - 1 ? lineStarts[i + 1] : text.length]);
+        } else if (text[start + rawLines[i].length] === '\r') {
+          // Kept CRLF line, blank lines included: the rejoin emits a single
+          // '\n', so the separator's '\r' alone (located right after the
+          // line's content) is dropped and must be recorded.
+          spans.push([start + rawLines[i].length, start + rawLines[i].length + 1]);
+        }
+      }
+      for (const [s, e] of spans) {
+        coordMap.record(s, e);
+      }
+    }
+
     return {
       text: rawLines.filter((_, i) => !stripIndexes.has(i)).join('\n'),
       quotedLines: stripIndexes.size,
@@ -1388,6 +1490,13 @@ const AIDetector = (() => {
       return { ...buildV2Defaults('UNSCORED', 'low'), score: 0, label: 'Empty', issues: [], stats: {}, tooShort: true };
     }
 
+    // Coordinate map over the caller's original string. Preprocessing may
+    // delete characters (plain-mode blockquote lines, zero-width chars,
+    // roleplay markers); anything that reports an offset into the working
+    // string is translated back through this map before it leaves the
+    // function, so issue.index and highlight ranges address the input.
+    const coordMap = createOffsetMap(text);
+
     // Context mode selects context-appropriate flagging. Accepted values:
     //   'general' (default) — full ruleset
     //   'technical' — skip title-case headers; individual prose-only rules
@@ -1429,14 +1538,15 @@ const AIDetector = (() => {
     // keeps later issue and highlight offsets aligned with the source file.
     const blockquotes = sourceMode === 'rendered-markdown'
       ? maskMultilineBlockquotes(text)
-      : stripMultilineBlockquotes(text);
+      : stripMultilineBlockquotes(text, coordMap);
     text = blockquotes.text;
     const { quotedLines } = blockquotes;
 
     // Pre-pass: strip bypass-trick chars before pattern matching so
-    // "delve" with a Cyrillic 'е' still hits Tier 1. Original text is
-    // preserved so reported `match.index` values remain visually accurate.
-    const norm = normalizeText(text);
+    // "delve" with a Cyrillic 'е' still hits Tier 1. The coordinator is
+    // passed along so every dropped span is recorded; issue and highlight
+    // offsets are remapped to the source just before the result is built.
+    const norm = normalizeText(text, coordMap);
     text = norm.text;
 
     const wordCount = countWords(text);
@@ -2147,6 +2257,19 @@ const AIDetector = (() => {
       denseAIVocab,
     });
 
+    // Translate every offset produced against the (shortened) working
+    // string back to the caller's original input. Both the dense issue
+    // index and the coarser sentence-highlight boundaries must align.
+    for (const issue of deduped) {
+      if (Number.isInteger(issue.index)) {
+        issue.index = coordMap.inverse(issue.index);
+      }
+    }
+    for (const region of regions) {
+      region.start = coordMap.inverse(region.start);
+      region.end   = coordMap.inverse(region.end);
+    }
+
     return {
       // Legacy fields preserved for existing callers.
       score: normalizedScore,
@@ -2478,6 +2601,7 @@ const AIDetector = (() => {
   return {
     analyzeText,
     normalizeText,
+    createOffsetMap,
     getLabel,
     getColor,
     SEVERITY_LABELS,

--- a/skills/avoid-ai-writing/detector/patterns.js
+++ b/skills/avoid-ai-writing/detector/patterns.js
@@ -44,79 +44,67 @@ const AIDetector = (() => {
   };
   const GREEK_LOOKALIKES = { 'ο': 'o', 'Ο': 'O', 'α': 'a', 'Α': 'A', 'ρ': 'p', 'Ρ': 'P' };
 
-  // ─── Source-coordinate map (issue #189) ─────────────────────────────
+  // ─── Source-coordinate mapping (issue #189) ─────────────────────────
   //
-  // Preprocessing deletes characters: `normalizeText` strips zero-width
-  // chars and *roleplay-action* markers, and plain mode drops whole quoted
-  // lines. Masking stages never delete — they blank spans in place so the
-  // string keeps its length — but those deletions shrink the working
-  // string, so `match.index` and sentence boundaries no longer address the
-  // caller's input. This map records each removed span (in original source
-  // code units) as preprocessing runs, so any coordinate in the final
-  // working string can be translated back to the original input. Nothing
-  // inserts or reorders, so the translation is monotonic and unambiguous
-  // for live positions. `this.text` is the deletions-only copy and always
-  // indexes identically to the caller's final working string.
-  function createOffsetMap(text) {
-    return {
-      text,            // mutated by record() — mirrors preprocessed deletions
-      runs: [],        // ascending, disjoint [srcStart, srcEnd) spans
-      // Forward: source position -> working position. Only meaningful at
-      // live positions (run starts), where every earlier run is fully past.
-      forward(p) {
-        let removed = 0;
-        for (const [s, e] of this.runs) {
-          if (p >= e) removed += e - s;
-        }
-        return p - removed;
-      },
-      // Inverse: working position -> original source position.
-      inverse(k) {
-        let p = k;
-        for (const [s, e] of this.runs) {
-          if (p >= s) p += e - s;
-        }
-        return p;
-      },
-      record(start, end) {
-        const curStart = this.forward(start);
-        const len = end - start;
-        this.text = this.text.slice(0, curStart) + this.text.slice(curStart + len);
-        this.runs.push([start, end]);
-      },
-    };
+  // Each entry maps one code unit in the working string to the matching
+  // code unit in the caller's source. Deletion passes copy the entries for
+  // retained characters once, so interleaved or overlapping removals cannot
+  // double-count offsets. Masking and homoglyph replacement keep their input
+  // length and therefore keep the current map unchanged.
+  function identitySourceMap(length) {
+    return Array.from({ length }, (_, index) => index);
   }
 
-  function normalizeText(text, coordMap) {
+  function appendMapRange(target, source, start, end) {
+    for (let index = start; index < end; index += 1) target.push(source[index]);
+  }
+
+  function remapFindingsToSource(issues, regions, sourceMap) {
+    for (const issue of issues) {
+      if (Number.isInteger(issue.index)) issue.index = sourceMap[issue.index];
+    }
+    for (const region of regions) {
+      region.start = sourceMap[region.start];
+      region.end = sourceMap[region.end - 1] + 1;
+    }
+  }
+
+  const ZERO_WIDTH_RE = /[​-‍﻿⁠]/u;
+  const ZERO_WIDTH_GLOBAL_RE = /[​-‍﻿⁠]/gu;
+  const HOMOGLYPH_GLOBAL_RE = /[Ѐ-ӿͰ-Ͽ]/gu;
+  const ROLEPLAY_VERBS_RE = /^(?:nods|sighs|laughs|smiles|frowns|shrugs|grins|winks|chuckles|gasps|pauses|thinks|wonders|whispers|shouts|gestures|raises|leans|turns|looks|glances|smirks|blinks|nodding|sighing|laughing|smiling|thinking|gesturing)\b/i;
+  const ROLEPLAY_MARKER_RE = /(?<!\*)\*([^*\n]{1,80}?)\*(?!\*)/gu;
+
+  function normalizeText(text, sourceMap) {
     const flags = { zeroWidth: 0, homoglyph: 0, roleplay: 0 };
     let out = text;
-
-    // Replace-pass offsets are positions in the string handed to `.replace()`
-    // (this pass's input), stable for every match — not offsets into a buffer
-    // that shrinks as earlier matches are removed. So each pass translates its
-    // match offsets to source coordinates against the map state that existed
-    // when that pass STARTED (only prior stages' deletions), then hands
-    // record() the resulting SOURCE spans. Translating against the live runs
-    // as records accumulate would shift each later match past the deletions
-    // this same pass just recorded, corrupting coordMap.text.
-    const srcIn = (snap, k) => {
-      let p = k;
-      for (const [s, e] of snap) if (p >= s) p += e - s;
-      return p;
-    };
+    let map = Array.isArray(sourceMap) ? sourceMap : null;
 
     // 1. Strip zero-width chars (ZWSP U+200B, ZWNJ U+200C, ZWJ U+200D,
     //    BOM U+FEFF, word joiner U+2060).
-    const zwSnap = coordMap ? coordMap.runs.slice() : null;
-    out = out.replace(/[​-‍﻿⁠]/g, (m, offset) => {
-      flags.zeroWidth++;
-      if (coordMap) coordMap.record(srcIn(zwSnap, offset), srcIn(zwSnap, offset + m.length));
-      return '';
-    });
+    if (map) {
+      const chars = [];
+      const nextMap = [];
+      for (let i = 0; i < out.length; i += 1) {
+        if (ZERO_WIDTH_RE.test(out[i])) {
+          flags.zeroWidth += 1;
+          continue;
+        }
+        chars.push(out[i]);
+        nextMap.push(map[i]);
+      }
+      out = chars.join('');
+      map = nextMap;
+    } else {
+      out = out.replace(ZERO_WIDTH_GLOBAL_RE, () => {
+        flags.zeroWidth += 1;
+        return '';
+      });
+    }
 
     // 2. Swap Cyrillic / Greek Latin-lookalike chars back to Latin so
     //    pattern matching catches obfuscated tokens.
-    out = out.replace(/[Ѐ-ӿͰ-Ͽ]/g, (m) => {
+    out = out.replace(HOMOGLYPH_GLOBAL_RE, (m) => {
       const swap = CYRILLIC_LOOKALIKES[m] ?? GREEK_LOOKALIKES[m];
       if (swap) { flags.homoglyph++; return swap; }
       return m;
@@ -128,18 +116,34 @@ const AIDetector = (() => {
     //    artifact shape. Markdown `**bold**` is rejected by the
     //    lookbehind/lookahead; legitimate multi-word `*italic*` is
     //    preserved because the verb whitelist is narrow.
-    const ROLEPLAY_VERBS = /^(?:nods|sighs|laughs|smiles|frowns|shrugs|grins|winks|chuckles|gasps|pauses|thinks|wonders|whispers|shouts|gestures|raises|leans|turns|looks|glances|smirks|blinks|nodding|sighing|laughing|smiling|thinking|gesturing)\b/i;
-    const rpSnap = coordMap ? coordMap.runs.slice() : null;
-    out = out.replace(/(?<!\*)\*([^*\n]{1,80}?)\*(?!\*)/gu, (m, inner, offset) => {
-      if (ROLEPLAY_VERBS.test(inner)) {
-        flags.roleplay++;
-        if (coordMap) coordMap.record(srcIn(rpSnap, offset), srcIn(rpSnap, offset + m.length));
-        return '';
+    if (map) {
+      const chars = [];
+      const nextMap = [];
+      const matcher = new RegExp(ROLEPLAY_MARKER_RE.source, ROLEPLAY_MARKER_RE.flags);
+      let cursor = 0;
+      let match;
+      while ((match = matcher.exec(out)) !== null) {
+        if (!ROLEPLAY_VERBS_RE.test(match[1])) continue;
+        chars.push(out.slice(cursor, match.index));
+        appendMapRange(nextMap, map, cursor, match.index);
+        flags.roleplay += 1;
+        cursor = match.index + match[0].length;
       }
-      return m;
-    });
+      chars.push(out.slice(cursor));
+      appendMapRange(nextMap, map, cursor, map.length);
+      out = chars.join('');
+      map = nextMap;
+    } else {
+      out = out.replace(ROLEPLAY_MARKER_RE, (m, inner) => {
+        if (ROLEPLAY_VERBS_RE.test(inner)) {
+          flags.roleplay += 1;
+          return '';
+        }
+        return m;
+      });
+    }
 
-    return { text: out, flags };
+    return map ? { text: out, flags, sourceMap: map } : { text: out, flags };
   }
 
   // ─── Tier 1: Always flag ───────────────────────────────────────────
@@ -1050,52 +1054,45 @@ const AIDetector = (() => {
   // Keep the historical deletion behavior for default plain mode. Paragraph-
   // scoped rules depend on the surrounding lines being rejoined exactly this
   // way, so changing this prepass would change scores for existing callers.
-  function stripMultilineBlockquotes(text, coordMap) {
+  function stripMultilineBlockquotes(text, sourceMap) {
     const rawLines = text.split(/\r?\n/);
     const isQuote = rawLines.map((line) => /^\s*>\s/.test(line));
     const stripIndexes = new Set();
     for (let i = 0; i < rawLines.length; i += 1) {
       if (isQuote[i] && ((isQuote[i - 1] && i > 0) || isQuote[i + 1])) stripIndexes.add(i);
     }
+    const kept = rawLines
+      .map((_, index) => index)
+      .filter((index) => !stripIndexes.has(index));
+    const result = {
+      text: kept.map((index) => rawLines[index]).join('\n'),
+      quotedLines: stripIndexes.size,
+    };
+    if (!Array.isArray(sourceMap)) return result;
 
-    // Record every character the join below actually drops, in original
-    // source coordinates, so reported issue/highlight offsets translate
-    // back to the caller's input exactly. Two kinds of spans:
-    //   - a stripped line removes its whole span, terminator included;
-    //   - a kept CRLF line is re-joined as '\n', so its '\r' alone is dropped.
-    // These spans index `text`, which is the caller's raw input in this
-    // stage (no deletion has run yet in plain mode), so they are already
-    // source coordinates and go straight to record(). Passing them back
-    // through inverse() would shift a source position past its own run.
-    if (coordMap) {
-      const spans = [];
-      const lineStarts = [];
-      let offset = 0;
-      for (let i = 0; i < rawLines.length; i += 1) {
-        lineStarts.push(offset);
-        const nextLf = text.indexOf('\n', offset + rawLines[i].length);
-        offset = nextLf === -1 ? text.length : nextLf + 1;
-      }
-      for (let i = 0; i < rawLines.length; i += 1) {
-        const start = lineStarts[i];
-        if (stripIndexes.has(i)) {
-          spans.push([start, i < rawLines.length - 1 ? lineStarts[i + 1] : text.length]);
-        } else if (text[start + rawLines[i].length] === '\r') {
-          // Kept CRLF line, blank lines included: the rejoin emits a single
-          // '\n', so the separator's '\r' alone (located right after the
-          // line's content) is dropped and must be recorded.
-          spans.push([start + rawLines[i].length, start + rawLines[i].length + 1]);
-        }
-      }
-      for (const [s, e] of spans) {
-        coordMap.record(s, e);
+    const lineStarts = [];
+    let offset = 0;
+    for (let i = 0; i < rawLines.length; i += 1) {
+      lineStarts.push(offset);
+      offset += rawLines[i].length;
+      if (i < rawLines.length - 1) {
+        if (text[offset] === '\r') offset += 1;
+        if (text[offset] === '\n') offset += 1;
       }
     }
 
-    return {
-      text: rawLines.filter((_, i) => !stripIndexes.has(i)).join('\n'),
-      quotedLines: stripIndexes.size,
-    };
+    const mapped = [];
+    for (let i = 0; i < kept.length; i += 1) {
+      const lineIndex = kept[i];
+      const start = lineStarts[lineIndex];
+      appendMapRange(mapped, sourceMap, start, start + rawLines[lineIndex].length);
+      if (i < kept.length - 1) {
+        const separatorStart = start + rawLines[lineIndex].length;
+        const newlineIndex = text[separatorStart] === '\r' ? separatorStart + 1 : separatorStart;
+        mapped.push(sourceMap[newlineIndex]);
+      }
+    }
+    return { ...result, sourceMap: mapped };
   }
 
   function maskTopLevelIndentedCode(chars, { listAware = false } = {}) {
@@ -1490,12 +1487,10 @@ const AIDetector = (() => {
       return { ...buildV2Defaults('UNSCORED', 'low'), score: 0, label: 'Empty', issues: [], stats: {}, tooShort: true };
     }
 
-    // Coordinate map over the caller's original string. Preprocessing may
-    // delete characters (plain-mode blockquote lines, zero-width chars,
-    // roleplay markers); anything that reports an offset into the working
-    // string is translated back through this map before it leaves the
-    // function, so issue.index and highlight ranges address the input.
-    const coordMap = createOffsetMap(text);
+    // Map each working-string code unit back to the caller's source. Every
+    // length-changing preprocessing stage composes this map as it removes
+    // characters, and results are translated before they leave the function.
+    let sourceMap = identitySourceMap(text.length);
 
     // Context mode selects context-appropriate flagging. Accepted values:
     //   'general' (default) — full ruleset
@@ -1538,16 +1533,17 @@ const AIDetector = (() => {
     // keeps later issue and highlight offsets aligned with the source file.
     const blockquotes = sourceMode === 'rendered-markdown'
       ? maskMultilineBlockquotes(text)
-      : stripMultilineBlockquotes(text, coordMap);
+      : stripMultilineBlockquotes(text, sourceMap);
     text = blockquotes.text;
+    if (blockquotes.sourceMap) sourceMap = blockquotes.sourceMap;
     const { quotedLines } = blockquotes;
 
     // Pre-pass: strip bypass-trick chars before pattern matching so
-    // "delve" with a Cyrillic 'е' still hits Tier 1. The coordinator is
-    // passed along so every dropped span is recorded; issue and highlight
-    // offsets are remapped to the source just before the result is built.
-    const norm = normalizeText(text, coordMap);
+    // "delve" with a Cyrillic 'е' still hits Tier 1. Compose the map while
+    // deleting characters so later offsets still address the source.
+    const norm = normalizeText(text, sourceMap);
     text = norm.text;
+    sourceMap = norm.sourceMap;
 
     const wordCount = countWords(text);
     if (wordCount < 10) {
@@ -2257,18 +2253,10 @@ const AIDetector = (() => {
       denseAIVocab,
     });
 
-    // Translate every offset produced against the (shortened) working
-    // string back to the caller's original input. Both the dense issue
-    // index and the coarser sentence-highlight boundaries must align.
-    for (const issue of deduped) {
-      if (Number.isInteger(issue.index)) {
-        issue.index = coordMap.inverse(issue.index);
-      }
-    }
-    for (const region of regions) {
-      region.start = coordMap.inverse(region.start);
-      region.end   = coordMap.inverse(region.end);
-    }
+    // Translate both dense issue indexes and half-open highlight boundaries.
+    // Mapping the region end from its final retained code unit avoids pulling
+    // a later removed roleplay marker into the highlighted source slice.
+    remapFindingsToSource(deduped, regions, sourceMap);
 
     return {
       // Legacy fields preserved for existing callers.
@@ -2601,7 +2589,6 @@ const AIDetector = (() => {
   return {
     analyzeText,
     normalizeText,
-    createOffsetMap,
     getLabel,
     getColor,
     SEVERITY_LABELS,

--- a/skills/avoid-ai-writing/detector/patterns.js
+++ b/skills/avoid-ai-writing/detector/patterns.js
@@ -44,13 +44,75 @@ const AIDetector = (() => {
   };
   const GREEK_LOOKALIKES = { 'ο': 'o', 'Ο': 'O', 'α': 'a', 'Α': 'A', 'ρ': 'p', 'Ρ': 'P' };
 
-  function normalizeText(text) {
+  // ─── Source-coordinate map (issue #189) ─────────────────────────────
+  //
+  // Preprocessing deletes characters: `normalizeText` strips zero-width
+  // chars and *roleplay-action* markers, and plain mode drops whole quoted
+  // lines. Masking stages never delete — they blank spans in place so the
+  // string keeps its length — but those deletions shrink the working
+  // string, so `match.index` and sentence boundaries no longer address the
+  // caller's input. This map records each removed span (in original source
+  // code units) as preprocessing runs, so any coordinate in the final
+  // working string can be translated back to the original input. Nothing
+  // inserts or reorders, so the translation is monotonic and unambiguous
+  // for live positions. `this.text` is the deletions-only copy and always
+  // indexes identically to the caller's final working string.
+  function createOffsetMap(text) {
+    return {
+      text,            // mutated by record() — mirrors preprocessed deletions
+      runs: [],        // ascending, disjoint [srcStart, srcEnd) spans
+      // Forward: source position -> working position. Only meaningful at
+      // live positions (run starts), where every earlier run is fully past.
+      forward(p) {
+        let removed = 0;
+        for (const [s, e] of this.runs) {
+          if (p >= e) removed += e - s;
+        }
+        return p - removed;
+      },
+      // Inverse: working position -> original source position.
+      inverse(k) {
+        let p = k;
+        for (const [s, e] of this.runs) {
+          if (p >= s) p += e - s;
+        }
+        return p;
+      },
+      record(start, end) {
+        const curStart = this.forward(start);
+        const len = end - start;
+        this.text = this.text.slice(0, curStart) + this.text.slice(curStart + len);
+        this.runs.push([start, end]);
+      },
+    };
+  }
+
+  function normalizeText(text, coordMap) {
     const flags = { zeroWidth: 0, homoglyph: 0, roleplay: 0 };
     let out = text;
 
+    // Replace-pass offsets are positions in the string handed to `.replace()`
+    // (this pass's input), stable for every match — not offsets into a buffer
+    // that shrinks as earlier matches are removed. So each pass translates its
+    // match offsets to source coordinates against the map state that existed
+    // when that pass STARTED (only prior stages' deletions), then hands
+    // record() the resulting SOURCE spans. Translating against the live runs
+    // as records accumulate would shift each later match past the deletions
+    // this same pass just recorded, corrupting coordMap.text.
+    const srcIn = (snap, k) => {
+      let p = k;
+      for (const [s, e] of snap) if (p >= s) p += e - s;
+      return p;
+    };
+
     // 1. Strip zero-width chars (ZWSP U+200B, ZWNJ U+200C, ZWJ U+200D,
     //    BOM U+FEFF, word joiner U+2060).
-    out = out.replace(/[​-‍﻿⁠]/g, () => { flags.zeroWidth++; return ''; });
+    const zwSnap = coordMap ? coordMap.runs.slice() : null;
+    out = out.replace(/[​-‍﻿⁠]/g, (m, offset) => {
+      flags.zeroWidth++;
+      if (coordMap) coordMap.record(srcIn(zwSnap, offset), srcIn(zwSnap, offset + m.length));
+      return '';
+    });
 
     // 2. Swap Cyrillic / Greek Latin-lookalike chars back to Latin so
     //    pattern matching catches obfuscated tokens.
@@ -67,8 +129,13 @@ const AIDetector = (() => {
     //    lookbehind/lookahead; legitimate multi-word `*italic*` is
     //    preserved because the verb whitelist is narrow.
     const ROLEPLAY_VERBS = /^(?:nods|sighs|laughs|smiles|frowns|shrugs|grins|winks|chuckles|gasps|pauses|thinks|wonders|whispers|shouts|gestures|raises|leans|turns|looks|glances|smirks|blinks|nodding|sighing|laughing|smiling|thinking|gesturing)\b/i;
-    out = out.replace(/(?<!\*)\*([^*\n]{1,80}?)\*(?!\*)/gu, (m, inner) => {
-      if (ROLEPLAY_VERBS.test(inner)) { flags.roleplay++; return ''; }
+    const rpSnap = coordMap ? coordMap.runs.slice() : null;
+    out = out.replace(/(?<!\*)\*([^*\n]{1,80}?)\*(?!\*)/gu, (m, inner, offset) => {
+      if (ROLEPLAY_VERBS.test(inner)) {
+        flags.roleplay++;
+        if (coordMap) coordMap.record(srcIn(rpSnap, offset), srcIn(rpSnap, offset + m.length));
+        return '';
+      }
       return m;
     });
 
@@ -983,13 +1050,48 @@ const AIDetector = (() => {
   // Keep the historical deletion behavior for default plain mode. Paragraph-
   // scoped rules depend on the surrounding lines being rejoined exactly this
   // way, so changing this prepass would change scores for existing callers.
-  function stripMultilineBlockquotes(text) {
+  function stripMultilineBlockquotes(text, coordMap) {
     const rawLines = text.split(/\r?\n/);
     const isQuote = rawLines.map((line) => /^\s*>\s/.test(line));
     const stripIndexes = new Set();
     for (let i = 0; i < rawLines.length; i += 1) {
       if (isQuote[i] && ((isQuote[i - 1] && i > 0) || isQuote[i + 1])) stripIndexes.add(i);
     }
+
+    // Record every character the join below actually drops, in original
+    // source coordinates, so reported issue/highlight offsets translate
+    // back to the caller's input exactly. Two kinds of spans:
+    //   - a stripped line removes its whole span, terminator included;
+    //   - a kept CRLF line is re-joined as '\n', so its '\r' alone is dropped.
+    // These spans index `text`, which is the caller's raw input in this
+    // stage (no deletion has run yet in plain mode), so they are already
+    // source coordinates and go straight to record(). Passing them back
+    // through inverse() would shift a source position past its own run.
+    if (coordMap) {
+      const spans = [];
+      const lineStarts = [];
+      let offset = 0;
+      for (let i = 0; i < rawLines.length; i += 1) {
+        lineStarts.push(offset);
+        const nextLf = text.indexOf('\n', offset + rawLines[i].length);
+        offset = nextLf === -1 ? text.length : nextLf + 1;
+      }
+      for (let i = 0; i < rawLines.length; i += 1) {
+        const start = lineStarts[i];
+        if (stripIndexes.has(i)) {
+          spans.push([start, i < rawLines.length - 1 ? lineStarts[i + 1] : text.length]);
+        } else if (text[start + rawLines[i].length] === '\r') {
+          // Kept CRLF line, blank lines included: the rejoin emits a single
+          // '\n', so the separator's '\r' alone (located right after the
+          // line's content) is dropped and must be recorded.
+          spans.push([start + rawLines[i].length, start + rawLines[i].length + 1]);
+        }
+      }
+      for (const [s, e] of spans) {
+        coordMap.record(s, e);
+      }
+    }
+
     return {
       text: rawLines.filter((_, i) => !stripIndexes.has(i)).join('\n'),
       quotedLines: stripIndexes.size,
@@ -1388,6 +1490,13 @@ const AIDetector = (() => {
       return { ...buildV2Defaults('UNSCORED', 'low'), score: 0, label: 'Empty', issues: [], stats: {}, tooShort: true };
     }
 
+    // Coordinate map over the caller's original string. Preprocessing may
+    // delete characters (plain-mode blockquote lines, zero-width chars,
+    // roleplay markers); anything that reports an offset into the working
+    // string is translated back through this map before it leaves the
+    // function, so issue.index and highlight ranges address the input.
+    const coordMap = createOffsetMap(text);
+
     // Context mode selects context-appropriate flagging. Accepted values:
     //   'general' (default) — full ruleset
     //   'technical' — skip title-case headers; individual prose-only rules
@@ -1429,14 +1538,15 @@ const AIDetector = (() => {
     // keeps later issue and highlight offsets aligned with the source file.
     const blockquotes = sourceMode === 'rendered-markdown'
       ? maskMultilineBlockquotes(text)
-      : stripMultilineBlockquotes(text);
+      : stripMultilineBlockquotes(text, coordMap);
     text = blockquotes.text;
     const { quotedLines } = blockquotes;
 
     // Pre-pass: strip bypass-trick chars before pattern matching so
-    // "delve" with a Cyrillic 'е' still hits Tier 1. Original text is
-    // preserved so reported `match.index` values remain visually accurate.
-    const norm = normalizeText(text);
+    // "delve" with a Cyrillic 'е' still hits Tier 1. The coordinator is
+    // passed along so every dropped span is recorded; issue and highlight
+    // offsets are remapped to the source just before the result is built.
+    const norm = normalizeText(text, coordMap);
     text = norm.text;
 
     const wordCount = countWords(text);
@@ -2147,6 +2257,19 @@ const AIDetector = (() => {
       denseAIVocab,
     });
 
+    // Translate every offset produced against the (shortened) working
+    // string back to the caller's original input. Both the dense issue
+    // index and the coarser sentence-highlight boundaries must align.
+    for (const issue of deduped) {
+      if (Number.isInteger(issue.index)) {
+        issue.index = coordMap.inverse(issue.index);
+      }
+    }
+    for (const region of regions) {
+      region.start = coordMap.inverse(region.start);
+      region.end   = coordMap.inverse(region.end);
+    }
+
     return {
       // Legacy fields preserved for existing callers.
       score: normalizedScore,
@@ -2478,6 +2601,7 @@ const AIDetector = (() => {
   return {
     analyzeText,
     normalizeText,
+    createOffsetMap,
     getLabel,
     getColor,
     SEVERITY_LABELS,

--- a/skills/preservation-verifier/scripts/patterns.js
+++ b/skills/preservation-verifier/scripts/patterns.js
@@ -44,79 +44,67 @@ const AIDetector = (() => {
   };
   const GREEK_LOOKALIKES = { 'ο': 'o', 'Ο': 'O', 'α': 'a', 'Α': 'A', 'ρ': 'p', 'Ρ': 'P' };
 
-  // ─── Source-coordinate map (issue #189) ─────────────────────────────
+  // ─── Source-coordinate mapping (issue #189) ─────────────────────────
   //
-  // Preprocessing deletes characters: `normalizeText` strips zero-width
-  // chars and *roleplay-action* markers, and plain mode drops whole quoted
-  // lines. Masking stages never delete — they blank spans in place so the
-  // string keeps its length — but those deletions shrink the working
-  // string, so `match.index` and sentence boundaries no longer address the
-  // caller's input. This map records each removed span (in original source
-  // code units) as preprocessing runs, so any coordinate in the final
-  // working string can be translated back to the original input. Nothing
-  // inserts or reorders, so the translation is monotonic and unambiguous
-  // for live positions. `this.text` is the deletions-only copy and always
-  // indexes identically to the caller's final working string.
-  function createOffsetMap(text) {
-    return {
-      text,            // mutated by record() — mirrors preprocessed deletions
-      runs: [],        // ascending, disjoint [srcStart, srcEnd) spans
-      // Forward: source position -> working position. Only meaningful at
-      // live positions (run starts), where every earlier run is fully past.
-      forward(p) {
-        let removed = 0;
-        for (const [s, e] of this.runs) {
-          if (p >= e) removed += e - s;
-        }
-        return p - removed;
-      },
-      // Inverse: working position -> original source position.
-      inverse(k) {
-        let p = k;
-        for (const [s, e] of this.runs) {
-          if (p >= s) p += e - s;
-        }
-        return p;
-      },
-      record(start, end) {
-        const curStart = this.forward(start);
-        const len = end - start;
-        this.text = this.text.slice(0, curStart) + this.text.slice(curStart + len);
-        this.runs.push([start, end]);
-      },
-    };
+  // Each entry maps one code unit in the working string to the matching
+  // code unit in the caller's source. Deletion passes copy the entries for
+  // retained characters once, so interleaved or overlapping removals cannot
+  // double-count offsets. Masking and homoglyph replacement keep their input
+  // length and therefore keep the current map unchanged.
+  function identitySourceMap(length) {
+    return Array.from({ length }, (_, index) => index);
   }
 
-  function normalizeText(text, coordMap) {
+  function appendMapRange(target, source, start, end) {
+    for (let index = start; index < end; index += 1) target.push(source[index]);
+  }
+
+  function remapFindingsToSource(issues, regions, sourceMap) {
+    for (const issue of issues) {
+      if (Number.isInteger(issue.index)) issue.index = sourceMap[issue.index];
+    }
+    for (const region of regions) {
+      region.start = sourceMap[region.start];
+      region.end = sourceMap[region.end - 1] + 1;
+    }
+  }
+
+  const ZERO_WIDTH_RE = /[​-‍﻿⁠]/u;
+  const ZERO_WIDTH_GLOBAL_RE = /[​-‍﻿⁠]/gu;
+  const HOMOGLYPH_GLOBAL_RE = /[Ѐ-ӿͰ-Ͽ]/gu;
+  const ROLEPLAY_VERBS_RE = /^(?:nods|sighs|laughs|smiles|frowns|shrugs|grins|winks|chuckles|gasps|pauses|thinks|wonders|whispers|shouts|gestures|raises|leans|turns|looks|glances|smirks|blinks|nodding|sighing|laughing|smiling|thinking|gesturing)\b/i;
+  const ROLEPLAY_MARKER_RE = /(?<!\*)\*([^*\n]{1,80}?)\*(?!\*)/gu;
+
+  function normalizeText(text, sourceMap) {
     const flags = { zeroWidth: 0, homoglyph: 0, roleplay: 0 };
     let out = text;
-
-    // Replace-pass offsets are positions in the string handed to `.replace()`
-    // (this pass's input), stable for every match — not offsets into a buffer
-    // that shrinks as earlier matches are removed. So each pass translates its
-    // match offsets to source coordinates against the map state that existed
-    // when that pass STARTED (only prior stages' deletions), then hands
-    // record() the resulting SOURCE spans. Translating against the live runs
-    // as records accumulate would shift each later match past the deletions
-    // this same pass just recorded, corrupting coordMap.text.
-    const srcIn = (snap, k) => {
-      let p = k;
-      for (const [s, e] of snap) if (p >= s) p += e - s;
-      return p;
-    };
+    let map = Array.isArray(sourceMap) ? sourceMap : null;
 
     // 1. Strip zero-width chars (ZWSP U+200B, ZWNJ U+200C, ZWJ U+200D,
     //    BOM U+FEFF, word joiner U+2060).
-    const zwSnap = coordMap ? coordMap.runs.slice() : null;
-    out = out.replace(/[​-‍﻿⁠]/g, (m, offset) => {
-      flags.zeroWidth++;
-      if (coordMap) coordMap.record(srcIn(zwSnap, offset), srcIn(zwSnap, offset + m.length));
-      return '';
-    });
+    if (map) {
+      const chars = [];
+      const nextMap = [];
+      for (let i = 0; i < out.length; i += 1) {
+        if (ZERO_WIDTH_RE.test(out[i])) {
+          flags.zeroWidth += 1;
+          continue;
+        }
+        chars.push(out[i]);
+        nextMap.push(map[i]);
+      }
+      out = chars.join('');
+      map = nextMap;
+    } else {
+      out = out.replace(ZERO_WIDTH_GLOBAL_RE, () => {
+        flags.zeroWidth += 1;
+        return '';
+      });
+    }
 
     // 2. Swap Cyrillic / Greek Latin-lookalike chars back to Latin so
     //    pattern matching catches obfuscated tokens.
-    out = out.replace(/[Ѐ-ӿͰ-Ͽ]/g, (m) => {
+    out = out.replace(HOMOGLYPH_GLOBAL_RE, (m) => {
       const swap = CYRILLIC_LOOKALIKES[m] ?? GREEK_LOOKALIKES[m];
       if (swap) { flags.homoglyph++; return swap; }
       return m;
@@ -128,18 +116,34 @@ const AIDetector = (() => {
     //    artifact shape. Markdown `**bold**` is rejected by the
     //    lookbehind/lookahead; legitimate multi-word `*italic*` is
     //    preserved because the verb whitelist is narrow.
-    const ROLEPLAY_VERBS = /^(?:nods|sighs|laughs|smiles|frowns|shrugs|grins|winks|chuckles|gasps|pauses|thinks|wonders|whispers|shouts|gestures|raises|leans|turns|looks|glances|smirks|blinks|nodding|sighing|laughing|smiling|thinking|gesturing)\b/i;
-    const rpSnap = coordMap ? coordMap.runs.slice() : null;
-    out = out.replace(/(?<!\*)\*([^*\n]{1,80}?)\*(?!\*)/gu, (m, inner, offset) => {
-      if (ROLEPLAY_VERBS.test(inner)) {
-        flags.roleplay++;
-        if (coordMap) coordMap.record(srcIn(rpSnap, offset), srcIn(rpSnap, offset + m.length));
-        return '';
+    if (map) {
+      const chars = [];
+      const nextMap = [];
+      const matcher = new RegExp(ROLEPLAY_MARKER_RE.source, ROLEPLAY_MARKER_RE.flags);
+      let cursor = 0;
+      let match;
+      while ((match = matcher.exec(out)) !== null) {
+        if (!ROLEPLAY_VERBS_RE.test(match[1])) continue;
+        chars.push(out.slice(cursor, match.index));
+        appendMapRange(nextMap, map, cursor, match.index);
+        flags.roleplay += 1;
+        cursor = match.index + match[0].length;
       }
-      return m;
-    });
+      chars.push(out.slice(cursor));
+      appendMapRange(nextMap, map, cursor, map.length);
+      out = chars.join('');
+      map = nextMap;
+    } else {
+      out = out.replace(ROLEPLAY_MARKER_RE, (m, inner) => {
+        if (ROLEPLAY_VERBS_RE.test(inner)) {
+          flags.roleplay += 1;
+          return '';
+        }
+        return m;
+      });
+    }
 
-    return { text: out, flags };
+    return map ? { text: out, flags, sourceMap: map } : { text: out, flags };
   }
 
   // ─── Tier 1: Always flag ───────────────────────────────────────────
@@ -1050,52 +1054,45 @@ const AIDetector = (() => {
   // Keep the historical deletion behavior for default plain mode. Paragraph-
   // scoped rules depend on the surrounding lines being rejoined exactly this
   // way, so changing this prepass would change scores for existing callers.
-  function stripMultilineBlockquotes(text, coordMap) {
+  function stripMultilineBlockquotes(text, sourceMap) {
     const rawLines = text.split(/\r?\n/);
     const isQuote = rawLines.map((line) => /^\s*>\s/.test(line));
     const stripIndexes = new Set();
     for (let i = 0; i < rawLines.length; i += 1) {
       if (isQuote[i] && ((isQuote[i - 1] && i > 0) || isQuote[i + 1])) stripIndexes.add(i);
     }
+    const kept = rawLines
+      .map((_, index) => index)
+      .filter((index) => !stripIndexes.has(index));
+    const result = {
+      text: kept.map((index) => rawLines[index]).join('\n'),
+      quotedLines: stripIndexes.size,
+    };
+    if (!Array.isArray(sourceMap)) return result;
 
-    // Record every character the join below actually drops, in original
-    // source coordinates, so reported issue/highlight offsets translate
-    // back to the caller's input exactly. Two kinds of spans:
-    //   - a stripped line removes its whole span, terminator included;
-    //   - a kept CRLF line is re-joined as '\n', so its '\r' alone is dropped.
-    // These spans index `text`, which is the caller's raw input in this
-    // stage (no deletion has run yet in plain mode), so they are already
-    // source coordinates and go straight to record(). Passing them back
-    // through inverse() would shift a source position past its own run.
-    if (coordMap) {
-      const spans = [];
-      const lineStarts = [];
-      let offset = 0;
-      for (let i = 0; i < rawLines.length; i += 1) {
-        lineStarts.push(offset);
-        const nextLf = text.indexOf('\n', offset + rawLines[i].length);
-        offset = nextLf === -1 ? text.length : nextLf + 1;
-      }
-      for (let i = 0; i < rawLines.length; i += 1) {
-        const start = lineStarts[i];
-        if (stripIndexes.has(i)) {
-          spans.push([start, i < rawLines.length - 1 ? lineStarts[i + 1] : text.length]);
-        } else if (text[start + rawLines[i].length] === '\r') {
-          // Kept CRLF line, blank lines included: the rejoin emits a single
-          // '\n', so the separator's '\r' alone (located right after the
-          // line's content) is dropped and must be recorded.
-          spans.push([start + rawLines[i].length, start + rawLines[i].length + 1]);
-        }
-      }
-      for (const [s, e] of spans) {
-        coordMap.record(s, e);
+    const lineStarts = [];
+    let offset = 0;
+    for (let i = 0; i < rawLines.length; i += 1) {
+      lineStarts.push(offset);
+      offset += rawLines[i].length;
+      if (i < rawLines.length - 1) {
+        if (text[offset] === '\r') offset += 1;
+        if (text[offset] === '\n') offset += 1;
       }
     }
 
-    return {
-      text: rawLines.filter((_, i) => !stripIndexes.has(i)).join('\n'),
-      quotedLines: stripIndexes.size,
-    };
+    const mapped = [];
+    for (let i = 0; i < kept.length; i += 1) {
+      const lineIndex = kept[i];
+      const start = lineStarts[lineIndex];
+      appendMapRange(mapped, sourceMap, start, start + rawLines[lineIndex].length);
+      if (i < kept.length - 1) {
+        const separatorStart = start + rawLines[lineIndex].length;
+        const newlineIndex = text[separatorStart] === '\r' ? separatorStart + 1 : separatorStart;
+        mapped.push(sourceMap[newlineIndex]);
+      }
+    }
+    return { ...result, sourceMap: mapped };
   }
 
   function maskTopLevelIndentedCode(chars, { listAware = false } = {}) {
@@ -1490,12 +1487,10 @@ const AIDetector = (() => {
       return { ...buildV2Defaults('UNSCORED', 'low'), score: 0, label: 'Empty', issues: [], stats: {}, tooShort: true };
     }
 
-    // Coordinate map over the caller's original string. Preprocessing may
-    // delete characters (plain-mode blockquote lines, zero-width chars,
-    // roleplay markers); anything that reports an offset into the working
-    // string is translated back through this map before it leaves the
-    // function, so issue.index and highlight ranges address the input.
-    const coordMap = createOffsetMap(text);
+    // Map each working-string code unit back to the caller's source. Every
+    // length-changing preprocessing stage composes this map as it removes
+    // characters, and results are translated before they leave the function.
+    let sourceMap = identitySourceMap(text.length);
 
     // Context mode selects context-appropriate flagging. Accepted values:
     //   'general' (default) — full ruleset
@@ -1538,16 +1533,17 @@ const AIDetector = (() => {
     // keeps later issue and highlight offsets aligned with the source file.
     const blockquotes = sourceMode === 'rendered-markdown'
       ? maskMultilineBlockquotes(text)
-      : stripMultilineBlockquotes(text, coordMap);
+      : stripMultilineBlockquotes(text, sourceMap);
     text = blockquotes.text;
+    if (blockquotes.sourceMap) sourceMap = blockquotes.sourceMap;
     const { quotedLines } = blockquotes;
 
     // Pre-pass: strip bypass-trick chars before pattern matching so
-    // "delve" with a Cyrillic 'е' still hits Tier 1. The coordinator is
-    // passed along so every dropped span is recorded; issue and highlight
-    // offsets are remapped to the source just before the result is built.
-    const norm = normalizeText(text, coordMap);
+    // "delve" with a Cyrillic 'е' still hits Tier 1. Compose the map while
+    // deleting characters so later offsets still address the source.
+    const norm = normalizeText(text, sourceMap);
     text = norm.text;
+    sourceMap = norm.sourceMap;
 
     const wordCount = countWords(text);
     if (wordCount < 10) {
@@ -2257,18 +2253,10 @@ const AIDetector = (() => {
       denseAIVocab,
     });
 
-    // Translate every offset produced against the (shortened) working
-    // string back to the caller's original input. Both the dense issue
-    // index and the coarser sentence-highlight boundaries must align.
-    for (const issue of deduped) {
-      if (Number.isInteger(issue.index)) {
-        issue.index = coordMap.inverse(issue.index);
-      }
-    }
-    for (const region of regions) {
-      region.start = coordMap.inverse(region.start);
-      region.end   = coordMap.inverse(region.end);
-    }
+    // Translate both dense issue indexes and half-open highlight boundaries.
+    // Mapping the region end from its final retained code unit avoids pulling
+    // a later removed roleplay marker into the highlighted source slice.
+    remapFindingsToSource(deduped, regions, sourceMap);
 
     return {
       // Legacy fields preserved for existing callers.
@@ -2601,7 +2589,6 @@ const AIDetector = (() => {
   return {
     analyzeText,
     normalizeText,
-    createOffsetMap,
     getLabel,
     getColor,
     SEVERITY_LABELS,

--- a/skills/preservation-verifier/scripts/patterns.js
+++ b/skills/preservation-verifier/scripts/patterns.js
@@ -44,13 +44,75 @@ const AIDetector = (() => {
   };
   const GREEK_LOOKALIKES = { 'ο': 'o', 'Ο': 'O', 'α': 'a', 'Α': 'A', 'ρ': 'p', 'Ρ': 'P' };
 
-  function normalizeText(text) {
+  // ─── Source-coordinate map (issue #189) ─────────────────────────────
+  //
+  // Preprocessing deletes characters: `normalizeText` strips zero-width
+  // chars and *roleplay-action* markers, and plain mode drops whole quoted
+  // lines. Masking stages never delete — they blank spans in place so the
+  // string keeps its length — but those deletions shrink the working
+  // string, so `match.index` and sentence boundaries no longer address the
+  // caller's input. This map records each removed span (in original source
+  // code units) as preprocessing runs, so any coordinate in the final
+  // working string can be translated back to the original input. Nothing
+  // inserts or reorders, so the translation is monotonic and unambiguous
+  // for live positions. `this.text` is the deletions-only copy and always
+  // indexes identically to the caller's final working string.
+  function createOffsetMap(text) {
+    return {
+      text,            // mutated by record() — mirrors preprocessed deletions
+      runs: [],        // ascending, disjoint [srcStart, srcEnd) spans
+      // Forward: source position -> working position. Only meaningful at
+      // live positions (run starts), where every earlier run is fully past.
+      forward(p) {
+        let removed = 0;
+        for (const [s, e] of this.runs) {
+          if (p >= e) removed += e - s;
+        }
+        return p - removed;
+      },
+      // Inverse: working position -> original source position.
+      inverse(k) {
+        let p = k;
+        for (const [s, e] of this.runs) {
+          if (p >= s) p += e - s;
+        }
+        return p;
+      },
+      record(start, end) {
+        const curStart = this.forward(start);
+        const len = end - start;
+        this.text = this.text.slice(0, curStart) + this.text.slice(curStart + len);
+        this.runs.push([start, end]);
+      },
+    };
+  }
+
+  function normalizeText(text, coordMap) {
     const flags = { zeroWidth: 0, homoglyph: 0, roleplay: 0 };
     let out = text;
 
+    // Replace-pass offsets are positions in the string handed to `.replace()`
+    // (this pass's input), stable for every match — not offsets into a buffer
+    // that shrinks as earlier matches are removed. So each pass translates its
+    // match offsets to source coordinates against the map state that existed
+    // when that pass STARTED (only prior stages' deletions), then hands
+    // record() the resulting SOURCE spans. Translating against the live runs
+    // as records accumulate would shift each later match past the deletions
+    // this same pass just recorded, corrupting coordMap.text.
+    const srcIn = (snap, k) => {
+      let p = k;
+      for (const [s, e] of snap) if (p >= s) p += e - s;
+      return p;
+    };
+
     // 1. Strip zero-width chars (ZWSP U+200B, ZWNJ U+200C, ZWJ U+200D,
     //    BOM U+FEFF, word joiner U+2060).
-    out = out.replace(/[​-‍﻿⁠]/g, () => { flags.zeroWidth++; return ''; });
+    const zwSnap = coordMap ? coordMap.runs.slice() : null;
+    out = out.replace(/[​-‍﻿⁠]/g, (m, offset) => {
+      flags.zeroWidth++;
+      if (coordMap) coordMap.record(srcIn(zwSnap, offset), srcIn(zwSnap, offset + m.length));
+      return '';
+    });
 
     // 2. Swap Cyrillic / Greek Latin-lookalike chars back to Latin so
     //    pattern matching catches obfuscated tokens.
@@ -67,8 +129,13 @@ const AIDetector = (() => {
     //    lookbehind/lookahead; legitimate multi-word `*italic*` is
     //    preserved because the verb whitelist is narrow.
     const ROLEPLAY_VERBS = /^(?:nods|sighs|laughs|smiles|frowns|shrugs|grins|winks|chuckles|gasps|pauses|thinks|wonders|whispers|shouts|gestures|raises|leans|turns|looks|glances|smirks|blinks|nodding|sighing|laughing|smiling|thinking|gesturing)\b/i;
-    out = out.replace(/(?<!\*)\*([^*\n]{1,80}?)\*(?!\*)/gu, (m, inner) => {
-      if (ROLEPLAY_VERBS.test(inner)) { flags.roleplay++; return ''; }
+    const rpSnap = coordMap ? coordMap.runs.slice() : null;
+    out = out.replace(/(?<!\*)\*([^*\n]{1,80}?)\*(?!\*)/gu, (m, inner, offset) => {
+      if (ROLEPLAY_VERBS.test(inner)) {
+        flags.roleplay++;
+        if (coordMap) coordMap.record(srcIn(rpSnap, offset), srcIn(rpSnap, offset + m.length));
+        return '';
+      }
       return m;
     });
 
@@ -983,13 +1050,48 @@ const AIDetector = (() => {
   // Keep the historical deletion behavior for default plain mode. Paragraph-
   // scoped rules depend on the surrounding lines being rejoined exactly this
   // way, so changing this prepass would change scores for existing callers.
-  function stripMultilineBlockquotes(text) {
+  function stripMultilineBlockquotes(text, coordMap) {
     const rawLines = text.split(/\r?\n/);
     const isQuote = rawLines.map((line) => /^\s*>\s/.test(line));
     const stripIndexes = new Set();
     for (let i = 0; i < rawLines.length; i += 1) {
       if (isQuote[i] && ((isQuote[i - 1] && i > 0) || isQuote[i + 1])) stripIndexes.add(i);
     }
+
+    // Record every character the join below actually drops, in original
+    // source coordinates, so reported issue/highlight offsets translate
+    // back to the caller's input exactly. Two kinds of spans:
+    //   - a stripped line removes its whole span, terminator included;
+    //   - a kept CRLF line is re-joined as '\n', so its '\r' alone is dropped.
+    // These spans index `text`, which is the caller's raw input in this
+    // stage (no deletion has run yet in plain mode), so they are already
+    // source coordinates and go straight to record(). Passing them back
+    // through inverse() would shift a source position past its own run.
+    if (coordMap) {
+      const spans = [];
+      const lineStarts = [];
+      let offset = 0;
+      for (let i = 0; i < rawLines.length; i += 1) {
+        lineStarts.push(offset);
+        const nextLf = text.indexOf('\n', offset + rawLines[i].length);
+        offset = nextLf === -1 ? text.length : nextLf + 1;
+      }
+      for (let i = 0; i < rawLines.length; i += 1) {
+        const start = lineStarts[i];
+        if (stripIndexes.has(i)) {
+          spans.push([start, i < rawLines.length - 1 ? lineStarts[i + 1] : text.length]);
+        } else if (text[start + rawLines[i].length] === '\r') {
+          // Kept CRLF line, blank lines included: the rejoin emits a single
+          // '\n', so the separator's '\r' alone (located right after the
+          // line's content) is dropped and must be recorded.
+          spans.push([start + rawLines[i].length, start + rawLines[i].length + 1]);
+        }
+      }
+      for (const [s, e] of spans) {
+        coordMap.record(s, e);
+      }
+    }
+
     return {
       text: rawLines.filter((_, i) => !stripIndexes.has(i)).join('\n'),
       quotedLines: stripIndexes.size,
@@ -1388,6 +1490,13 @@ const AIDetector = (() => {
       return { ...buildV2Defaults('UNSCORED', 'low'), score: 0, label: 'Empty', issues: [], stats: {}, tooShort: true };
     }
 
+    // Coordinate map over the caller's original string. Preprocessing may
+    // delete characters (plain-mode blockquote lines, zero-width chars,
+    // roleplay markers); anything that reports an offset into the working
+    // string is translated back through this map before it leaves the
+    // function, so issue.index and highlight ranges address the input.
+    const coordMap = createOffsetMap(text);
+
     // Context mode selects context-appropriate flagging. Accepted values:
     //   'general' (default) — full ruleset
     //   'technical' — skip title-case headers; individual prose-only rules
@@ -1429,14 +1538,15 @@ const AIDetector = (() => {
     // keeps later issue and highlight offsets aligned with the source file.
     const blockquotes = sourceMode === 'rendered-markdown'
       ? maskMultilineBlockquotes(text)
-      : stripMultilineBlockquotes(text);
+      : stripMultilineBlockquotes(text, coordMap);
     text = blockquotes.text;
     const { quotedLines } = blockquotes;
 
     // Pre-pass: strip bypass-trick chars before pattern matching so
-    // "delve" with a Cyrillic 'е' still hits Tier 1. Original text is
-    // preserved so reported `match.index` values remain visually accurate.
-    const norm = normalizeText(text);
+    // "delve" with a Cyrillic 'е' still hits Tier 1. The coordinator is
+    // passed along so every dropped span is recorded; issue and highlight
+    // offsets are remapped to the source just before the result is built.
+    const norm = normalizeText(text, coordMap);
     text = norm.text;
 
     const wordCount = countWords(text);
@@ -2147,6 +2257,19 @@ const AIDetector = (() => {
       denseAIVocab,
     });
 
+    // Translate every offset produced against the (shortened) working
+    // string back to the caller's original input. Both the dense issue
+    // index and the coarser sentence-highlight boundaries must align.
+    for (const issue of deduped) {
+      if (Number.isInteger(issue.index)) {
+        issue.index = coordMap.inverse(issue.index);
+      }
+    }
+    for (const region of regions) {
+      region.start = coordMap.inverse(region.start);
+      region.end   = coordMap.inverse(region.end);
+    }
+
     return {
       // Legacy fields preserved for existing callers.
       score: normalizedScore,
@@ -2478,6 +2601,7 @@ const AIDetector = (() => {
   return {
     analyzeText,
     normalizeText,
+    createOffsetMap,
     getLabel,
     getColor,
     SEVERITY_LABELS,


### PR DESCRIPTION
## Summary

Fixes #189.

Preprocessing in `analyzeText()` can change the length of the working string before pattern matching. In particular, plain-mode blockquote stripping and text normalization can remove characters/spans, causing reported issue indexes and highlight ranges to no longer correspond to the original JavaScript input.

This change adds source-coordinate tracking through the length-changing preprocessing stages and maps detector coordinates back to the original input before returning results.

## What changed

- Added source offset mapping for length-changing preprocessing.
- Preserved the existing plain-mode blockquote deletion/rejoin behavior.
- Preserved rendered-Markdown masking behavior.
- Tracked removed zero-width and roleplay-action spans.
- Translated issue indexes and highlight ranges back to original source coordinates.
- Added regression coverage for LF/CRLF line endings, blockquotes, zero-width characters, multiple deletions, roleplay markers, unchanged text, and highlight/source-slice round trips.
- Regenerated the repository's detector mirrors.

## Verification

- `npm test` — passed
- Focused detector tests — 153/153 passed
- `npm run self-scan:check` — passed
- Detector mirror copies verified byte-identical to the canonical implementation.

The detector's existing scoring, masking, normalization, and classification behavior is preserved.