### PR TITLE
ci: reject release version drift before tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,20 +35,7 @@ jobs:
 
       - name: Parse latest version from CHANGELOG.md
         id: changelog
-        run: |
-          HEADING_LINE="$(grep -m1 -E '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md || true)"
-          if [ -z "$HEADING_LINE" ]; then
-            echo "::error::Could not find a '## [X.Y.Z]' heading in CHANGELOG.md"
-            exit 1
-          fi
-          VERSION="$(echo "$HEADING_LINE" | sed -E 's/^## \[([0-9]+\.[0-9]+\.[0-9]+)\].*/\1/')"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Latest CHANGELOG.md version: $VERSION"
-
-          PKG_VERSION="$(node -p "require('./package.json').version" 2>/dev/null || echo unknown)"
-          if [ "$PKG_VERSION" != "$VERSION" ]; then
-            echo "::warning::package.json version ($PKG_VERSION) does not match the top CHANGELOG.md entry ($VERSION). This is pre-existing drift, not something this workflow fixes."
-          fi
+        run: node scripts/verify-release-versions.js --github-output "$GITHUB_OUTPUT"
 
       - name: Check if the release tag already exists
         id: tagcheck
@@ -96,8 +83,8 @@ jobs:
   # all. This job closes that gap. It is independently idempotent (skips when
   # the version is already on npm), so re-runs and already-tagged pushes are
   # safe, and it publishes package.json's version only after proving it matches
-  # the CHANGELOG heading the release job used — the drift this workflow
-  # already warns about must block a publish, not ride into the registry.
+  # the CHANGELOG heading the release job used — the same version guard as the
+  # release job must block a publish, not ride into the registry.
   publish-npm:
     needs: release
     runs-on: ubuntu-latest
@@ -130,18 +117,7 @@ jobs:
           '
 
       - name: Refuse to publish a version that disagrees with CHANGELOG.md
-        run: |
-          PKG_VERSION="$(node -p "require('./package.json').version")"
-          HEADING_LINE="$(grep -m1 -E '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md || true)"
-          if [ -z "$HEADING_LINE" ]; then
-            echo "::error::Could not find a '## [X.Y.Z]' heading in CHANGELOG.md"
-            exit 1
-          fi
-          CHANGELOG_VERSION="$(echo "$HEADING_LINE" | sed -E 's/^## \[([0-9]+\.[0-9]+\.[0-9]+)\].*/\1/')"
-          if [ "$PKG_VERSION" != "$CHANGELOG_VERSION" ]; then
-            echo "::error::package.json ($PKG_VERSION) != CHANGELOG.md ($CHANGELOG_VERSION) — fix the drift, then re-run. Publishing a mismatched version bakes the drift into the registry."
-            exit 1
-          fi
+        run: node scripts/verify-release-versions.js
 
       - name: Skip if this version is already on npm
         id: npmcheck

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "node": ">=18"
   },
   "scripts": {
-    "test": "node scripts/flatten-skill.test.js && node detector/patterns.test.js && node detector/categories.test.js && node detector/validate.test.js && node scripts/corpus.test.js && node scripts/check-style.test.js && node scripts/normalize-quotes.test.js && node scripts/test-canonical-skill-package.js && node bin/avoid-ai-writing.test.js && node bin/avoid-ai-writing-gate.test.js",
+    "test": "node scripts/flatten-skill.test.js && node detector/patterns.test.js && node detector/categories.test.js && node detector/validate.test.js && node scripts/corpus.test.js && node scripts/check-style.test.js && node scripts/normalize-quotes.test.js && node scripts/verify-release-versions.test.js && node scripts/test-canonical-skill-package.js && node bin/avoid-ai-writing.test.js && node bin/avoid-ai-writing-gate.test.js",
     "self-scan": "node scripts/self-scan.js",
     "self-scan:check": "node scripts/self-scan.js --check",
     "corpus": "node scripts/corpus.js list",

--- a/scripts/verify-release-versions.js
+++ b/scripts/verify-release-versions.js
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+/** Same line anchor the release workflow has used since npm publish guards landed. */
+const CHANGELOG_HEADING_RE = /^## \[([0-9]+\.[0-9]+\.[0-9]+)\]/;
+const SEMVER_RE = /^[0-9]+\.[0-9]+\.[0-9]+$/;
+
+function readChangelogVersion(changelogText) {
+  for (const line of changelogText.split('\n')) {
+    const match = line.match(CHANGELOG_HEADING_RE);
+    if (match) {
+      return match[1];
+    }
+  }
+  return null;
+}
+
+function readPackageVersion(packageJsonText) {
+  let parsed;
+  try {
+    parsed = JSON.parse(packageJsonText);
+  } catch {
+    return { error: 'package.json is not valid JSON' };
+  }
+  const version = parsed && parsed.version;
+  if (typeof version !== 'string' || version.length === 0) {
+    return { error: 'package.json is missing a string "version" field' };
+  }
+  if (!SEMVER_RE.test(version)) {
+    return { error: `package.json version (${version}) is not a numeric X.Y.Z semver` };
+  }
+  return { version };
+}
+
+/**
+ * @param {string} root Repository root containing CHANGELOG.md and package.json
+ * @returns {{ ok: true, changelogVersion: string, packageVersion: string } | { ok: false, message: string }}
+ */
+function verifyReleaseVersions(root) {
+  const changelogPath = path.join(root, 'CHANGELOG.md');
+  const packagePath = path.join(root, 'package.json');
+
+  let changelogText;
+  try {
+    changelogText = fs.readFileSync(changelogPath, 'utf8');
+  } catch {
+    return { ok: false, message: 'Could not read CHANGELOG.md' };
+  }
+
+  const changelogVersion = readChangelogVersion(changelogText);
+  if (!changelogVersion) {
+    return {
+      ok: false,
+      message: "Could not find a '## [X.Y.Z]' heading in CHANGELOG.md",
+    };
+  }
+  if (!SEMVER_RE.test(changelogVersion)) {
+    return {
+      ok: false,
+      message: `Latest CHANGELOG.md version (${changelogVersion}) is not a numeric X.Y.Z semver`,
+    };
+  }
+
+  let packageText;
+  try {
+    packageText = fs.readFileSync(packagePath, 'utf8');
+  } catch {
+    return { ok: false, message: 'Could not read package.json' };
+  }
+
+  const pkg = readPackageVersion(packageText);
+  if (pkg.error) {
+    return { ok: false, message: pkg.error };
+  }
+
+  if (pkg.version !== changelogVersion) {
+    return {
+      ok: false,
+      message:
+        `package.json (${pkg.version}) != CHANGELOG.md (${changelogVersion}) — fix the drift, then re-run. ` +
+        'Publishing or tagging a mismatched version bakes the drift into the registry and release list.',
+    };
+  }
+
+  return { ok: true, changelogVersion, packageVersion: pkg.version };
+}
+
+function formatGithubError(message) {
+  return `::error::${message}`;
+}
+
+function main(argv) {
+  const args = argv.slice(2);
+  let root = process.cwd();
+  let githubOutput = null;
+
+  for (let i = 0; i < args.length; i += 1) {
+    if (args[i] === '--root') {
+      root = path.resolve(args[i + 1] || '');
+      i += 1;
+    } else if (args[i] === '--github-output') {
+      githubOutput = args[i + 1] || process.env.GITHUB_OUTPUT || null;
+      i += 1;
+    } else if (args[i] === '--help' || args[i] === '-h') {
+      process.stdout.write(
+        'Usage: node scripts/verify-release-versions.js [--root DIR] [--github-output FILE]\n',
+      );
+      process.exit(0);
+    } else {
+      process.stderr.write(`Unknown argument: ${args[i]}\n`);
+      process.exit(2);
+    }
+  }
+
+  const result = verifyReleaseVersions(root);
+  if (!result.ok) {
+    process.stderr.write(`${formatGithubError(result.message)}\n`);
+    process.exit(1);
+  }
+
+  process.stdout.write(
+    `package.json and CHANGELOG.md agree on ${result.changelogVersion}\n`,
+  );
+  if (githubOutput) {
+    fs.appendFileSync(githubOutput, `version=${result.changelogVersion}\n`, 'utf8');
+  }
+  process.exit(0);
+}
+
+module.exports = {
+  CHANGELOG_HEADING_RE,
+  readChangelogVersion,
+  readPackageVersion,
+  verifyReleaseVersions,
+};
+
+if (require.main === module) {
+  main(process.argv);
+}

--- a/scripts/verify-release-versions.test.js
+++ b/scripts/verify-release-versions.test.js
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const {
+  readChangelogVersion,
+  verifyReleaseVersions,
+} = require('./verify-release-versions.js');
+
+const scriptPath = path.join(__dirname, 'verify-release-versions.js');
+
+let passed = 0;
+const t = (name, fn) => {
+  fn();
+  passed += 1;
+  process.stdout.write(`  ✓ ${name}\n`);
+};
+
+function fixtureRoot() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'avoid-ai-writing-release-versions-'));
+}
+
+function writeFixture(root, { changelog, packageVersion }) {
+  fs.writeFileSync(
+    path.join(root, 'CHANGELOG.md'),
+    changelog,
+    'utf8',
+  );
+  fs.writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify({ name: 'fixture', version: packageVersion }, null, 2) + '\n',
+    'utf8',
+  );
+}
+
+function runCli(root, extraArgs = []) {
+  return spawnSync(process.execPath, [scriptPath, '--root', root, ...extraArgs], {
+    encoding: 'utf8',
+  });
+}
+
+t('readChangelogVersion skips Unreleased and reads the first numeric heading', () => {
+  const text = `# Changelog
+
+## [Unreleased]
+
+### Added
+- Docs only.
+
+## [3.34.0] — 2026-09-11
+
+### Fixed
+- Something.
+`;
+  assert.strictEqual(readChangelogVersion(text), '3.34.0');
+});
+
+t('verifyReleaseVersions accepts matching package.json and changelog versions', () => {
+  const root = fixtureRoot();
+  writeFixture(root, {
+    changelog: '## [1.2.3] — 2026-01-01\n\n- ok\n',
+    packageVersion: '1.2.3',
+  });
+  const result = verifyReleaseVersions(root);
+  assert.strictEqual(result.ok, true);
+  assert.strictEqual(result.changelogVersion, '1.2.3');
+  assert.strictEqual(result.packageVersion, '1.2.3');
+});
+
+t('verifyReleaseVersions rejects version drift', () => {
+  const root = fixtureRoot();
+  writeFixture(root, {
+    changelog: '## [3.35.0] — 2026-09-12\n',
+    packageVersion: '3.34.0',
+  });
+  const result = verifyReleaseVersions(root);
+  assert.strictEqual(result.ok, false);
+  assert.match(result.message, /package\.json \(3\.34\.0\) != CHANGELOG\.md \(3\.35\.0\)/);
+});
+
+t('verifyReleaseVersions rejects changelog with no numeric heading', () => {
+  const root = fixtureRoot();
+  writeFixture(root, {
+    changelog: '## [Unreleased]\n\n- only docs\n',
+    packageVersion: '1.0.0',
+  });
+  const result = verifyReleaseVersions(root);
+  assert.strictEqual(result.ok, false);
+  assert.match(result.message, /Could not find/);
+});
+
+t('verifyReleaseVersions rejects malformed package.json', () => {
+  const root = fixtureRoot();
+  fs.writeFileSync(path.join(root, 'CHANGELOG.md'), '## [1.0.0]\n', 'utf8');
+  fs.writeFileSync(path.join(root, 'package.json'), '{not json', 'utf8');
+  const result = verifyReleaseVersions(root);
+  assert.strictEqual(result.ok, false);
+  assert.match(result.message, /not valid JSON/);
+});
+
+t('verifyReleaseVersions rejects non-semver package version', () => {
+  const root = fixtureRoot();
+  writeFixture(root, {
+    changelog: '## [1.0.0]\n',
+    packageVersion: 'v1.0.0',
+  });
+  const result = verifyReleaseVersions(root);
+  assert.strictEqual(result.ok, false);
+  assert.match(result.message, /not a numeric X\.Y\.Z semver/);
+});
+
+t('CLI exits 0 on match and writes github output', () => {
+  const root = fixtureRoot();
+  writeFixture(root, {
+    changelog: '## [2.0.0]\n',
+    packageVersion: '2.0.0',
+  });
+  const outputPath = path.join(root, 'github-output.txt');
+  const result = runCli(root, ['--github-output', outputPath]);
+  assert.strictEqual(result.status, 0);
+  assert.match(result.stdout, /agree on 2\.0\.0/);
+  assert.strictEqual(fs.readFileSync(outputPath, 'utf8'), 'version=2.0.0\n');
+});
+
+t('CLI exits 1 on drift before any release command would run', () => {
+  const root = fixtureRoot();
+  writeFixture(root, {
+    changelog: '## [9.9.9]\n',
+    packageVersion: '9.9.8',
+  });
+  const binDir = path.join(root, 'bin');
+  fs.mkdirSync(binDir);
+  const ghLog = path.join(root, 'gh-calls.log');
+  fs.writeFileSync(
+    path.join(binDir, 'gh'),
+    `#!/bin/sh
+echo release-create-called >> "${ghLog.replace(/"/g, '\\"')}"
+exit 0
+`,
+    'utf8',
+  );
+  fs.chmodSync(path.join(binDir, 'gh'), 0o755);
+
+  const verify = spawnSync(process.execPath, [scriptPath, '--root', root], {
+    encoding: 'utf8',
+    env: { ...process.env, PATH: `${binDir}:${process.env.PATH}` },
+  });
+  assert.strictEqual(verify.status, 1);
+  assert.match(verify.stderr, /::error::/);
+
+  const simulateRelease = spawnSync(
+    'bash',
+    ['-ec', `
+      set -euo pipefail
+      cd "${root}"
+      if ! node "${scriptPath}" --root .; then
+        exit 0
+      fi
+      gh release create "v$(node -p "require('./verify-release-versions.js').readChangelogVersion(require('fs').readFileSync('CHANGELOG.md','utf8'))")"
+    `],
+    {
+      encoding: 'utf8',
+      env: { ...process.env, PATH: `${binDir}:${process.env.PATH}` },
+    },
+  );
+  assert.strictEqual(simulateRelease.status, 0);
+  assert.strictEqual(fs.existsSync(ghLog), false);
+});
+
+process.stdout.write(`verify-release-versions.test.js: ${passed} passed\n`);


### PR DESCRIPTION
## Summary

Fails the release job when `package.json` and the latest numeric `CHANGELOG.md` heading disagree, instead of only warning and still running `gh release create`.

- Adds `scripts/verify-release-versions.js` shared guard
- Wires it into `.github/workflows/release.yml` for release + publish-npm
- Adds fixture tests covering match, drift, and bad inputs

## Test plan

- [x] `npm test` (includes new verify-release-versions cases)

Fixes #191