### PR TITLE
ci: harden fork workflows before relaxing approvals

### DIFF
--- a/.github/workflows/detector-test.yml
+++ b/.github/workflows/detector-test.yml
@@ -38,6 +38,9 @@ on:
       - 'action.yml'
       - '.pre-commit-hooks.yaml'
 
+permissions:
+  contents: read
+
 jobs:
   # Kept as a single job on purpose: branch protection pins required checks by
   # job name, so a second job would silently not be required until someone
@@ -46,6 +49,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v6
         with:
           node-version: "20"

--- a/.github/workflows/plugin-skill-sync.yml
+++ b/.github/workflows/plugin-skill-sync.yml
@@ -57,6 +57,9 @@ on:
       - "cursor-rules/**"
       - "scripts/**"
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -65,6 +68,7 @@ jobs:
         with:
           # merge-base --is-ancestor in validate-openai-plugin.py needs history
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Validate manifest JSON
         run: |

--- a/.github/workflows/plugin-skill-sync.yml
+++ b/.github/workflows/plugin-skill-sync.yml
@@ -28,6 +28,7 @@ on:
       - "LICENSE"
       - "cursor-rules/**"
       - "scripts/**"
+      - ".github/workflows/plugin-skill-sync.yml"
   push:
     branches: [main]
     paths:
@@ -56,6 +57,7 @@ on:
       - "LICENSE"
       - "cursor-rules/**"
       - "scripts/**"
+      - ".github/workflows/plugin-skill-sync.yml"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Give the detector and plugin-sync workflows explicit read-only repository access.
- Disable persisted checkout credentials in both workflows.
- Run plugin-sync validation when its own workflow definition changes.
- Match the existing SSOT workflow's least-privilege posture.

## Why

This prepares the repository to reduce CI friction for outside contributors. After this PR merges, the repository's fork-workflow approval setting can move from `first_time_contributors` to `first_time_contributors_new_to_github`: established GitHub users will run automatically, while newly created accounts will still require maintainer approval.

The repository setting is not stored in git, so it must be changed directly after this reviewable hardening change lands.

## Verification

- Workflow YAML parses successfully.
- No pull-request workflow uses `pull_request_target` or repository secrets.
- Repository-wide default workflow permissions remain read-only.
- `npm test` passes.

No changelog entry is needed for internal CI maintenance.
