### PR TITLE
fix: keep punctuation-prefix sentence scanning linear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project are documented here.
 
 ### Fixed
 
+- Consume bodyless punctuation runs once when splitting sentence highlights, avoiding the quadratic punctuation-prefix regression introduced in #260 while preserving trailing-fragment boundaries.
 - Remove four quadratic scans from `analyzeText()`: the sentence splitter behind highlight regions, its boundary-whitespace trim in rendered-Markdown mode, the Markdown table delimiter test, and the line-anchored `Interesting part:` opener all rescanned a long whitespace or blank-line run from every position, so a document that ended in blank lines or carried a large masked comment block took seconds instead of milliseconds. Sentence boundaries are unchanged; the regression test compares them against the former regex on every boundary shape and asserts linear growth by ratio rather than by a wall-clock budget (#235).
 - Preserve detector issue indexes and sentence-highlight ranges against the original source after blockquote and normalization preprocessing (#189).
 - Include every observed corpus register in `corpus.js list`; preserve the preferred accepted-register order and sort additional registers deterministically.

--- a/detector/patterns.js
+++ b/detector/patterns.js
@@ -2441,14 +2441,17 @@ const AIDetector = (() => {
         break;
       }
       if (run.index === pos) {
-        // A terminator with no sentence body before it only counts as the
-        // trailing fragment when nothing after it ends a sentence.
-        SENTENCE_TERMINATOR_RUN.lastIndex = pos + 1;
+        // Skip the entire bodyless run, not one character at a time: matching
+        // every remaining suffix would make a long punctuation run quadratic.
+        // If no later sentence terminator exists, the former regex's trailing
+        // alternative starts at the LAST terminator of this run.
+        const runEnd = pos + run[0].length;
+        SENTENCE_TERMINATOR_RUN.lastIndex = runEnd;
         if (SENTENCE_TERMINATOR_RUN.exec(text) === null) {
-          spans.push([pos, length]);
+          spans.push([runEnd - 1, length]);
           break;
         }
-        pos += 1;
+        pos = runEnd;
         continue;
       }
       const end = run.index + run[0].length;

--- a/detector/patterns.test.js
+++ b/detector/patterns.test.js
@@ -2486,12 +2486,38 @@ test('#235: sentence spans match the former regex scan on every boundary shape',
   for (const text of [
     `...We must delve into it. ${clean} ${clean}`,
     `. We must delve into it. ${clean} ${clean}`,
+    ...['.', '?!', '...!?'].flatMap((prefix) => [
+      `${prefix}We must delve into it and then keep going for a good while longer`,
+      `${prefix}\r\nWe must delve into it and then keep going for a good while longer`,
+      `${prefix}We must delve into it. ${clean} ${clean}`,
+    ]),
     'We must delve into it and then keep going for a good while longer without stopping',
   ]) {
     const [[start, end]] = oracle(text).filter(([, , raw]) => raw.includes('delve'));
     const regions = AIDetector.analyzeText(text, { sourceMode: 'plain' }).highlight_sentence_for_ai;
     assert.equal(regions.length, 1, `one region for ${JSON.stringify(text)}`);
     assert.deepEqual([regions[0].start, regions[0].end], [start, end], `span for ${JSON.stringify(text)}`);
+  }
+});
+
+test('#260: punctuation-prefix analysis scales without rescanning each suffix', () => {
+  const timeFor = (n, ending) => {
+    const text = '.!?'.repeat(n) + ' We must delve into it and then keep going for a good while longer' + ending;
+    let best = Infinity;
+    for (let run = 0; run < 3; run += 1) {
+      const start = performance.now();
+      AIDetector.analyzeText(text, { sourceMode: 'plain' });
+      best = Math.min(best, performance.now() - start);
+    }
+    return best;
+  };
+  for (const ending of ['', '.']) {
+    // Cover both the trailing-fragment fallback and a later terminator.
+    timeFor(100, ending);
+    const small = Math.max(timeFor(3000, ending), 5);
+    const large = timeFor(12000, ending);
+    assert.ok(large < small * 8,
+      `punctuation prefix (${JSON.stringify(ending)}): 4x input took ${(large / small).toFixed(1)}x time (${small.toFixed(1)}ms vs ${large.toFixed(1)}ms)`);
   }
 });
 

--- a/plugins/avoid-ai-writing/skills/avoid-ai-writing/detector/patterns.js
+++ b/plugins/avoid-ai-writing/skills/avoid-ai-writing/detector/patterns.js
@@ -2441,14 +2441,17 @@ const AIDetector = (() => {
         break;
       }
       if (run.index === pos) {
-        // A terminator with no sentence body before it only counts as the
-        // trailing fragment when nothing after it ends a sentence.
-        SENTENCE_TERMINATOR_RUN.lastIndex = pos + 1;
+        // Skip the entire bodyless run, not one character at a time: matching
+        // every remaining suffix would make a long punctuation run quadratic.
+        // If no later sentence terminator exists, the former regex's trailing
+        // alternative starts at the LAST terminator of this run.
+        const runEnd = pos + run[0].length;
+        SENTENCE_TERMINATOR_RUN.lastIndex = runEnd;
         if (SENTENCE_TERMINATOR_RUN.exec(text) === null) {
-          spans.push([pos, length]);
+          spans.push([runEnd - 1, length]);
           break;
         }
-        pos += 1;
+        pos = runEnd;
         continue;
       }
       const end = run.index + run[0].length;

--- a/skills/ai-writing-detector/scripts/patterns.js
+++ b/skills/ai-writing-detector/scripts/patterns.js
@@ -2441,14 +2441,17 @@ const AIDetector = (() => {
         break;
       }
       if (run.index === pos) {
-        // A terminator with no sentence body before it only counts as the
-        // trailing fragment when nothing after it ends a sentence.
-        SENTENCE_TERMINATOR_RUN.lastIndex = pos + 1;
+        // Skip the entire bodyless run, not one character at a time: matching
+        // every remaining suffix would make a long punctuation run quadratic.
+        // If no later sentence terminator exists, the former regex's trailing
+        // alternative starts at the LAST terminator of this run.
+        const runEnd = pos + run[0].length;
+        SENTENCE_TERMINATOR_RUN.lastIndex = runEnd;
         if (SENTENCE_TERMINATOR_RUN.exec(text) === null) {
-          spans.push([pos, length]);
+          spans.push([runEnd - 1, length]);
           break;
         }
-        pos += 1;
+        pos = runEnd;
         continue;
       }
       const end = run.index + run[0].length;

--- a/skills/avoid-ai-writing/detector/patterns.js
+++ b/skills/avoid-ai-writing/detector/patterns.js
@@ -2441,14 +2441,17 @@ const AIDetector = (() => {
         break;
       }
       if (run.index === pos) {
-        // A terminator with no sentence body before it only counts as the
-        // trailing fragment when nothing after it ends a sentence.
-        SENTENCE_TERMINATOR_RUN.lastIndex = pos + 1;
+        // Skip the entire bodyless run, not one character at a time: matching
+        // every remaining suffix would make a long punctuation run quadratic.
+        // If no later sentence terminator exists, the former regex's trailing
+        // alternative starts at the LAST terminator of this run.
+        const runEnd = pos + run[0].length;
+        SENTENCE_TERMINATOR_RUN.lastIndex = runEnd;
         if (SENTENCE_TERMINATOR_RUN.exec(text) === null) {
-          spans.push([pos, length]);
+          spans.push([runEnd - 1, length]);
           break;
         }
-        pos += 1;
+        pos = runEnd;
         continue;
       }
       const end = run.index + run[0].length;

--- a/skills/preservation-verifier/scripts/patterns.js
+++ b/skills/preservation-verifier/scripts/patterns.js
@@ -2441,14 +2441,17 @@ const AIDetector = (() => {
         break;
       }
       if (run.index === pos) {
-        // A terminator with no sentence body before it only counts as the
-        // trailing fragment when nothing after it ends a sentence.
-        SENTENCE_TERMINATOR_RUN.lastIndex = pos + 1;
+        // Skip the entire bodyless run, not one character at a time: matching
+        // every remaining suffix would make a long punctuation run quadratic.
+        // If no later sentence terminator exists, the former regex's trailing
+        // alternative starts at the LAST terminator of this run.
+        const runEnd = pos + run[0].length;
+        SENTENCE_TERMINATOR_RUN.lastIndex = runEnd;
         if (SENTENCE_TERMINATOR_RUN.exec(text) === null) {
-          spans.push([pos, length]);
+          spans.push([runEnd - 1, length]);
           break;
         }
-        pos += 1;
+        pos = runEnd;
         continue;
       }
       const end = run.index + run[0].length;


### PR DESCRIPTION
## Problem

The sentence scanner introduced in #260 matches a bodyless punctuation run twice and advances only one character. Long punctuation prefixes therefore take quadratic time. On the reviewed head, 40,000 leading periods took about 953 ms to analyze versus 25 ms before #260.

## Changes

Consume the entire punctuation run before looking for a later terminator. When there is no later terminator, retain the former regex's trailing-fragment behavior: the span starts at the last punctuation character in the run.

Add mixed-punctuation scaling coverage for both terminated and unterminated prose, and extend the regex-oracle highlight fixtures for punctuation prefixes and CRLF boundaries. Regenerate all four bundled detector copies and add an Unreleased changelog entry.

## Validation

- New regression fails on the previous implementation: 4x input took 15.3x time (55.5 ms versus 846.4 ms).
- Full npm test and npm run self-scan:check pass after the fix.
- Both bundle sync scripts and git diff --check pass.
- An independent exhaustive local check compared the internal scanner with the former regex on 97,656 short inputs, with no boundary differences.
- Full analysis after the fix: 10,000 / 20,000 / 40,000 leading periods took 6.1 / 11.5 / 22.7 ms on this machine. These are local measurements, not universal timing guarantees.

Implemented and reviewed by ChatGPT/Codex at @conorbronsdon's request. Follow-up to #260; no public API or scoring changes.