### PR TITLE
docs: require Conor and Codex credit for assisted commits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# Repository instructions for Codex
+
+Read `CONTRIBUTING.md` and `CLAUDE.md` for repository structure, canonical files,
+generated artifacts, and validation commands before making changes.
+
+## Commit attribution
+
+When Codex performs work at Conor Bronsdon's direction, every commit it creates
+must credit both Conor and Codex. Never create or push a Codex-only commit.
+
+- Use `Conor Bronsdon <120674402+conorbronsdon@users.noreply.github.com>` as
+  the author and include `Co-authored-by: Codex <codex@openai.com>` in the message.
+- If preserving a different original author, retain that author and add the
+  missing Conor and Codex co-author trailers instead.
+- Before pushing, inspect the author and trailers of every new commit in the
+  branch. Correct missing attribution on unpublished commits before pushing.
+- Preserve attribution when amending, rebasing, cherry-picking, or squashing.
+  Do not rewrite shared or merged history solely to change attribution.
+- This requirement applies to Codex work directed by Conor. It does not require
+  adding Conor to independent contributors' commits or taking over their PRs.


### PR DESCRIPTION
Codex previously created an implementation commit without Conor's attribution. At Conor's request, add a root AGENTS.md requiring both identities on every commit Codex creates for work directed by Conor.

Use Conor as author with a Codex co-author trailer, preserve existing authors where appropriate, and inspect all new commits before pushing. Independent contributors retain their authorship; this policy does not add Conor to their independent work. Existing shared history is left intact.

Validation: git diff --check passed; inspected the sole new commit and verified Conor's GitHub-linked author address and the Codex trailer. This is repository guidance only, so no runtime tests or changelog entry are needed.

The current checkout also uses Conor's repository-local Git identity. The instruction becomes available to future checkouts when this PR is merged; it is not a server-enforced GitHub rule.

Prepared by Codex.