### PR TITLE
docs: clarify contributors can start without assignment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,12 +6,19 @@ keep the project coherent.
 
 ## Choosing an issue
 
+Check the assignee, comments, and linked PRs to see whether someone is already
+working on an issue. For an unclaimed issue, leave a short comment letting us
+know you're starting. We appreciate the heads-up, and you can begin right away:
+you do not need to wait for assignment or maintainer confirmation. If someone
+is already working on it, coordinate with them before duplicating their work.
+If the issue explicitly needs a design decision before implementation, resolve
+that question first.
+
 Issues labeled `good first issue` are reserved for people making their first
-contribution to this repository. Check the assignee and comments, then comment
-on one unclaimed issue before starting. Take only one `good first issue` for
-your first PR; leave the others for fellow newcomers, including while your PR
-is awaiting review.
-- You are also welcome to propose your own issues & ideas
+contribution to this repository. Take only one for your first PR; leave the
+others for fellow newcomers, including while your PR is awaiting review.
+
+You are also welcome to propose your own issues and ideas.
 
 If you've already contributed here, choose a `help wanted` issue without the
 `good first issue` label, propose another improvement, or help review and test


### PR DESCRIPTION
A first-time contributor on #265 read the contribution guidance as requiring confirmation before starting. Clarify that commenting on an unclaimed issue is a heads-up: contributors can start without assignment or maintainer confirmation.

Ask contributors to check assignees, comments and linked PRs and coordinate with anyone already working on the issue. Preserve the one-good-first-issue limit and the requirement to resolve an explicitly outstanding design decision first.

Validation: npm run self-scan:check and git diff --check passed. Contributor documentation only; no changelog or version bump.

Prepared by Codex. Commit credits Conor Bronsdon and Codex.