### PR TITLE
test: measure the #260 punctuation-prefix scaling check above timer noise

### DIFF
--- a/detector/patterns.test.js
+++ b/detector/patterns.test.js
@@ -2512,10 +2512,12 @@ test('#260: punctuation-prefix analysis scales without rescanning each suffix', 
     return best;
   };
   for (const ending of ['', '.']) {
-    // Cover both the trailing-fragment fallback and a later terminator.
+    // Cover both the trailing-fragment fallback and a later terminator. The
+    // sizes keep the small run well above timer noise: at 3000 prefixes it
+    // measured 6 ms on a CI runner and the ratio read 8x on a linear scan.
     timeFor(100, ending);
-    const small = Math.max(timeFor(3000, ending), 5);
-    const large = timeFor(12000, ending);
+    const small = Math.max(timeFor(20000, ending), 20);
+    const large = timeFor(80000, ending);
     assert.ok(large < small * 8,
       `punctuation prefix (${JSON.stringify(ending)}): 4x input took ${(large / small).toFixed(1)}x time (${small.toFixed(1)}ms vs ${large.toFixed(1)}ms)`);
   }


### PR DESCRIPTION
## Summary

Closes #270. Split out of #269 at the author's request so the flaky main test is repaired without waiting on the evaluation work.

The `#260: punctuation-prefix analysis scales without rescanning each suffix` test (added in `bbc8bb2`) compares 3000 against 12000 punctuation prefixes with a 5 ms floor. On a GitHub runner the small run measured 6.2 ms and the large 50.8 ms, an 8.2x ratio on a scan that is linear, so the `pull_request` run of #269 failed while the `push` run of the same commit passed. Local timings at the new sizes:

| Prefixes | Time |
|---|---|
| 20000 | 84 ms |
| 80000 | 334 ms |

That is a 4.0x ratio on 4x input, on both endings the test covers. The change raises the sizes to 20000 and 80000 and the floor to 20 ms, matching the `#235` scaling test two tests below. Passed on three consecutive local runs.

## Checklist

- [x] `npm test` passes (engine fixtures + `CATEGORIES.md` contract check)
- [x] If I added a detector `type`: n/a
- [x] If I added a judgment-only rule: n/a
- [x] I considered false positives and added carve-outs for legitimate human writing: n/a, test only
- [x] Any factual claim about how AI or humans write cites a source: n/a
- [x] The prose I added passes the skill's own audit
- [x] Changelog: exempt, test only
- [x] If this PR prepares a release: n/a
- [x] If I added or removed a detection `###` in `references/patterns.md`: n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmCsufeKSGpesBP7w4Xf4j

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmCsufeKSGpesBP7w4Xf4j)_