### PR TITLE
test: cover statistics and self-scan exemptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "node": ">=18"
   },
   "scripts": {
-    "test": "node scripts/flatten-skill.test.js && node detector/patterns.test.js && node detector/categories.test.js && node detector/validate.test.js && node scripts/corpus.test.js && node scripts/check-style.test.js && node scripts/normalize-quotes.test.js && node scripts/test-canonical-skill-package.js && node bin/avoid-ai-writing.test.js && node bin/avoid-ai-writing-gate.test.js && node scripts/rewrite-demo.test.js",
+    "test": "node scripts/flatten-skill.test.js && node detector/patterns.test.js && node detector/categories.test.js && node detector/validate.test.js && node scripts/corpus.test.js && node scripts/check-style.test.js && node scripts/normalize-quotes.test.js && node scripts/fp-measure.test.js && node scripts/self-scan.test.js && node scripts/test-canonical-skill-package.js && node bin/avoid-ai-writing.test.js && node bin/avoid-ai-writing-gate.test.js && node scripts/rewrite-demo.test.js",
     "self-scan": "node scripts/self-scan.js",
     "self-scan:check": "node scripts/self-scan.js --check",
     "corpus": "node scripts/corpus.js list",

--- a/scripts/fp-measure.test.js
+++ b/scripts/fp-measure.test.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+/* Focused statistical-helper tests for `npm test`. */
+'use strict';
+const assert = require('assert');
+const { wilson, rocAuc } = require('./fp-measure.js');
+
+let passed = 0;
+const t = (name, fn) => { fn(); passed += 1; process.stdout.write(`  ✓ ${name}\n`); };
+const close = (actual, expected, message) => {
+  assert.ok(Math.abs(actual - expected) <= 1e-12, `${message}: expected ${expected}, got ${actual}`);
+};
+
+t('wilson handles empty, boundary, and middle samples with z=2', () => {
+  const cases = [
+    [0, 0, [0, 0]],
+    [0, 4, [0, 0.5]],
+    [4, 4, [0.5, 1]],
+    [2, 4, [0.1464466094067262, 0.8535533905932737]],
+  ];
+  for (const [successes, n, expected] of cases) {
+    const actual = wilson(successes, n, 2);
+    assert.strictEqual(actual.length, 2);
+    actual.forEach((bound) => assert.ok(bound >= 0 && bound <= 1, `${successes}/${n} bound ${bound} is outside [0, 1]`));
+    close(actual[0], expected[0], `${successes}/${n} lower`);
+    close(actual[1], expected[1], `${successes}/${n} upper`);
+  }
+});
+
+t('rocAuc credits separation, inversion, ties, and empty classes correctly', () => {
+  assert.strictEqual(rocAuc([2, 3], [0, 1]), 1);
+  assert.strictEqual(rocAuc([0, 1], [2, 3]), 0);
+  assert.strictEqual(rocAuc([1, 1], [1, 1]), 0.5);
+  assert.strictEqual(rocAuc([1, 2], [0, 1]), 0.875);
+  assert.strictEqual(rocAuc([], [0, 1]), null);
+  assert.strictEqual(rocAuc([0, 1], []), null);
+});
+
+process.stdout.write(`\n${passed} fp-measure helper tests passed\n`);

--- a/scripts/self-scan.test.js
+++ b/scripts/self-scan.test.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+/* Exemption-span tests for `npm test`. */
+'use strict';
+const assert = require('assert');
+const { applyExemptions } = require('./self-scan.js');
+
+let passed = 0;
+const t = (name, fn) => { fn(); passed += 1; process.stdout.write(`  ✓ ${name}\n`); };
+const blank = (text) => text.replace(/[^\n]/g, ' ');
+const before = 'Ordinary prose before.\n';
+const after = '\nOrdinary prose after.';
+
+const exempt = (name, middle, protectedText) => t(name, () => {
+  const source = before + middle + after;
+  const expected = source.replace(protectedText, blank(protectedText));
+  const actual = applyExemptions(source);
+  assert.strictEqual(actual, expected, 'the complete output must contain only the blanked exempt span');
+  assert.strictEqual(actual.length, source.length, 'string length must be preserved');
+  assert.deepStrictEqual([...actual.matchAll(/\n/g)].map((m) => m.index), [...source.matchAll(/\n/g)].map((m) => m.index), 'newline indices must be preserved');
+  assert.strictEqual(actual.slice(0, before.length), before, 'leading ordinary prose must remain byte-for-byte unchanged');
+  assert.strictEqual(actual.slice(-after.length), after, 'trailing ordinary prose must remain byte-for-byte unchanged');
+});
+
+exempt('blanks a triple-backtick fence', '```js\nconst raw = "quoted";\n```', '```js\nconst raw = "quoted";\n```');
+exempt('blanks a triple-tilde fence', '~~~text\nraw "quoted"\n~~~', '~~~text\nraw "quoted"\n~~~');
+exempt('blanks a multirow pipe-delimited table', '| name | note |\n| --- | --- |\n| alpha | "raw" |', '| name | note |\n| --- | --- |\n| alpha | "raw" |');
+exempt('blanks a blockquote', '> quoted "raw"\n> another row', '> quoted "raw"\n> another row');
+exempt('blanks inline backticks', 'Use `raw "code"` here.', '`raw "code"`');
+exempt('blanks paired straight double quotes', 'The "quoted text" stays exempt.', '"quoted text"');
+exempt('blanks paired curly double quotes', 'The “quoted text” stays exempt.', '“quoted text”');
+exempt('blanks paired straight single quotes', "The 'quoted text' stays exempt.", "'quoted text'");
+
+t('ordinary prose remains unchanged', () => {
+  const source = 'Ordinary prose before and after has no exempt span.';
+  assert.strictEqual(applyExemptions(source), source);
+});
+
+process.stdout.write(`\n${passed} self-scan exemption tests passed\n`);


### PR DESCRIPTION
## Summary

Adds dependency-free Node coverage for the exported `wilson`, `rocAuc`, and `applyExemptions` helpers, then wires both focused files into `npm test`.

The fixtures cover the issue’s requested statistical boundaries/ties and exact exemption masking while asserting byte length, newline offsets, and surrounding prose preservation. No production behavior changes.

Closes #214

## Verification

- `node scripts/fp-measure.test.js`
- `node scripts/self-scan.test.js`
- `npm test`
- `npm run self-scan:check`
- `git diff --check`

## Checklist

- [x] `npm test` passes (engine fixtures + `CATEGORIES.md` contract check)
- [x] No detector type or judgment-only rule added
- [x] No factual claim about AI or human writing added
- [x] Test-only change; exempt from changelog/versioning