### PR TITLE
Give corpus fetch per-document progress and a bounded timeout

### DIFF
--- a/scripts/corpus.js
+++ b/scripts/corpus.js
@@ -36,6 +36,17 @@ const CORPUS_DIR = path.join(ROOT, 'corpus');
 const MANIFEST = path.join(CORPUS_DIR, 'manifest.json');
 const CACHE = path.join(CORPUS_DIR, 'cache');
 
+/** Same bound as dataset ranged fetches in dataset-hc3.js / dataset-raid.js. */
+const FETCH_TIMEOUT_MS = 180000;
+
+function fetchHost(url) {
+  try {
+    return new URL(url).host;
+  } catch {
+    return String(url);
+  }
+}
+
 /**
  * Registers are the unit of analysis, not a label of convenience.
  *
@@ -201,10 +212,13 @@ function loadText(doc) {
   return fs.readFileSync(p, 'utf8');
 }
 
-async function fetchDoc(doc, force) {
+async function fetchDoc(doc, force, opts = {}) {
+  const timeoutMs = opts.timeoutMs ?? FETCH_TIMEOUT_MS;
   if (doc.source.type === 'local') return { id: doc.id, status: 'local' };
   const p = cachePath(doc);
-  if (fs.existsSync(p) && !force) return { id: doc.id, status: 'cached' };
+  if (fs.existsSync(p) && !force) {
+    return { id: doc.id, status: 'cached', bytes: fs.statSync(p).size };
+  }
 
   // A dataset entry is a whole sampled collection rather than one document.
   // The sampler is deterministic, so the cached JSONL and its hash are
@@ -216,10 +230,21 @@ async function fetchDoc(doc, force) {
     const { jsonl, stats } = await build(doc.source.select, (m) => console.error(m));
     fs.mkdirSync(CACHE, { recursive: true });
     fs.writeFileSync(p, jsonl);
-    return { id: doc.id, status: 'fetched', sha256: sha256(jsonl), words: null, stats };
+    const bytes = Buffer.byteLength(jsonl, 'utf8');
+    return { id: doc.id, status: 'fetched', sha256: sha256(jsonl), words: null, stats, bytes };
   }
 
-  const res = await fetch(doc.source.url, { redirect: 'follow' });
+  const url = doc.source.url;
+  const host = fetchHost(url);
+  let res;
+  try {
+    res = await fetch(url, { redirect: 'follow', signal: AbortSignal.timeout(timeoutMs) });
+  } catch (err) {
+    if (err.name === 'TimeoutError') {
+      throw new Error(`${doc.id}: timed out after ${timeoutMs}ms (${host})`);
+    }
+    throw new Error(`${doc.id}: ${err.message} (${host})`);
+  }
   if (!res.ok) return { id: doc.id, status: `HTTP ${res.status}` };
   let text = await res.text();
   if (doc.source.gutenberg) text = stripGutenberg(text);
@@ -228,17 +253,45 @@ async function fetchDoc(doc, force) {
 
   fs.mkdirSync(CACHE, { recursive: true });
   fs.writeFileSync(p, text);
-  return { id: doc.id, status: 'fetched', sha256: sha256(text), words: (text.match(/\S+/g) || []).length };
+  const bytes = Buffer.byteLength(text, 'utf8');
+  return {
+    id: doc.id,
+    status: 'fetched',
+    sha256: sha256(text),
+    words: (text.match(/\S+/g) || []).length,
+    bytes,
+  };
+}
+
+function logFetchProgress(phase, index, total, doc, detail) {
+  const line = `fetch ${index + 1}/${total}: ${doc.id}${detail ? ` ${detail}` : ''}`;
+  console.error(phase === 'start' ? `${line} ...` : line);
 }
 
 async function cmdFetch(force) {
   const m = readManifest();
   const results = [];
-  for (const doc of m.documents) {
+  const total = m.documents.length;
+  for (let i = 0; i < m.documents.length; i++) {
+    const doc = m.documents[i];
+    logFetchProgress('start', i, total, doc);
     try {
-      results.push(await fetchDoc(doc, force));
+      const r = await fetchDoc(doc, force);
+      results.push(r);
+      if (r.status === 'cached') {
+        logFetchProgress('done', i, total, doc, `cached (${r.bytes} bytes)`);
+      } else if (r.status === 'local') {
+        logFetchProgress('done', i, total, doc, 'local');
+      } else if (r.status === 'fetched') {
+        const hash = r.sha256 ? `, sha256 ${r.sha256.slice(0, 16)}` : '';
+        logFetchProgress('done', i, total, doc, `fetched (${r.bytes} bytes${hash})`);
+      } else {
+        logFetchProgress('done', i, total, doc, String(r.status));
+      }
     } catch (err) {
-      results.push({ id: doc.id, status: `error: ${err.message}` });
+      const r = { id: doc.id, status: `error: ${err.message}` };
+      results.push(r);
+      logFetchProgress('done', i, total, doc, r.status);
     }
   }
 
@@ -392,4 +445,17 @@ async function main() {
 
 if (require.main === module) main();
 
-module.exports = { readManifest, loadText, loadRows, sha256, REGISTERS, AUTHORSHIP, stripGutenberg, htmlToText, applySlice, cmdList };
+module.exports = {
+  readManifest,
+  loadText,
+  loadRows,
+  sha256,
+  REGISTERS,
+  AUTHORSHIP,
+  stripGutenberg,
+  htmlToText,
+  applySlice,
+  cmdList,
+  fetchDoc,
+  FETCH_TIMEOUT_MS,
+};

--- a/scripts/corpus.test.js
+++ b/scripts/corpus.test.js
@@ -9,7 +9,18 @@
  */
 
 const assert = require('node:assert/strict');
-const { stripGutenberg, htmlToText, applySlice, sha256, cmdList } = require('./corpus.js');
+const fs = require('node:fs');
+const http = require('node:http');
+const path = require('node:path');
+const {
+  stripGutenberg,
+  htmlToText,
+  applySlice,
+  sha256,
+  cmdList,
+  fetchDoc,
+  FETCH_TIMEOUT_MS,
+} = require('./corpus.js');
 const { parseCsv } = require('./csv-lite.js');
 const { DOMAIN_REGISTER } = require('./dataset-raid.js');
 
@@ -291,5 +302,47 @@ test('sha256 is stable and content-sensitive', () => {
   assert.match(sha256('abc'), /^[0-9a-f]{64}$/);
 });
 
-console.log(`\n${failed === 0 ? 'all corpus tests passed' : `${failed} test(s) failed`}\n`);
-process.exit(failed === 0 ? 0 : 1);
+test('default fetch timeout matches dataset ranged reads', () => {
+  assert.equal(FETCH_TIMEOUT_MS, 180000);
+});
+
+let asyncFailed = 0;
+async function asyncTest(name, fn) {
+  try {
+    await fn();
+    console.log(`  ✓ ${name}`);
+  } catch (err) {
+    asyncFailed++;
+    console.error(`  ✗ ${name}`);
+    console.error(`    ${err.message}`);
+  }
+}
+
+(async () => {
+  await asyncTest('fetch times out with document id and host in the error', async () => {
+    const server = http.createServer(() => {});
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const { port } = server.address();
+    const id = 'corpus-fetch-timeout-test';
+    const cacheFile = path.join(__dirname, '..', 'corpus', 'cache', `${id}.txt`);
+    const doc = { id, source: { type: 'url', url: `http://127.0.0.1:${port}/hang` } };
+    try {
+      await assert.rejects(
+        () => fetchDoc(doc, true, { timeoutMs: 200 }),
+        (err) => {
+          assert.match(err.message, new RegExp(id));
+          assert.match(err.message, /127\.0\.0\.1/);
+          assert.match(err.message, /timed out after 200ms/);
+          return true;
+        },
+      );
+    } finally {
+      server.close();
+      if (fs.existsSync(cacheFile)) fs.unlinkSync(cacheFile);
+    }
+  });
+
+  failed += asyncFailed;
+  console.log(`\n${failed === 0 ? 'all corpus tests passed' : `${failed} test(s) failed`}\n`);
+  process.exit(failed === 0 ? 0 : 1);
+})();


### PR DESCRIPTION
## Summary

- `fetchDoc()` URL fetches use `AbortSignal.timeout(180000)`; timeout/network errors include document id and host
- `cmdFetch()` logs per-document start/finish on stderr (bytes + sha256 prefix when available)
- Regression coverage in `corpus.test.js` for the timeout path

## Test plan

- [x] Relevant corpus tests
- [ ] Optional: run a small `cmdFetch` against a live doc and confirm progress lines

Fixes #253