### PR TITLE
fix: run every npm test suite and report combined results

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,15 @@ The rules from the [#88 license audit](https://github.com/conorbronsdon/avoid-ai
 npm test
 ```
 
+`npm test` runs every suite via `scripts/run-tests.js` and prints a combined
+summary; earlier failures do not skip later files. To run one suite:
+
+```bash
+node scripts/run-tests.js detector/patterns.test.js
+# or invoke the file directly:
+node detector/patterns.test.js
+```
+
 This runs the engine fixtures and the `CATEGORIES.md` contract checks: every
 detector `type` must be documented, every documented type must be real, and every
 prose statement of the engine `type` total must match the code. All must pass. No

--- a/detector/README.md
+++ b/detector/README.md
@@ -78,9 +78,9 @@ the workflow.
 Use the repository directly when developing or validating detector changes:
 
 ```bash
-npm test          # pattern, category-contract, and preservation tests (no deps)
-# or directly:
-node detector/patterns.test.js
+npm test          # all suites; failures in one file still run the rest (no deps)
+node scripts/run-tests.js detector/patterns.test.js   # one suite
+node detector/patterns.test.js                        # same, direct
 ```
 
 ```js

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "node": ">=18"
   },
   "scripts": {
-    "test": "node scripts/flatten-skill.test.js && node detector/patterns.test.js && node detector/categories.test.js && node detector/validate.test.js && node scripts/corpus.test.js && node scripts/check-style.test.js && node scripts/normalize-quotes.test.js && node scripts/fp-measure.test.js && node scripts/self-scan.test.js && node scripts/test-canonical-skill-package.js && node bin/avoid-ai-writing.test.js && node bin/avoid-ai-writing-gate.test.js && node scripts/rewrite-demo.test.js && node scripts/rewrite-eval.test.js && node scripts/fp-measure-cli.test.js",
+    "test": "node scripts/run-tests.js",
     "self-scan": "node scripts/self-scan.js",
     "self-scan:check": "node scripts/self-scan.js --check",
     "corpus": "node scripts/corpus.js list",

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+
+const root = path.resolve(__dirname, '..');
+
+/** Default `npm test` suites, in run order. */
+const SUITES = [
+  'scripts/flatten-skill.test.js',
+  'detector/patterns.test.js',
+  'detector/categories.test.js',
+  'detector/validate.test.js',
+  'scripts/corpus.test.js',
+  'scripts/check-style.test.js',
+  'scripts/normalize-quotes.test.js',
+  'scripts/fp-measure.test.js',
+  'scripts/self-scan.test.js',
+  'scripts/test-canonical-skill-package.js',
+  'bin/avoid-ai-writing.test.js',
+  'bin/avoid-ai-writing-gate.test.js',
+  'scripts/rewrite-demo.test.js',
+  'scripts/rewrite-eval.test.js',
+  'scripts/fp-measure-cli.test.js',
+];
+
+function resolveSuite(arg) {
+  const abs = path.isAbsolute(arg) ? arg : path.join(root, arg);
+  return path.relative(root, abs);
+}
+
+function main() {
+  const selected = process.argv.slice(2);
+  const suites = selected.length ? selected.map(resolveSuite) : SUITES;
+  const results = [];
+
+  for (const rel of suites) {
+    const abs = path.join(root, rel);
+    const child = spawnSync(process.execPath, [abs], { cwd: root, stdio: 'inherit' });
+    const status = child.status == null ? 1 : child.status;
+    results.push({ rel, ok: status === 0, status });
+  }
+
+  const failed = results.filter((r) => !r.ok);
+  console.log('');
+  console.log(`Test summary: ${results.length - failed.length} passed, ${failed.length} failed`);
+  for (const r of results) {
+    console.log(`  ${r.ok ? 'ok' : 'FAIL'}  ${r.rel}${r.ok ? '' : ` (exit ${r.status})`}`);
+  }
+
+  process.exit(failed.length ? 1 : 0);
+}
+
+main();


### PR DESCRIPTION
## Summary

Replaces the `&&` chain in `npm test` with `scripts/run-tests.js` so one failing file does not skip the rest. Prints a pass/fail summary and exits nonzero when any suite fails. Documents single-suite invocation in CONTRIBUTING.md and detector/README.md.

## Test plan

- [x] Injected a mid-suite failure — later suites still ran; exit code 1
- [x] Full `npm test` passes

Fixes #251