### PR TITLE
docs: clarify GUARD is envelope guard, not graph edge

### DIFF
--- a/OPENAI_PLUGIN.md
+++ b/OPENAI_PLUGIN.md
@@ -30,7 +30,8 @@ The network uses typed relationships rather than loose prose references:
 - `REPAIR` returns a failed preservation scope to the correct owner once.
 - `RECHECK` permits one bounded residual audit when requested.
 - `ESCALATE` sends interpretation questions to the terminal reviewer.
-- `GUARD` attaches protected semantic constraints without changing the primary owner.
+
+Conditional guards live in `skill-graph.json` `guards` and the handoff envelope; they constrain semantics without adding a graph edge or changing the primary owner.
 
 Cross-stage state follows `skills/avoid-ai-writing-router/references/handoff-contract.md`. The envelope carries context mode, voice, protected constraints, execution evidence, detector summary, verification state, risk flags, and pass limits without making each Skill infer them again.
 

--- a/skills/avoid-ai-writing-router/SKILL.md
+++ b/skills/avoid-ai-writing-router/SKILL.md
@@ -66,7 +66,8 @@ Use the edge semantics in `references/handoff-contract.md`:
 - `REPAIR`: return a failed preservation result to the correct mutation owner.
 - `RECHECK`: run one bounded residual check when requested.
 - `ESCALATE`: move uncertain or consequential authorship interpretation to `false-positive-reviewer`.
-- `GUARD`: add conditional protected constraints without changing the primary owner.
+
+Conditional guards are not graph edges. Encode them in `skill-graph.json` `guards` and the handoff envelope (`protected_constraints`, `human_representation_sensitive`) per `references/handoff-contract.md`.
 
 ## Conditional human-representation guard
 

--- a/skills/avoid-ai-writing-router/references/handoff-contract.md
+++ b/skills/avoid-ai-writing-router/references/handoff-contract.md
@@ -89,7 +89,11 @@ When detector signals are being used for an interpretation the detector does not
 
 `false-positive-reviewer` does not call the detector back directly. If additional signal collection is requested, it returns control to `avoid-ai-writing-router` with `return_to_router_reason: fresh_signal_collection_needed`. This prevents an unbounded reviewer-detector cycle.
 
-### GUARD
+## Conditional guards (not graph edges)
+
+Guards are declared in `skill-graph.json` `guards` and carried on the handoff envelope. They do not appear in `edges` and are not a seventh edge `type`.
+
+### Human representation preservation
 
 When the source is an image/video prompt or creative brief describing people, preserve identity, cultural, geographic, disability, age, attire, and physical-reality details as protected constraints. Rewriting may remove AI-writing style tells but must not genericize human representation.
 

--- a/skills/avoid-ai-writing-router/references/routing-matrix.md
+++ b/skills/avoid-ai-writing-router/references/routing-matrix.md
@@ -40,7 +40,8 @@
 - `REPAIR`: return blocking preservation scope to the correct rewrite or mutation owner.
 - `RECHECK`: run one residual audit when requested.
 - `ESCALATE`: move interpretation limits to `false-positive-reviewer`.
-- `GUARD`: attach protected semantic constraints without changing the primary owner.
+
+Conditional guards (`skill-graph.json` `guards`, handoff envelope fields) attach protected semantic constraints without changing the primary owner. They are not entries in the `edges` array above.
 
 ## Tie breakers
 


### PR DESCRIPTION
## Summary

`GUARD` was listed alongside typed graph edges (`ROUTE`, `FEED`, etc.), but `validate_connections` only accepts the six edge types in `skill-graph.json` `edges`. Guards already live in the `guards` array and handoff envelope.

Updated docs to match the validator (no validator change).

## Test plan

- [x] `validate_connections.py` / `validate-openai-plugin.py` / `npm test`

Fixes #245